### PR TITLE
feat(db): migrate prisma datasource to postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL="mysql://root:password@127.0.0.1:3306/beagle_db_v2"
+DATABASE_URL="postgresql://postgres:password@127.0.0.1:5432/beagle_db_v2"
 LEGACY_DATABASE_URL="mysql://root:password@127.0.0.1:3306/beagle_db_v1"
 AUTH_SECRET="replace-with-strong-secret"
 NEXT_PUBLIC_API_URL="http://localhost:3000"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Monorepo for a public Beagle database app with auth, admin-ready routing, and a 
 
 - `apps/web`: main Next.js app (public pages, auth pages, admin route group, API routes under `app/api/*`, and Server Actions under `app/actions/*`).
 - `packages/server`: backend use-case services (auth + authorization helpers).
-- `packages/db`: Prisma + MariaDB access.
+- `packages/db`: Prisma + PostgreSQL access (legacy import source uses MariaDB).
 - `packages/contracts`: shared API request/response types.
 - `packages/api-client`: typed HTTP client used by frontend hooks.
 
@@ -20,7 +20,8 @@ Current access model:
 
 - Node.js 20+
 - pnpm 10+
-- MariaDB (local or remote)
+- PostgreSQL (local or remote) for app data
+- MariaDB (local or remote) only for phase-1 legacy imports
 
 ## Environment setup
 
@@ -32,7 +33,7 @@ cp .env.example .env
 
 2. Update `.env` values:
 
-- `DATABASE_URL`: MariaDB connection string.
+- `DATABASE_URL`: PostgreSQL connection string.
 - `AUTH_SECRET`: strong random secret.
 - `NEXT_PUBLIC_API_URL`: optional API base URL override for web app clients. Default is same-origin.
 - `CORS_ORIGINS`: optional comma-separated cross-origin allowlist for API responses.

--- a/apps/web/components/home/__tests__/statistics-section.test.ts
+++ b/apps/web/components/home/__tests__/statistics-section.test.ts
@@ -7,8 +7,7 @@ import { StatisticsSection } from "../statistics-section";
 type Locale = "fi" | "sv";
 
 const translations: Record<string, string> = {
-  "common.dataPending": "Data pending",
-  "common.dataUnavailable": "Data unavailable",
+  "common.noData": "No data",
 };
 
 let mockedLocale: Locale = "fi";
