### PR TITLE
refactor(web-listing): unify responsive result layout and loading skeletons

### DIFF
--- a/apps/web/components/admin-users/admin-user-search.tsx
+++ b/apps/web/components/admin-users/admin-user-search.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+
+type AdminUserSearchProps = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  ariaLabel: string;
+  disabled?: boolean;
+};
+
+export function AdminUserSearch({
+  value,
+  onChange,
+  placeholder,
+  ariaLabel,
+  disabled = false,
+}: AdminUserSearchProps) {
+  return (
+    <Input
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={placeholder}
+      aria-label={ariaLabel}
+      disabled={disabled}
+    />
+  );
+}

--- a/apps/web/components/admin-users/admin-users-page-client.tsx
+++ b/apps/web/components/admin-users/admin-users-page-client.tsx
@@ -6,6 +6,7 @@ import { toast } from "@/components/ui/sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { ListingResponsiveResults } from "@/components/listing";
 import { ListLoadingSkeleton } from "@/components/ui/list-loading-skeleton";
 import { useI18n } from "@/hooks/i18n";
 import {
@@ -16,6 +17,7 @@ import {
   useSetAdminUserPasswordMutation,
   useSetAdminUserStatusMutation,
 } from "@/queries/admin";
+import { AdminUserSearch } from "./admin-user-search";
 
 export function AdminUsersPageClient() {
   const { t } = useI18n();
@@ -280,7 +282,14 @@ export function AdminUsersPageClient() {
           <CardTitle>{t("admin.users.management.title")}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          {isInitialLoading ? <ListLoadingSkeleton showSearchBar /> : null}
+          <AdminUserSearch
+            value={query}
+            onChange={setQuery}
+            placeholder={t("admin.users.searchPlaceholder")}
+            ariaLabel={t("admin.users.searchAria")}
+            disabled={isInitialLoading || isError}
+          />
+          {isInitialLoading ? <ListLoadingSkeleton /> : null}
           {isError ? (
             <div className="flex items-center justify-between gap-3 rounded-md border p-3">
               <p className="text-sm text-muted-foreground">
@@ -297,95 +306,87 @@ export function AdminUsersPageClient() {
               </Button>
             </div>
           ) : null}
-          <Input
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder={t("admin.users.searchPlaceholder")}
-            aria-label={t("admin.users.searchAria")}
-            disabled={isInitialLoading || isError}
-          />
 
           {!isInitialLoading ? (
-            <div className="hidden overflow-x-auto md:block">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b text-left">
-                    <th className="px-2 py-2">
-                      {t("admin.users.columns.email")}
-                    </th>
-                    <th className="px-2 py-2">
-                      {t("admin.users.columns.name")}
-                    </th>
-                    <th className="px-2 py-2">
-                      {t("admin.users.columns.role")}
-                    </th>
-                    <th className="px-2 py-2">
-                      {t("admin.users.columns.status")}
-                    </th>
-                    <th className="px-2 py-2">
-                      {t("admin.users.columns.actions")}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredUsers.map((user) => (
-                    <tr key={user.id} className="border-b align-top">
-                      <td className="px-2 py-2">{user.email}</td>
-                      <td className="px-2 py-2">{user.name ?? "-"}</td>
-                      <td className="px-2 py-2">{user.role}</td>
-                      <td className="px-2 py-2">{user.status}</td>
-                      <td className="px-2 py-2">
-                        <div className="flex flex-wrap gap-2">
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => {
-                              setResetTarget({
-                                id: user.id,
-                                email: user.email,
-                              });
-                              setResetPassword("");
-                              setResetPasswordConfirm("");
-                            }}
-                          >
-                            {t("admin.users.actions.resetPassword")}
-                          </Button>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => void onToggleSuspend(user)}
-                          >
-                            {user.status === "active"
-                              ? t("admin.users.actions.suspend")
-                              : t("admin.users.actions.unsuspend")}
-                          </Button>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() =>
-                              setDeleteTarget({
-                                id: user.id,
-                                email: user.email,
-                              })
-                            }
-                          >
-                            {t("admin.users.actions.delete")}
-                          </Button>
-                        </div>
-                      </td>
+            <ListingResponsiveResults
+              desktopClassName="overflow-x-auto"
+              mobileClassName="space-y-3"
+              desktop={
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left">
+                      <th className="px-2 py-2">
+                        {t("admin.users.columns.email")}
+                      </th>
+                      <th className="px-2 py-2">
+                        {t("admin.users.columns.name")}
+                      </th>
+                      <th className="px-2 py-2">
+                        {t("admin.users.columns.role")}
+                      </th>
+                      <th className="px-2 py-2">
+                        {t("admin.users.columns.status")}
+                      </th>
+                      <th className="px-2 py-2">
+                        {t("admin.users.columns.actions")}
+                      </th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ) : null}
-
-          {!isInitialLoading ? (
-            <div className="space-y-3 md:hidden">
-              {filteredUsers.map((user) => (
+                  </thead>
+                  <tbody>
+                    {filteredUsers.map((user) => (
+                      <tr key={user.id} className="border-b align-top">
+                        <td className="px-2 py-2">{user.email}</td>
+                        <td className="px-2 py-2">{user.name ?? "-"}</td>
+                        <td className="px-2 py-2">{user.role}</td>
+                        <td className="px-2 py-2">{user.status}</td>
+                        <td className="px-2 py-2">
+                          <div className="flex flex-wrap gap-2">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => {
+                                setResetTarget({
+                                  id: user.id,
+                                  email: user.email,
+                                });
+                                setResetPassword("");
+                                setResetPasswordConfirm("");
+                              }}
+                            >
+                              {t("admin.users.actions.resetPassword")}
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => void onToggleSuspend(user)}
+                            >
+                              {user.status === "active"
+                                ? t("admin.users.actions.suspend")
+                                : t("admin.users.actions.unsuspend")}
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() =>
+                                setDeleteTarget({
+                                  id: user.id,
+                                  email: user.email,
+                                })
+                              }
+                            >
+                              {t("admin.users.actions.delete")}
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              }
+              mobile={filteredUsers.map((user) => (
                 <Card key={user.id}>
                   <CardContent className="space-y-3 pt-4">
                     <div>
@@ -439,7 +440,7 @@ export function AdminUsersPageClient() {
                   </CardContent>
                 </Card>
               ))}
-            </div>
+            />
           ) : null}
         </CardContent>
       </Card>

--- a/apps/web/components/beagle-search/beagle-search-loading-state.tsx
+++ b/apps/web/components/beagle-search/beagle-search-loading-state.tsx
@@ -1,5 +1,5 @@
 import { ListLoadingSkeleton } from "@/components/ui/list-loading-skeleton";
 
 export function BeagleSearchLoadingState() {
-  return <ListLoadingSkeleton rows={5} desktopRows={0} mobileCards={0} />;
+  return <ListLoadingSkeleton />;
 }

--- a/apps/web/components/beagle-search/beagle-search-page.tsx
+++ b/apps/web/components/beagle-search/beagle-search-page.tsx
@@ -3,7 +3,10 @@
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { toast } from "@/components/ui/sonner";
-import { ListingSectionShell } from "@/components/listing";
+import {
+  ListingResponsiveResults,
+  ListingSectionShell,
+} from "@/components/listing";
 import { beagleTheme } from "@/components/ui/beagle-theme";
 import {
   formatBeagleRowsForClipboard,
@@ -220,13 +223,14 @@ export function BeagleSearchPage() {
           <BeagleSearchEmptyState variant="error" />
         ) : hasResultItems ? (
           <>
-            {/* Desktop uses table, mobile uses cards; both render same row contract. */}
-            <div className="hidden md:block">
-              <BeagleSearchResultsDesktopTable rows={searchResults.items} />
-            </div>
-            <div className="md:hidden">
-              <BeagleSearchResultsMobileCards rows={searchResults.items} />
-            </div>
+            <ListingResponsiveResults
+              desktop={
+                <BeagleSearchResultsDesktopTable rows={searchResults.items} />
+              }
+              mobile={
+                <BeagleSearchResultsMobileCards rows={searchResults.items} />
+              }
+            />
             <BeagleSearchPagination
               page={searchResults.page}
               pageSize={urlState.pageSize}
@@ -250,14 +254,14 @@ export function BeagleSearchPage() {
         ) : hasNewestError ? (
           <BeagleSearchEmptyState variant="error" />
         ) : (
-          <>
-            <div className="hidden md:block">
+          <ListingResponsiveResults
+            desktop={
               <BeagleSearchResultsDesktopTable rows={newestQuery.data ?? []} />
-            </div>
-            <div className="md:hidden">
+            }
+            mobile={
               <BeagleSearchResultsMobileCards rows={newestQuery.data ?? []} />
-            </div>
-          </>
+            }
+          />
         )}
       </ListingSectionShell>
     </>

--- a/apps/web/components/listing/index.ts
+++ b/apps/web/components/listing/index.ts
@@ -1,1 +1,2 @@
 export { ListingSectionShell } from "./listing-section-shell";
+export { ListingResponsiveResults } from "./listing-responsive-results";

--- a/apps/web/components/listing/listing-responsive-results.tsx
+++ b/apps/web/components/listing/listing-responsive-results.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function ListingResponsiveResults({
+  desktop,
+  mobile,
+  desktopClassName,
+  mobileClassName,
+}: {
+  desktop: ReactNode;
+  mobile: ReactNode;
+  desktopClassName?: string;
+  mobileClassName?: string;
+}) {
+  return (
+    <>
+      <div className={cn("hidden md:block", desktopClassName)}>{desktop}</div>
+      <div className={cn("md:hidden", mobileClassName)}>{mobile}</div>
+    </>
+  );
+}

--- a/apps/web/components/ui/__tests__/list-loading-skeleton.test.tsx
+++ b/apps/web/components/ui/__tests__/list-loading-skeleton.test.tsx
@@ -7,7 +7,6 @@ describe("ListLoadingSkeleton", () => {
   it("renders configured loading blocks", () => {
     const html = renderToStaticMarkup(
       React.createElement(ListLoadingSkeleton, {
-        showSearchBar: true,
         desktopRows: 2,
         mobileCards: 1,
       }),
@@ -18,12 +17,16 @@ describe("ListLoadingSkeleton", () => {
     expect(html).toContain("md:hidden");
     expect(
       html.match(/data-slot="skeleton"/g)?.length ?? 0,
-    ).toBeGreaterThanOrEqual(6);
+    ).toBeGreaterThanOrEqual(5);
   });
 
   it("renders simple row list variant", () => {
     const html = renderToStaticMarkup(
-      React.createElement(ListLoadingSkeleton, { rows: 4 }),
+      React.createElement(ListLoadingSkeleton, {
+        rows: 4,
+        desktopRows: 0,
+        mobileCards: 0,
+      }),
     );
 
     expect(html).toContain('aria-busy="true"');

--- a/apps/web/components/ui/list-loading-skeleton.tsx
+++ b/apps/web/components/ui/list-loading-skeleton.tsx
@@ -1,22 +1,18 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
 type ListLoadingSkeletonProps = {
-  showSearchBar?: boolean;
   rows?: number;
   desktopRows?: number;
   mobileCards?: number;
 };
 
 export function ListLoadingSkeleton({
-  showSearchBar = false,
   rows = 0,
   desktopRows = 5,
   mobileCards = 3,
 }: ListLoadingSkeletonProps) {
   return (
     <div className="space-y-3" aria-busy="true">
-      {showSearchBar ? <Skeleton className="h-9 w-full" /> : null}
-
       {rows > 0 ? (
         <div className="space-y-2">
           {Array.from({ length: rows }).map((_, index) => (


### PR DESCRIPTION
## Summary

- Refactor web listing rendering to use a shared responsive layout wrapper for desktop/mobile result views.
- Introduce a feature-specific admin user search component while keeping shared listing primitives generic.
- Standardize loading skeleton behavior by removing fake search-bar skeleton support and aligning Beagle Search to shared defaults.

## Checklist

- [ ] This PR includes user-visible changes.
- [ ] If user-visible, I updated `CHANGELOG.md` under a versioned block (e.g., `## [x.y.z] - YYYY-MM-DD`).
- [x] If changelog update is not needed, this PR is internal-only (`refactor` / `test` / `chore`) and I explained why in the PR description.

## Changes

- Added `ListingResponsiveResults` and exported it from the listing module.
- Updated Beagle Search results/newest sections to use shared responsive listing layout.
- Added `AdminUserSearch` and refactored Admin Users page to consume shared responsive listing layout.
- Removed fake search skeleton capability from `ListLoadingSkeleton` and updated associated tests.
- Standardized Beagle Search loading state to use shared skeleton defaults.

## Files

- `apps/web/components/admin-users/admin-user-search.tsx`
- `apps/web/components/admin-users/admin-users-page-client.tsx`
- `apps/web/components/beagle-search/beagle-search-loading-state.tsx`
- `apps/web/components/beagle-search/beagle-search-page.tsx`
- `apps/web/components/listing/index.ts`
- `apps/web/components/listing/listing-responsive-results.tsx`
- `apps/web/components/ui/__tests__/list-loading-skeleton.test.tsx`
- `apps/web/components/ui/list-loading-skeleton.tsx`

## Testing

- `pnpm --filter @beagle/web test:unit`
