### PR TITLE
feat(release-notes): add public what's new page from changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+
+- Describe what changed and why.
+
+## Checklist
+
+- [ ] This PR includes user-visible changes.
+- [ ] If user-visible, I updated `CHANGELOG.md` under `## [Unreleased]`.
+- [ ] If changelog update is not needed, this PR is internal-only (`refactor` / `test` / `chore`) and I explained why in the PR description.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,71 +1,55 @@
 # Changelog
 
+This project uses a user-facing changelog format.
+
+## How to write entries
+
+- Add one user-visible bullet under `Unreleased`.
+- Keep language plain first; add technical detail only when useful.
+- Internal-only changes are optional in the changelog.
+- Use sections: `Added`, `Changed`, `Fixed`, `Removed`.
+
 ## [Unreleased]
 
-- Consolidate runtime to one Next.js server:
-  - Move API transport routes from `apps/api/app/api/*` to `apps/web/app/api/*`.
-  - Move API transport helpers to `apps/web/lib/server/*`.
-  - Remove standalone `apps/api` package.
-  - Keep route paths and auth cookie behavior unchanged.
-  - Update root dev workflow to run only `@beagle/web`.
-- Shift home statistics to web Server Action + query hook:
-  - Remove `GET /api/v1/home/statistics` route.
-  - Add `apps/web/app/actions/home/get-home-statistics.ts`.
-  - Keep auth and import status endpoints in `app/api/*`.
+### Added
 
-- Redesign web main page shell with legacy-inspired menu layout, top-right login action, and disabled "coming soon" menu items.
-- Add legacy Beagle logo accent and subtle logo watermark background to the new homepage shell.
+- No user-facing additions yet.
 
-- Refactor architecture toward layered backend and shared contracts/client.
-- Add `@beagle/server`, `@beagle/contracts`, and `@beagle/api-client` packages.
-- Move auth route orchestration to `@beagle/server` services.
-- Add admin route group with access gate in `apps/web/app/(admin)`.
-- Remove placeholder import write flow and return not-implemented for import POST until schema is designed.
-- Remove unused `@beagle/domain` package and migrate remaining contract type usage to `@beagle/contracts`.
-- Add phase-1 data foundation for public stats and dog search:
-  - Prisma schema/models for dogs, breeders, owners, ownerships, trial/show events, and import runs
-  - Legacy phase-1 import service with admin-only v1 API routes
-  - Keep UI/read APIs unchanged for now (import-first groundwork only)
-- Standardize Prisma model field ordering (id, business, relations, audit metadata last) with no schema semantic changes.
+### Changed
 
-Files:
+- No user-facing changes yet.
 
-- `apps/api/app/api/auth/login/route.ts`
-- `apps/api/app/api/auth/register/route.ts`
-- `apps/api/app/api/auth/me/route.ts`
-- `apps/api/app/api/auth/logout/route.ts`
-- `apps/api/app/api/import/example/route.ts`
-- `apps/api/package.json`
-- `apps/api/tsconfig.json`
-- `apps/web/app/(auth)/login/page.tsx`
-- `apps/web/app/(auth)/register/page.tsx`
-- `apps/web/app/(admin)/layout.tsx`
-- `apps/web/app/(admin)/admin/page.tsx`
-- `apps/web/components/auth-status.tsx`
-- `apps/web/components/import-status.tsx`
-- `apps/web/components/admin-gate.tsx`
-- `apps/web/package.json`
-- `apps/web/tsconfig.json`
-- `packages/api-client/index.ts`
-- `packages/api-client/package.json`
-- `packages/api-client/tsconfig.json`
-- `packages/contracts/index.ts`
-- `packages/contracts/package.json`
-- `packages/contracts/tsconfig.json`
-- `packages/server/auth/service.ts`
-- `packages/server/auth/service.test.ts`
-- `packages/server/admin/service.ts`
-- `packages/server/index.ts`
-- `packages/server/package.json`
-- `packages/server/shared/result.ts`
-- `packages/server/shared/types.ts`
-- `packages/server/tsconfig.json`
-- `docs/planning/public-read-admin-write-layered-refactor.md`
-- `packages/db/prisma/schema.prisma`
-- `packages/db/index.ts`
-- `packages/server/imports/service.ts`
-- `apps/api/app/api/v1/imports/[id]/route.ts`
-- `packages/server/scripts/run-legacy-phase1.ts`
-- `README.md`
-- `packages/db/prisma/schema.prisma`
-- `CHANGELOG.md`
+### Fixed
+
+- No user-facing fixes yet.
+
+### Removed
+
+- No user-facing removals yet.
+
+## [0.1.0] - 2026-02-16
+
+### Added
+
+- Palvelussa on nyt selkeä etusivu ja sivupalkki.
+- Beaglehaun ensimmäinen versio on julkaistu. Haku toimii EK-numerolla, rekisterinumerolla ja nimellä.
+- Lisäsuodattimista käytössä ovat sukupuoli ja asetus "vain koirat, joilla on useita rekisterinumeroita".
+- Hakutuloksissa näkyvät sekä mobiili- että desktop-näkymässä samat perustiedot: rekisterinumero, EK-numero, sukupuoli, nimi, koemäärä ja näyttelymäärä.
+- Hakutuloksissa näytetään myös muut rekisterinumerot, jos koiralla on niitä useita.
+- Beaglehaussa näkyy myös Viimeisimmät lisäykset -lista (uusimmat koirat).
+- Kielen vaihto suomi/ruotsi on käytössä.
+- Julkinen "Mitä uutta" -sivu ja sen linkki yläpalkissa on lisätty.
+
+### Changed
+
+- Etusivun rakennetta päivitettiin selkeämmäksi.
+- Navigaatio koottiin yhtenäiseksi sivupalkkinäkymäksi.
+- Viimeisimmät lisäykset -listassa vanhojen beaglejen järjestys voi vaihdella, jos lisäysaika on sama.
+
+### Fixed
+
+- Ei käyttäjälle näkyviä korjauksia tässä julkaisussa.
+
+### Removed
+
+- Ei poistettu käyttäjälle näkyviä toimintoja tässä julkaisussa.