@@ -86,7 +85,7 @@ describe("StatisticsSection", () => {
 
     expect(html).toContain(fiNumber);
     expect(html).toContain(fiDate);
-    expect(html).not.toContain("Data unavailable");
+    expect(html).not.toContain("No data");
   });
 
   it("renders formatted values for successful sv locale data", () => {
@@ -104,15 +103,15 @@ describe("StatisticsSection", () => {
     expect(html).toContain(svDate);
   });
 
-  it("renders unavailable fallback when statistics load fails", () => {
+  it("renders no-data fallback when statistics load fails", () => {
     mockedQueryData = null;
     mockedQueryIsError = true;
     const html = renderSection();
 
-    expect(html).toContain("Data unavailable");
+    expect(html).toContain("No data");
   });
 
-  it("renders pending fallback when response fields are missing", () => {
+  it("renders no-data fallback when response fields are missing", () => {
     mockedQueryData = {
       ...baseData,
       registrations: {
@@ -122,6 +121,6 @@ describe("StatisticsSection", () => {
     };
     const html = renderSection();
 
-    expect(html).toContain("Data pending");
+    expect(html).toContain("No data");
   });
 });

--- a/apps/web/components/home/statistics-section.tsx
+++ b/apps/web/components/home/statistics-section.tsx
@@ -75,15 +75,13 @@ const statGroups: StatGroup[] = [
 
 export function StatisticsSection() {
   const { t, locale } = useI18n();
-  const { data, isError, isLoading } = useHomeStatisticsQuery();
+  const { data, isLoading } = useHomeStatisticsQuery();
   const isInitialLoading = isLoading && !data;
 
   const localeTag = locale === "fi" ? "fi-FI" : "sv-SE";
   const numberFormat = new Intl.NumberFormat(localeTag);
   const dateFormat = new Intl.DateTimeFormat(localeTag);
-  const fallbackText = isError
-    ? t("common.dataUnavailable")
-    : t("common.dataPending");
+  const fallbackText = t("common.noData");
 
   const formatNumber = (value: number | null): string =>
     value == null ? fallbackText : numberFormat.format(value);

--- a/apps/web/lib/i18n/messages.ts
+++ b/apps/web/lib/i18n/messages.ts
@@ -31,6 +31,7 @@ const fi = {
   "home.stats.row.totalTrialEntries": "Ajokoestartteja yhteensä",
   "home.stats.row.performedByDogs": "Suorittaneita koiria",
   "home.stats.row.totalShowEntries": "Näyttelystartteja yhteensä",
+  "common.noData": "Ei dataa",
   "common.dataPending": "Tieto tulossa",
   "common.dataUnavailable": "Tieto ei saatavilla",
 } as const;
@@ -69,6 +70,7 @@ const sv: Messages = {
   "home.stats.row.totalTrialEntries": "Jaktprovsstarter totalt",
   "home.stats.row.performedByDogs": "Genomförda av hundar",
   "home.stats.row.totalShowEntries": "Utställningsstarter totalt",
+  "common.noData": "Ingen data",
   "common.dataPending": "Data kommer",
   "common.dataUnavailable": "Data ej tillgänglig",
 };

--- a/packages/db/core/prisma.ts
+++ b/packages/db/core/prisma.ts
@@ -1,4 +1,4 @@
-import { PrismaMariaDb } from "@prisma/adapter-mariadb";
+import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
 import { config as loadEnv } from "dotenv";
 import path from "node:path";
@@ -10,8 +10,8 @@ loadEnv({ path: path.resolve(thisDir, "../../../.env") });
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 const configuredDatabaseUrl =
   process.env.DATABASE_URL ??
-  "mysql://root:password@127.0.0.1:3306/beagle_db_v2";
-const adapter = new PrismaMariaDb(configuredDatabaseUrl);
+  "postgresql://postgres:password@127.0.0.1:5432/beagle_db_v2";
+const adapter = new PrismaPg({ connectionString: configuredDatabaseUrl });
 
 export const prisma = globalForPrisma.prisma ?? new PrismaClient({ adapter });
 if (process.env.NODE_ENV !== "production") {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,10 +19,11 @@
     "seed:initial-test-data": "node --import tsx/esm scripts/seed-initial-test-data.ts"
   },
   "dependencies": {
-    "@prisma/adapter-mariadb": "^7.3.0",
+    "@prisma/adapter-pg": "^7.3.0",
     "@prisma/client": "^7.3.0",
     "dotenv": "^17.2.4",
-    "mariadb": "^3.4.5"
+    "mariadb": "^3.4.5",
+    "pg": "^8.16.3"
   },
   "devDependencies": {
     "prisma": "^7.3.0"

--- a/packages/db/prisma.config.ts
+++ b/packages/db/prisma.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
   datasource: {
     url:
       process.env.DATABASE_URL ??
-      "mysql://root:password@127.0.0.1:3306/beagle_db_v2",
+      "postgresql://postgres:password@127.0.0.1:5432/beagle_db_v2",
   },
 });

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "mysql"
+  provider = "postgresql"
 }
 
 enum Role {
@@ -227,7 +227,7 @@ model ImportRunIssue {
   registrationNo String?
   sourceRowId    Int?
   sourceTable    String?
-  payloadJson    String?             @db.LongText
+  payloadJson    String?             @db.Text
   importRun      ImportRun           @relation(fields: [importRunId], references: [id], onDelete: Cascade)
   createdAt      DateTime            @default(now())
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,9 +132,9 @@ importers:
 
   packages/db:
     dependencies:
-      "@prisma/adapter-mariadb":
+      "@prisma/adapter-pg":
         specifier: ^7.3.0
-        version: 7.3.0
+        version: 7.4.0
       "@prisma/client":
         specifier: ^7.3.0
         version: 7.3.0(prisma@7.3.0(@types/react@19.2.13)(magicast@0.3.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
@@ -144,6 +144,9 @@ importers:
       mariadb:
         specifier: ^3.4.5
         version: 3.4.5
+      pg:
+        specifier: ^8.16.3
+        version: 8.18.0
     devDependencies:
       prisma:
         specifier: ^7.3.0
@@ -1367,10 +1370,10 @@ packages:
     engines: { node: ">=18" }
     hasBin: true
 
-  "@prisma/adapter-mariadb@7.3.0":
+  "@prisma/adapter-pg@7.4.0":
     resolution:
       {
-        integrity: sha512-cZaNZqdnm255Di8+0ztWDVdg40zRburNEMqHN2AIP98SO0Xbo9UDqHKC7sYkmm5Rqy9fNVxMjBJnoiZJ4Ae+tw==,
+        integrity: sha512-LWwTHaio0bMxvzahmpwpWqsZM0vTfMqwF8zo06YvILL/o47voaSfKzCVxZw/o9awf4fRgS5Vgthobikj9Dusaw==,
       }
 
   "@prisma/client-runtime-utils@7.3.0":
@@ -1412,16 +1415,22 @@ packages:
         integrity: sha512-yh/tHhraCzYkffsI1/3a7SHX8tpgbJu1NPnuxS4rEpJdWAUDHUH25F1EDo6PPzirpyLNkgPPZdhojQK804BGtg==,
       }
 
+  "@prisma/debug@7.4.0":
+    resolution:
+      {
+        integrity: sha512-fZicwzgFHvvPMrRLCUinrsBTdadJsi/1oirzShjmFvNLwtu2DYlkxwRVy5zEGhp85mrEGnLeS/PdNRCdE027+Q==,
+      }
+
   "@prisma/dev@0.20.0":
     resolution:
       {
         integrity: sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==,
       }
 
-  "@prisma/driver-adapter-utils@7.3.0":
+  "@prisma/driver-adapter-utils@7.4.0":
     resolution:
       {
-        integrity: sha512-Wdlezh1ck0Rq2dDINkfSkwbR53q53//Eo1vVqVLwtiZ0I6fuWDGNPxwq+SNAIHnsU+FD/m3aIJKevH3vF13U3w==,
+        integrity: sha512-jEyE5LkqZ27Ba/DIOfCGOQl6nKMLxuwJNRceCfh7/LRs46UkIKn3bmkI97MEH2t7zkYV3PGBrUr+6sMJaHvc0A==,
       }
 
   "@prisma/engines-version@7.3.0-16.9d6ad21cbbceab97458517b147a6a09ff43aa735":
@@ -6254,6 +6263,64 @@ packages:
         integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==,
       }
 
+  pg-cloudflare@1.3.0:
+    resolution:
+      {
+        integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==,
+      }
+
+  pg-connection-string@2.11.0:
+    resolution:
+      {
+        integrity: sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==,
+      }
+
+  pg-int8@1.0.1:
+    resolution:
+      {
+        integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==,
+      }
+    engines: { node: ">=4.0.0" }
+
+  pg-pool@3.11.0:
+    resolution:
+      {
+        integrity: sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==,
+      }
+    peerDependencies:
+      pg: ">=8.0"
+
+  pg-protocol@1.11.0:
+    resolution:
+      {
+        integrity: sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==,
+      }
+
+  pg-types@2.2.0:
+    resolution:
+      {
+        integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==,
+      }
+    engines: { node: ">=4" }
+
+  pg@8.18.0:
+    resolution:
+      {
+        integrity: sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==,
+      }
+    engines: { node: ">= 16.0.0" }
+    peerDependencies:
+      pg-native: ">=3.0.1"
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution:
+      {
+        integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==,
+      }
+
   picocolors@1.1.1:
     resolution:
       {
@@ -6338,6 +6405,41 @@ packages:
         integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
       }
     engines: { node: ^10 || ^12 || >=14 }
+
+  postgres-array@2.0.0:
+    resolution:
+      {
+        integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==,
+      }
+    engines: { node: ">=4" }
+
+  postgres-array@3.0.4:
+    resolution:
+      {
+        integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==,
+      }
+    engines: { node: ">=12" }
+
+  postgres-bytea@1.0.1:
+    resolution:
+      {
+        integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  postgres-date@1.0.7:
+    resolution:
+      {
+        integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  postgres-interval@1.2.0:
+    resolution:
+      {
+        integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   postgres@3.4.7:
     resolution:
@@ -6894,6 +6996,13 @@ packages:
         integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
       }
     engines: { node: ">=0.10.0" }
+
+  split2@4.2.0:
+    resolution:
+      {
+        integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
+      }
+    engines: { node: ">= 10.x" }
 
   sqlstring@2.3.3:
     resolution:
@@ -7719,6 +7828,13 @@ packages:
       }
     engines: { node: ">=20" }
 
+  xtend@4.0.2:
+    resolution:
+      {
+        integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==,
+      }
+    engines: { node: ">=0.4" }
+
   y18n@5.0.8:
     resolution:
       {
@@ -8525,10 +8641,13 @@ snapshots:
     dependencies:
       playwright: 1.58.2
 
-  "@prisma/adapter-mariadb@7.3.0":
+  "@prisma/adapter-pg@7.4.0":
     dependencies:
-      "@prisma/driver-adapter-utils": 7.3.0
-      mariadb: 3.4.5
+      "@prisma/driver-adapter-utils": 7.4.0
+      pg: 8.18.0
+      postgres-array: 3.0.4
+    transitivePeerDependencies:
+      - pg-native
 
   "@prisma/client-runtime-utils@7.3.0": {}
 
@@ -8552,6 +8671,8 @@ snapshots:
 
   "@prisma/debug@7.3.0": {}
 
+  "@prisma/debug@7.4.0": {}
+
   "@prisma/dev@0.20.0(typescript@5.9.3)":
     dependencies:
       "@electric-sql/pglite": 0.3.15
@@ -8574,9 +8695,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  "@prisma/driver-adapter-utils@7.3.0":
+  "@prisma/driver-adapter-utils@7.4.0":
     dependencies:
-      "@prisma/debug": 7.3.0
+      "@prisma/debug": 7.4.0
 
   "@prisma/engines-version@7.3.0-16.9d6ad21cbbceab97458517b147a6a09ff43aa735":
     {}
@@ -11767,6 +11888,41 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.11.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.11.0(pg@8.18.0):
+    dependencies:
+      pg: 8.18.0
+
+  pg-protocol@1.11.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.18.0:
+    dependencies:
+      pg-connection-string: 2.11.0
+      pg-pool: 3.11.0(pg@8.18.0)
+      pg-protocol: 1.11.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -11809,6 +11965,18 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-array@3.0.4: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   postgres@3.4.7: {}
 
@@ -12311,6 +12479,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
+
+  split2@4.2.0: {}
 
   sqlstring@2.3.3: {}
 
@@ -12859,6 +13029,8 @@ snapshots:
     dependencies:
       is-wsl: 3.1.0
       powershell-utils: 0.1.0
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
Switch Prisma DB runtime/config from MariaDB/MySQL to PostgreSQL by updating the adapter, datasource provider, and default connection URLs. Adjust schema provider-specific field mapping for Postgres and refresh lockfile dependencies.

Also simplify home statistics fallback UI to a single `common.noData` message and align tests/translations, then update README and env example to document PostgreSQL as the primary app database and MariaDB as legacy import source only.

Files:
- .env.example
- README.md
- apps/web/components/home/__tests__/statistics-section.test.ts
- apps/web/components/home/statistics-section.tsx
- apps/web/lib/i18n/messages.ts
- packages/db/core/prisma.ts
- packages/db/package.json
- packages/db/prisma.config.ts
- packages/db/prisma/schema.prisma
- pnpm-lock.yaml

BREAKING CHANGE: `DATABASE_URL` now targets PostgreSQL instead of MySQL/MariaDB.