### PR TITLE
docs(changelog): correct 0.1.1 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses a user-facing changelog format.
 - Internal-only changes are optional in the changelog.
 - Use sections: `Added`, `Changed`, `Fixed`, `Removed`.
 
-## [0.1.1] - 2026-02-16
+## [0.1.1] - 2026-02-17
 
 ### Added
 


### PR DESCRIPTION
Update the 0.1.1 changelog header date to match the release date.

Files:
- CHANGELOG.md

## Summary

- Describe what changed and why.

## Checklist

- [ ] This PR includes user-visible changes.
- [ ] If user-visible, I updated `CHANGELOG.md` under a versioned block (e.g., `## [x.y.z] - YYYY-MM-DD`).
- [ ] If changelog update is not needed, this PR is internal-only (`refactor` / `test` / `chore`) and I explained why in the PR description.