--- a/README.md
+++ b/README.md
@@ -216,3 +216,43 @@ For full import behavior (source tables, stage handling, required fields, issue 
 - `docs/roles-and-permissions.md`: baseline role and authorization rules.
 - `docs/migration-plan-v1-to-v2.md`: staged migration approach from legacy app.
 - `docs/import-phase1.md`: phase-1 import flow, data handling, and issue logging behavior.
+
+## How we communicate changes
+
+- User-facing changes are tracked in root `CHANGELOG.md`.
+- Changelog source format:
+  - `## [Unreleased]`
+  - `## [x.y.z] - YYYY-MM-DD`
+  - Sections: `Added`, `Changed`, `Fixed`, `Removed`
+- When a PR includes user-visible behavior, add one line under `Unreleased`.
+- For internal-only changes (`refactor`, `test`, `chore`), changelog updates are optional.
+- User-facing release-note surfaces:
+  - Header entry point: `Mitä uutta` in the app shell.
+  - Public app page: `/whats-new` (latest Finnish summary + full notes).
+  - Matching GitHub Release notes per tagged version.
+
+## Release procedure (manual)
+
+1. Confirm `CHANGELOG.md` `Unreleased` entries are complete and user-facing.
+2. Move `Unreleased` bullets into a new version block `## [x.y.z] - YYYY-MM-DD`.
+3. Keep entries grouped under `Added`, `Changed`, `Fixed`, `Removed`.
+4. Commit the changelog update.
+5. Tag the release (example: `git tag v0.4.0` and `git push origin v0.4.0`).
+6. Create a GitHub Release for that tag and paste the same changelog block as release notes.
+7. Reset `Unreleased` to an empty section skeleton for the next cycle.
+
+Dry-run example:
+
+```md
+## [Unreleased]
+
+### Added
+
+- No user-facing additions yet.
+
+## [0.4.0] - 2026-02-16
+
+### Added
+
+- Added Beagle search filters for owner and registration number.
+```

--- a/apps/web/app/(public)/whats-new/page.tsx
+++ b/apps/web/app/(public)/whats-new/page.tsx
@@ -1,0 +1,112 @@
+import { beagleTheme } from "@/components/ui/beagle-theme";
+import { getReleaseNotesData } from "@/lib/release-notes";
+import { cn } from "@/lib/utils";
+
+const sectionLabelFi: Record<
+  "Added" | "Changed" | "Fixed" | "Removed",
+  string
+> = {
+  Added: "Lisätty",
+  Changed: "Muutettu",
+  Fixed: "Korjattu",
+  Removed: "Poistettu",
+};
+
+export default async function WhatsNewPage() {
+  const releaseNotesData = await getReleaseNotesData();
+  const latestRelease = releaseNotesData.history[0];
+
+  return (
+    <>
+      <header className={cn(beagleTheme.panel, "px-5 py-5 md:px-6 md:py-6")}>
+        <h1 className={cn(beagleTheme.headingLg, beagleTheme.inkStrongText)}>
+          Mitä uutta
+        </h1>
+        {latestRelease ? (
+          <p className={cn("mt-1 text-xs md:text-sm", beagleTheme.mutedText)}>
+            Versio {latestRelease.version} ({latestRelease.date})
+          </p>
+        ) : null}
+        <h2
+          className={cn(
+            "mt-3",
+            beagleTheme.headingSm,
+            beagleTheme.inkStrongText,
+          )}
+        >
+          Uusimmat päivitykset
+        </h2>
+        <ul
+          className={cn(
+            "mt-2 list-disc space-y-1 pl-5 text-sm md:text-base",
+            beagleTheme.inkText,
+          )}
+        >
+          {releaseNotesData.latestUpdatesFi.slice(0, 5).map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+        <div className="mt-4">
+          <a
+            href="#full-release-notes"
+            className={cn(
+              "inline-flex items-center text-sm font-semibold underline underline-offset-2",
+              beagleTheme.inkStrongText,
+              beagleTheme.focusRing,
+            )}
+          >
+            Lue lisää
+          </a>
+        </div>
+      </header>
+
+      <section
+        id="full-release-notes"
+        className={cn(
+          beagleTheme.panel,
+          "scroll-mt-16 px-5 py-5 md:px-6 md:py-6",
+        )}
+      >
+        <h2 className={cn(beagleTheme.headingMd, beagleTheme.inkStrongText)}>
+          Kaikki muutokset
+        </h2>
+
+        <div className="mt-4 space-y-5">
+          {releaseNotesData.history.map((release) => (
+            <section key={`${release.version}-${release.date}`}>
+              <h3
+                className={cn(beagleTheme.headingSm, beagleTheme.inkStrongText)}
+              >
+                v{release.version} ({release.date})
+              </h3>
+              <div className="mt-3 space-y-4">
+                {release.blocks.map((block) => (
+                  <section key={block.section}>
+                    <h4
+                      className={cn(
+                        "text-sm font-semibold",
+                        beagleTheme.inkStrongText,
+                      )}
+                    >
+                      {sectionLabelFi[block.section]}
+                    </h4>
+                    <ul
+                      className={cn(
+                        "mt-2 list-disc space-y-2 pl-5 text-sm md:text-base",
+                        beagleTheme.inkText,
+                      )}
+                    >
+                      {block.items.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </section>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/web/components/sidebar/app-header.tsx
+++ b/apps/web/components/sidebar/app-header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { beagleTheme } from "@/components/ui/beagle-theme";
 import { SidebarTrigger } from "@/components/ui/sidebar";
@@ -48,6 +48,18 @@ export function AppHeader() {
           ) : null}
         </div>
         <div className="flex items-center gap-1">
+          <Button
+            asChild
+            type="button"
+            variant="ghost"
+            size="sm"
+            className={cn(beagleTheme.inkStrongText, beagleTheme.focusRing)}
+          >
+            <Link href="/whats-new" aria-label={t("header.whatsNewAria")}>
+              <Info className="size-4" />
+              <span>{t("header.whatsNew")}</span>
+            </Link>
+          </Button>
           {localeButtons.map((option) => (
             <Button
               key={option.locale}

--- a/apps/web/lib/i18n/messages/header.ts
+++ b/apps/web/lib/i18n/messages/header.ts
@@ -2,10 +2,14 @@ export const fiHeaderMessages = {
   "header.language.finnish": "Vaihda kieleksi suomi",
   "header.language.swedish": "Vaihda kieleksi ruotsi",
   "header.backHome": "Takaisin etusivulle",
+  "header.whatsNew": "Mitä uutta",
+  "header.whatsNewAria": "Avaa Mitä uutta -sivu",
 } as const;
 
 export const svHeaderMessages = {
   "header.language.finnish": "Byt språk till finska",
   "header.language.swedish": "Byt språk till svenska",
   "header.backHome": "Tillbaka till startsidan",
+  "header.whatsNew": "Vad är nytt",
+  "header.whatsNewAria": "Öppna sidan Vad är nytt",
 } as const;

--- a/apps/web/lib/release-notes/index.ts
+++ b/apps/web/lib/release-notes/index.ts
@@ -1,0 +1,1 @@
+export { getReleaseNotesData, type ReleaseNotesData } from "./latest";

--- a/apps/web/lib/release-notes/latest.ts
+++ b/apps/web/lib/release-notes/latest.ts
@@ -1,0 +1,148 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export type ReleaseNotesSection = "Added" | "Changed" | "Fixed" | "Removed";
+
+export type ReleaseNotesBlock = {
+  section: ReleaseNotesSection;
+  items: string[];
+};
+
+export type ReleaseHistoryEntry = {
+  version: string;
+  date: string;
+  blocks: ReleaseNotesBlock[];
+};
+
+export type ReleaseNotesData = {
+  latestUpdatesFi: string[];
+  history: ReleaseHistoryEntry[];
+};
+
+const SECTION_ORDER: ReleaseNotesSection[] = [
+  "Added",
+  "Changed",
+  "Fixed",
+  "Removed",
+];
+
+function uniqueItems(items: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+
+  for (const item of items) {
+    const key = item.trim();
+    if (!key || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(key);
+  }
+
+  return out;
+}
+
+async function readChangelogFile(): Promise<string> {
+  const cwd = process.cwd();
+  const candidates = [
+    path.join(cwd, "CHANGELOG.md"),
+    path.join(cwd, "..", "CHANGELOG.md"),
+    path.join(cwd, "..", "..", "CHANGELOG.md"),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      return await readFile(candidate, "utf8");
+    } catch {
+      // try next candidate
+    }
+  }
+
+  throw new Error("CHANGELOG.md not found");
+}
+
+function parseVersionBlocks(changelogText: string): ReleaseHistoryEntry[] {
+  const lines = changelogText.split(/\r?\n/);
+  const releaseIndices = lines
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => /^## \[[^\]]+\](?: - \d{4}-\d{2}-\d{2})?$/.test(line))
+    .map(({ index }) => index);
+
+  const releases: ReleaseHistoryEntry[] = [];
+
+  for (let i = 0; i < releaseIndices.length; i += 1) {
+    const start = releaseIndices[i];
+    const end =
+      i + 1 < releaseIndices.length ? releaseIndices[i + 1] : lines.length;
+    const header = lines[start];
+    const match = header.match(/^## \[([^\]]+)\](?: - (\d{4}-\d{2}-\d{2}))?$/);
+
+    if (!match) {
+      continue;
+    }
+
+    const version = match[1];
+    const date = match[2];
+    if (version === "Unreleased" || !date) {
+      continue;
+    }
+
+    const sectionItems: Record<ReleaseNotesSection, string[]> = {
+      Added: [],
+      Changed: [],
+      Fixed: [],
+      Removed: [],
+    };
+
+    let currentSection: ReleaseNotesSection | null = null;
+    for (let j = start + 1; j < end; j += 1) {
+      const line = lines[j];
+      const sectionMatch = line.match(/^### (Added|Changed|Fixed|Removed)$/);
+      if (sectionMatch) {
+        currentSection = sectionMatch[1] as ReleaseNotesSection;
+        continue;
+      }
+
+      const bulletMatch = line.match(/^- (.+)$/);
+      if (bulletMatch && currentSection) {
+        sectionItems[currentSection].push(bulletMatch[1].trim());
+      }
+    }
+
+    const blocks: ReleaseNotesBlock[] = SECTION_ORDER.map((section) => ({
+      section,
+      items: uniqueItems(sectionItems[section]),
+    })).filter((block) => block.items.length > 0);
+
+    releases.push({ version, date, blocks });
+  }
+
+  return releases;
+}
+
+function isNonUserVisiblePlaceholder(item: string): boolean {
+  const trimmed = item.trim();
+  return (
+    /^No user-visible /i.test(trimmed) ||
+    /^Ei käyttäjälle näkyviä /i.test(trimmed) ||
+    /^Ei poistettu käyttäjälle näkyviä /i.test(trimmed)
+  );
+}
+
+export async function getReleaseNotesData(): Promise<ReleaseNotesData> {
+  const changelogText = await readChangelogFile();
+  const history = parseVersionBlocks(changelogText);
+  const latest = history[0];
+  const latestItems = latest
+    ? uniqueItems(
+        latest.blocks.flatMap((block) =>
+          block.items.filter((item) => !isNonUserVisiblePlaceholder(item)),
+        ),
+      ).slice(0, 5)
+    : [];
+
+  return {
+    latestUpdatesFi: latestItems,
+    history,
+  };
+}


### PR DESCRIPTION
Add a public `/whats-new` page and header entry point that render latest updates and full release history by parsing `CHANGELOG.md`. Also document the changelog/release process and add a PR template checklist to keep user-facing notes consistent.

Files:
- .github/pull_request_template.md
- CHANGELOG.md
- README.md
- apps/web/app/(public)/whats-new/page.tsx
- apps/web/components/sidebar/app-header.tsx
- apps/web/lib/i18n/messages/header.ts
- apps/web/lib/release-notes/index.ts
- apps/web/lib/release-notes/latest.ts

#25