### PR TITLE
fix(web): show localized error toasts for failed data loads

### DIFF
--- a/apps/web/components/beagle-search/beagle-search-page.tsx
+++ b/apps/web/components/beagle-search/beagle-search-page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Image from "next/image";
-import { useCallback, useMemo } from "react";
-import { toast } from "sonner";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { toast } from "@/components/ui/sonner";
 import { ListingSectionShell } from "@/components/listing";
 import { beagleTheme } from "@/components/ui/beagle-theme";
 import {
@@ -72,6 +72,32 @@ export function BeagleSearchPage() {
     isPending || (searchQuery.isFetching && !searchQuery.data);
   const hasSearchError = searchQuery.isError && !searchQuery.data;
   const hasNewestError = newestQuery.isError && !newestQuery.data;
+  const hasNotifiedSearchError = useRef(false);
+  const hasNotifiedNewestError = useRef(false);
+
+  useEffect(() => {
+    if (hasSearchError && !hasNotifiedSearchError.current) {
+      toast.error(t("search.empty.fetchFailed"));
+      hasNotifiedSearchError.current = true;
+      return;
+    }
+
+    if (!hasSearchError) {
+      hasNotifiedSearchError.current = false;
+    }
+  }, [hasSearchError, t]);
+
+  useEffect(() => {
+    if (hasNewestError && !hasNotifiedNewestError.current) {
+      toast.error(t("search.newest.fetchFailed"));
+      hasNotifiedNewestError.current = true;
+      return;
+    }
+
+    if (!hasNewestError) {
+      hasNotifiedNewestError.current = false;
+    }
+  }, [hasNewestError, t]);
 
   const emptyVariant = hasSearchError
     ? "error"

--- a/apps/web/components/beagle-search/beagle-search-row-actions.tsx
+++ b/apps/web/components/beagle-search/beagle-search-row-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { toast } from "sonner";
+import { toast } from "@/components/ui/sonner";
 import { Button } from "@/components/ui/button";
 import {
   BEAGLE_ROW_ACTIONS,

--- a/apps/web/components/home/statistics-section.tsx
+++ b/apps/web/components/home/statistics-section.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef } from "react";
+import { toast } from "@/components/ui/sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { beagleTheme } from "@/components/ui/beagle-theme";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -84,8 +86,21 @@ const rowClassName = cn(
 
 export function StatisticsSection() {
   const { t, locale } = useI18n();
-  const { data, isLoading } = useHomeStatisticsQuery();
+  const { data, isError, isLoading } = useHomeStatisticsQuery();
+  const hasNotifiedLoadError = useRef(false);
   const isInitialLoading = isLoading && !data;
+
+  useEffect(() => {
+    if (isError && !hasNotifiedLoadError.current) {
+      toast.error(t("home.stats.fetchFailed"));
+      hasNotifiedLoadError.current = true;
+      return;
+    }
+
+    if (!isError) {
+      hasNotifiedLoadError.current = false;
+    }
+  }, [isError, t]);
 
   const localeTag = locale === "fi" ? "fi-FI" : "sv-FI";
   const numberFormat = new Intl.NumberFormat(localeTag);

--- a/apps/web/components/sidebar/app-sidebar.tsx
+++ b/apps/web/components/sidebar/app-sidebar.tsx
@@ -15,7 +15,7 @@ import {
   Trophy,
   Users,
 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/components/ui/sonner";
 import { Button } from "@/components/ui/button";
 import { beagleTheme } from "@/components/ui/beagle-theme";
 import {

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -7,7 +7,7 @@ import {
   OctagonXIcon,
   TriangleAlertIcon,
 } from "lucide-react";
-import { Toaster as Sonner, type ToasterProps } from "sonner";
+import { Toaster as Sonner, toast, type ToasterProps } from "sonner";
 
 const Toaster = ({ richColors, ...props }: ToasterProps) => {
   return (
@@ -35,4 +35,4 @@ const Toaster = ({ richColors, ...props }: ToasterProps) => {
   );
 };
 
-export { Toaster };
+export { Toaster, toast };

--- a/apps/web/lib/i18n/messages/home.ts
+++ b/apps/web/lib/i18n/messages/home.ts
@@ -13,6 +13,8 @@ export const fiHomeMessages = {
   "home.stats.row.totalTrialEntries": "Ajokoestartteja yhteensä",
   "home.stats.row.performedByDogs": "Suorittaneita koiria",
   "home.stats.row.totalShowEntries": "Näyttelystartteja yhteensä",
+  "home.stats.fetchFailed":
+    "Tilastojen lataus epäonnistui. Yritä uudelleen hetken kuluttua.",
 } as const;
 
 export const svHomeMessages = {
@@ -30,4 +32,6 @@ export const svHomeMessages = {
   "home.stats.row.totalTrialEntries": "Jaktprovsstarter totalt",
   "home.stats.row.performedByDogs": "Genomförda av hundar",
   "home.stats.row.totalShowEntries": "Utställningsstarter totalt",
+  "home.stats.fetchFailed":
+    "Det gick inte att ladda statistiken. Försök igen om en stund.",
 } as const;

--- a/apps/web/lib/i18n/messages/search.ts
+++ b/apps/web/lib/i18n/messages/search.ts
@@ -77,6 +77,8 @@ export const fiSearchMessages = {
     "Lista on järjestetty lisäysajan mukaan. Siirrossa uuteen järjestelmään monelle vanhalle koiralle tallentui sama lisäysaika, joten niiden keskinäinen järjestys voi vaihdella.",
   "search.newest.registration": "Rekisterinumero",
   "search.newest.birthDate": "Syntymäaika",
+  "search.newest.fetchFailed":
+    "Viimeisimpien lisäysten lataus epäonnistui. Yritä uudelleen hetken kuluttua.",
 } as const;
 
 export const svSearchMessages = {
@@ -158,4 +160,6 @@ export const svSearchMessages = {
     "Listan är sorterad enligt tilläggstid. Vid överföringen till det nya systemet fick många äldre hundar samma tilläggstid, så den inbördes ordningen kan variera.",
   "search.newest.registration": "Registreringsnummer",
   "search.newest.birthDate": "Födelsedatum",
+  "search.newest.fetchFailed":
+    "Det gick inte att ladda de senaste tilläggen. Försök igen om en stund.",
 } as const;


### PR DESCRIPTION
Add one-time error toasts for beagle search/newest and home statistics fetch failures, and route toast usage through the app's shared sonner wrapper so icons/theme stay consistent.

Files:
- apps/web/components/beagle-search/beagle-search-page.tsx
- apps/web/components/beagle-search/beagle-search-row-actions.tsx
- apps/web/components/home/statistics-section.tsx
- apps/web/components/sidebar/app-sidebar.tsx
- apps/web/components/ui/sonner.tsx
- apps/web/lib/i18n/messages/home.ts
- apps/web/lib/i18n/messages/search.ts

## Summary

- Describe what changed and why.

## Checklist

- [ ] This PR includes user-visible changes.
- [ ] If user-visible, I updated `CHANGELOG.md` under a versioned block (e.g., `## [x.y.z] - YYYY-MM-DD`).
- [ ] If changelog update is not needed, this PR is internal-only (`refactor` / `test` / `chore`) and I explained why in the PR description.
