### PR TITLE
style(web): refresh home and sidebar visual styling

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -9,9 +9,12 @@
   --beagle-ink-2: #072b4d;
   --beagle-muted: #4b6580;
   --beagle-surface: #ffffff;
+  --beagle-sidebar-surface: #f6fafe;
   --beagle-border: #c8d8e8;
   --beagle-accent-soft: #e6f1fb;
   --beagle-focus: #0d78d8;
+  --beagle-shadow-soft: 0 2px 10px rgba(8, 39, 70, 0.06);
+  --beagle-shadow-strong: 0 10px 30px rgba(8, 39, 70, 0.08);
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -36,13 +39,13 @@
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar: var(--beagle-sidebar-surface);
+  --sidebar-foreground: var(--beagle-ink);
+  --sidebar-primary: var(--beagle-ink);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-accent: var(--beagle-accent-soft);
+  --sidebar-accent-foreground: var(--beagle-ink);
+  --sidebar-border: var(--beagle-border);
   --sidebar-ring: oklch(0.708 0 0);
 }
 
@@ -110,7 +113,19 @@ body {
   border: 1px solid var(--beagle-border);
   border-radius: 16px;
   background: var(--beagle-surface);
-  box-shadow: 0 10px 30px rgba(8, 39, 70, 0.08);
+  box-shadow: var(--beagle-shadow-strong);
+}
+
+.beagle-subpanel {
+  border: 1px solid var(--beagle-border);
+  border-radius: 12px;
+  background: var(--beagle-surface);
+  box-shadow: var(--beagle-shadow-soft);
+}
+
+.beagle-focus-ring:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 2px var(--beagle-focus);
 }
 
 .beagle-hero {
@@ -137,33 +152,6 @@ body {
   font-size: 0.9rem;
 }
 
-.beagle-menu-item {
-  width: 100%;
-  min-height: 44px;
-  border: 1px solid var(--beagle-border);
-  border-radius: 12px;
-  background: linear-gradient(180deg, #fbfdff 0%, #f1f7fd 100%);
-  color: var(--beagle-ink);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.55rem 0.75rem;
-  font-size: 0.9rem;
-  font-weight: 600;
-  text-align: left;
-  cursor: pointer;
-}
-
-.beagle-menu-item:hover {
-  background: var(--beagle-accent-soft);
-}
-
-.beagle-menu-item:focus-visible {
-  outline: 0;
-  box-shadow: 0 0 0 2px var(--beagle-focus);
-}
-
 .beagle-badge {
   border-radius: 999px;
   background: #dceaf8;
@@ -172,33 +160,6 @@ body {
   font-size: 0.72rem;
   font-weight: 700;
   white-space: nowrap;
-}
-
-.beagle-signin-link {
-  min-height: 40px;
-  border: 1px solid var(--beagle-border);
-  border-radius: 0.5rem;
-  background: #fff;
-  color: var(--beagle-ink);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  line-height: 1;
-  cursor: pointer;
-  box-shadow: 0 1px 2px rgba(8, 39, 70, 0.08);
-  transition: background-color 150ms ease;
-}
-
-.beagle-signin-link:hover {
-  background: var(--beagle-accent-soft);
-}
-
-.beagle-signin-link:focus-visible {
-  outline: 0;
-  box-shadow: 0 0 0 2px var(--beagle-focus);
 }
 
 .dark {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,23 +2,13 @@ import { AppHeader } from "@/components/sidebar/app-header";
 import { AppSidebar } from "@/components/sidebar/app-sidebar";
 import { MainHeader } from "@/components/home/main-header";
 import { StatisticsSection } from "@/components/home/statistics-section";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { AppShell } from "@/components/layout";
 
 export default function Home() {
   return (
-    <SidebarProvider>
-      <div className="beagle-shell flex min-h-screen w-full">
-        <AppSidebar />
-        <SidebarInset className="min-h-screen">
-          <AppHeader />
-          <main className="flex-1 overflow-auto px-3 py-4 sm:px-4 md:px-6 md:py-6 lg:px-8 lg:py-8">
-            <section className="mx-auto w-full max-w-screen-2xl space-y-5 lg:space-y-6">
-              <MainHeader />
-              <StatisticsSection />
-            </section>
-          </main>
-        </SidebarInset>
-      </div>
-    </SidebarProvider>
+    <AppShell sidebar={<AppSidebar />} header={<AppHeader />}>
+      <MainHeader />
+      <StatisticsSection />
+    </AppShell>
   );
 }

--- a/apps/web/components/home/main-header.tsx
+++ b/apps/web/components/home/main-header.tsx
@@ -1,26 +1,39 @@
 "use client";
 
 import Image from "next/image";
+import { beagleTheme } from "@/components/ui/beagle-theme";
+import { cn } from "@/lib/utils";
 import { useI18n } from "@/lib/i18n";
 
 export function MainHeader() {
   const { t } = useI18n();
 
   return (
-    <header className="beagle-panel beagle-hero px-5 py-5 md:px-6 md:py-6">
+    <header
+      className={cn(beagleTheme.panel, "beagle-hero px-5 py-5 md:px-6 md:py-6")}
+    >
       <div className="flex items-center gap-3 md:gap-4">
         <Image
           src="/beagle-legacy-logo.png"
           alt={t("home.hero.logoAlt")}
           width={132}
           height={74}
-          className="h-auto w-[110px] rounded-sm border border-[var(--beagle-border)] bg-white p-1 md:w-[132px]"
+          className={cn(
+            "h-auto w-[110px] rounded-sm border p-1 md:w-[132px]",
+            beagleTheme.border,
+            beagleTheme.surface,
+          )}
         />
-        <h1 className="text-3xl font-semibold leading-tight text-[var(--beagle-ink)] md:text-4xl">
+        <h1 className={cn(beagleTheme.headingLg, beagleTheme.inkStrongText)}>
           {t("home.hero.title")}
         </h1>
       </div>
-      <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--beagle-muted)] md:text-base">
+      <p
+        className={cn(
+          "mt-3 max-w-2xl text-sm leading-6 md:text-base",
+          beagleTheme.mutedText,
+        )}
+      >
         {t("home.hero.description")}
       </p>
     </header>

--- a/apps/web/components/home/statistics-section.tsx
+++ b/apps/web/components/home/statistics-section.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { beagleTheme } from "@/components/ui/beagle-theme";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 import { useI18n, type MessageKey } from "@/lib/i18n";
 import { useHomeStatisticsQuery } from "@/queries/home/use-home-statistics-query";
 
@@ -73,6 +75,12 @@ const statGroups: StatGroup[] = [
   },
 ];
 
+const cardClassName = cn(beagleTheme.subpanel, "px-4 py-3.5");
+const rowClassName = cn(
+  "grid grid-cols-[1fr_auto] items-center gap-3 border-b pb-2 last:border-b-0 last:pb-0",
+  beagleTheme.border,
+);
+
 export function StatisticsSection() {
   const { t, locale } = useI18n();
   const { data, isLoading } = useHomeStatisticsQuery();
@@ -120,7 +128,7 @@ export function StatisticsSection() {
   if (isInitialLoading) {
     return (
       <Card
-        className="beagle-panel gap-0 overflow-hidden py-0"
+        className={cn(beagleTheme.panel, "gap-0 overflow-hidden py-0")}
         aria-busy="true"
       >
         <CardHeader className="px-5 pt-5 pb-4 md:px-6 md:pt-6 md:pb-4">
@@ -131,17 +139,14 @@ export function StatisticsSection() {
             {Array.from({ length: 3 }).map((_, cardIndex) => (
               <section
                 key={cardIndex}
-                className="rounded-xl border border-[var(--beagle-border)] bg-white px-4 py-3.5 shadow-sm"
+                className={cardClassName}
                 aria-hidden="true"
               >
                 <Skeleton className="h-5 w-28" />
                 <div className="mt-2.5 space-y-2.5">
                   {Array.from({ length: cardIndex === 0 ? 2 : 3 }).map(
                     (_, rowIndex) => (
-                      <div
-                        key={rowIndex}
-                        className="grid grid-cols-[1fr_auto] items-center gap-3 border-b border-[var(--beagle-border)] pb-2 last:border-b-0 last:pb-0"
-                      >
+                      <div key={rowIndex} className={rowClassName}>
                         <Skeleton className="h-4 w-24" />
                         <Skeleton className="h-5 w-16 rounded-md" />
                       </div>
@@ -157,9 +162,11 @@ export function StatisticsSection() {
   }
 
   return (
-    <Card className="beagle-panel gap-0 overflow-hidden py-0">
+    <Card className={cn(beagleTheme.panel, "gap-0 overflow-hidden py-0")}>
       <CardHeader className="px-5 pt-5 pb-4 md:px-6 md:pt-6 md:pb-4">
-        <CardTitle className="text-xl text-[var(--beagle-ink)]">
+        <CardTitle
+          className={cn(beagleTheme.headingMd, beagleTheme.inkStrongText)}
+        >
           {t("home.stats.title")}
         </CardTitle>
       </CardHeader>
@@ -172,22 +179,29 @@ export function StatisticsSection() {
           {statGroups.map((group) => (
             <section
               key={group.titleKey}
-              className="rounded-xl border border-[var(--beagle-border)] bg-white px-4 py-3.5 shadow-sm"
+              className={cardClassName}
               aria-label={t(group.titleKey)}
             >
-              <h3 className="text-base font-semibold text-[var(--beagle-ink)]">
+              <h3
+                className={cn(beagleTheme.headingSm, beagleTheme.inkStrongText)}
+              >
                 {t(group.titleKey)}
               </h3>
               <ul className="mt-2.5 space-y-2.5">
                 {group.rows.map((row) => (
-                  <li
-                    key={row.labelKey}
-                    className="grid grid-cols-[1fr_auto] items-center gap-3 border-b border-[var(--beagle-border)] pb-2 last:border-b-0 last:pb-0"
-                  >
-                    <span className="text-sm leading-5 text-[var(--beagle-muted)]">
+                  <li key={row.labelKey} className={rowClassName}>
+                    <span
+                      className={cn(beagleTheme.labelSm, beagleTheme.mutedText)}
+                    >
                       {t(row.labelKey)}
                     </span>
-                    <span className="rounded-md bg-[var(--beagle-accent-soft)] px-2 py-0.5 text-xs font-semibold text-[var(--beagle-ink)]">
+                    <span
+                      className={cn(
+                        "rounded-md px-2 py-0.5 text-xs font-semibold",
+                        beagleTheme.softAccent,
+                        beagleTheme.inkStrongText,
+                      )}
+                    >
                       {valueMap[row.valueId]}
                     </span>
                   </li>

--- a/apps/web/components/layout/app-shell.tsx
+++ b/apps/web/components/layout/app-shell.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+
+type AppShellProps = {
+  sidebar: ReactNode;
+  header: ReactNode;
+  children: ReactNode;
+};
+
+export function AppShell({ sidebar, header, children }: AppShellProps) {
+  return (
+    <SidebarProvider>
+      <div className="beagle-shell flex min-h-screen w-full">
+        {sidebar}
+        <SidebarInset className="min-h-screen">
+          {header}
+          <main className="flex-1 overflow-auto px-4 py-5 md:px-6 md:py-6 lg:px-8">
+            <section className="mx-auto w-full max-w-screen-2xl space-y-6">
+              {children}
+            </section>
+          </main>
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/apps/web/components/layout/index.ts
+++ b/apps/web/components/layout/index.ts
@@ -1,0 +1,1 @@
+export { AppShell } from "./app-shell";

--- a/apps/web/components/sidebar/app-header.tsx
+++ b/apps/web/components/sidebar/app-header.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { beagleTheme } from "@/components/ui/beagle-theme";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
 import { useI18n } from "@/lib/i18n";
 
 const localeButtons = [
@@ -13,10 +15,18 @@ export function AppHeader() {
   const { locale, setLocale, t } = useI18n();
 
   return (
-    <header className="sticky top-0 z-20 border-b border-[var(--beagle-border)] bg-white/95 backdrop-blur">
-      <div className="flex h-12 w-full items-center justify-between gap-3 px-3 sm:px-4 md:px-6">
+    <header
+      className={cn(
+        "sticky top-0 z-20 border-b backdrop-blur",
+        beagleTheme.border,
+        beagleTheme.sidebarSurface,
+      )}
+    >
+      <div className="flex h-12 w-full items-center justify-between gap-3 px-4 md:px-6">
         <div className="flex items-center gap-2.5">
-          <SidebarTrigger className="text-[var(--beagle-ink)]" />
+          <SidebarTrigger
+            className={cn(beagleTheme.inkStrongText, beagleTheme.focusRing)}
+          />
         </div>
         <div className="flex items-center gap-1">
           {localeButtons.map((option) => (
@@ -27,8 +37,17 @@ export function AppHeader() {
               size="icon-xs"
               className={
                 locale === option.locale
-                  ? "text-base border border-[var(--beagle-border)] bg-[var(--beagle-accent-soft)] ring-2 ring-[var(--beagle-border)]"
-                  : "text-base border border-transparent"
+                  ? cn(
+                      "h-11 w-11 text-base border ring-2 ring-[var(--beagle-focus)] md:h-8 md:w-8",
+                      beagleTheme.border,
+                      beagleTheme.softAccent,
+                      beagleTheme.focusRing,
+                    )
+                  : cn(
+                      "h-11 w-11 text-base border border-transparent md:h-8 md:w-8",
+                      beagleTheme.interactive,
+                      beagleTheme.focusRing,
+                    )
               }
               aria-label={t(option.labelKey)}
               aria-pressed={locale === option.locale}

--- a/apps/web/components/sidebar/app-sidebar.tsx
+++ b/apps/web/components/sidebar/app-sidebar.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { beagleTheme } from "@/components/ui/beagle-theme";
 import {
   Sidebar,
   SidebarContent,
@@ -26,6 +27,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
 import { useI18n, type MessageKey } from "@/lib/i18n";
 
 type NavItem = {
@@ -55,21 +57,32 @@ export function AppSidebar() {
 
   return (
     <Sidebar collapsible="icon" variant="sidebar">
-      <SidebarHeader className="gap-0 border-b border-[var(--beagle-border)] p-0">
+      <SidebarHeader className={cn("gap-0 border-b p-0", beagleTheme.border)}>
         <div
           data-testid="sidebar-title"
           className={
             state === "collapsed"
               ? "flex h-12 items-center justify-center px-0"
-              : "flex h-12 items-center px-3"
+              : "flex h-12 items-center px-4"
           }
         >
           {state === "collapsed" ? (
-            <p className="text-xs font-semibold leading-none tracking-wide text-[var(--beagle-ink)] uppercase">
+            <p
+              className={cn(
+                "text-xs font-semibold leading-none tracking-wide uppercase",
+                beagleTheme.inkStrongText,
+              )}
+            >
               {t("sidebar.shortTitle")}
             </p>
           ) : (
-            <p className="text-base font-semibold leading-none text-[var(--beagle-ink)]">
+            <p
+              className={cn(
+                "leading-none",
+                beagleTheme.headingSm,
+                beagleTheme.inkStrongText,
+              )}
+            >
               {t("sidebar.title")}
             </p>
           )}
@@ -85,7 +98,13 @@ export function AppSidebar() {
                   <SidebarMenuButton
                     tooltip={t(item.labelKey)}
                     onClick={() => handleComingSoon(t(item.labelKey))}
-                    className="text-[var(--beagle-ink)]"
+                    className={cn(
+                      beagleTheme.inkStrongText,
+                      beagleTheme.interactive,
+                      beagleTheme.focusRing,
+                      "min-h-11 md:min-h-9",
+                      "data-[active=true]:bg-[var(--beagle-accent-soft)]",
+                    )}
                   >
                     <item.icon className="size-4" />
                     <span>{t(item.labelKey)}</span>
@@ -97,10 +116,21 @@ export function AppSidebar() {
         </SidebarGroup>
       </SidebarContent>
 
-      <SidebarFooter className="mt-auto border-t border-[var(--beagle-border)] group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-0">
+      <SidebarFooter
+        className={cn(
+          "mt-auto border-t group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-0",
+          beagleTheme.border,
+        )}
+      >
         <Button
           variant="ghost"
-          className="justify-start gap-2 text-[var(--beagle-ink)] group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
+          className={cn(
+            "justify-start gap-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0",
+            beagleTheme.inkStrongText,
+            beagleTheme.interactive,
+            beagleTheme.focusRing,
+            "min-h-11 md:min-h-9",
+          )}
           onClick={() => handleComingSoon(t("sidebar.signIn"))}
         >
           <LogIn className="size-4" />

--- a/apps/web/components/ui/beagle-theme.ts
+++ b/apps/web/components/ui/beagle-theme.ts
@@ -1,0 +1,18 @@
+export const beagleTheme = {
+  panel: "beagle-panel",
+  subpanel: "beagle-subpanel",
+  inkText: "text-[var(--beagle-ink)]",
+  inkStrongText: "text-[var(--beagle-ink-2)]",
+  mutedText: "text-[var(--beagle-muted)]",
+  border: "border-[var(--beagle-border)]",
+  surface: "bg-[var(--beagle-surface)]",
+  sidebarSurface: "bg-[var(--beagle-sidebar-surface)]",
+  softAccent: "bg-[var(--beagle-accent-soft)]",
+  headingLg: "text-3xl font-semibold leading-tight tracking-tight md:text-4xl",
+  headingMd: "text-xl font-semibold tracking-tight",
+  headingSm: "text-base font-semibold tracking-tight",
+  labelSm: "text-sm leading-5",
+  focusRing: "beagle-focus-ring",
+  interactive:
+    "transition-colors duration-150 hover:bg-[var(--beagle-accent-soft)]",
+} as const;


### PR DESCRIPTION
Refine Beagle theme tokens and gradients, then apply updated spacing, typography, and surface styles across the home header, stats cards, and sidebar/header chrome for a more cohesive UI.

Files:
- apps/web/app/globals.css
- apps/web/components/home/main-header.tsx
- apps/web/components/home/statistics-section.tsx
- apps/web/components/sidebar/app-header.tsx
- apps/web/components/sidebar/app-sidebar.tsx