### PR TITLE
fix(db): centralize database url resolution for runtime and prisma

### DIFF
--- a/packages/db/core/__tests__/resolve-database-url.test.ts
+++ b/packages/db/core/__tests__/resolve-database-url.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { resolveDatabaseUrl } from "../resolve-database-url";
+
+describe("resolveDatabaseUrl", () => {
+  it("prefers production-scoped vars on Vercel production", () => {
+    const url = resolveDatabaseUrl({
+      VERCEL_ENV: "production",
+      beagle_db_develop_POSTGRES_PRISMA_URL: "postgresql://develop-pooled",
+      beagle_db_production_POSTGRES_PRISMA_URL:
+        "postgresql://production-pooled",
+    });
+
+    expect(url).toBe("postgresql://production-pooled");
+  });
+
+  it("prefers develop-scoped vars outside Vercel production", () => {
+    const url = resolveDatabaseUrl({
+      VERCEL_ENV: "preview",
+      beagle_db_develop_POSTGRES_PRISMA_URL: "postgresql://develop-pooled",
+      beagle_db_production_POSTGRES_PRISMA_URL:
+        "postgresql://production-pooled",
+    });
+
+    expect(url).toBe("postgresql://develop-pooled");
+  });
+
+  it("keeps runtime pooled URLs above non-pooling", () => {
+    const url = resolveDatabaseUrl({
+      beagle_db_develop_POSTGRES_URL_NON_POOLING:
+        "postgresql://develop-nonpooling",
+      beagle_db_develop_POSTGRES_PRISMA_URL: "postgresql://develop-pooled",
+    });
+
+    expect(url).toBe("postgresql://develop-pooled");
+  });
+
+  it("prefers non-pooling for migrations", () => {
+    const url = resolveDatabaseUrl(
+      {
+        beagle_db_develop_POSTGRES_URL_NON_POOLING:
+          "postgresql://develop-nonpooling",
+        beagle_db_develop_POSTGRES_PRISMA_URL: "postgresql://develop-pooled",
+      },
+      "migration",
+    );
+
+    expect(url).toBe("postgresql://develop-nonpooling");
+  });
+});

--- a/packages/db/core/prisma.ts
+++ b/packages/db/core/prisma.ts
@@ -1,17 +1,9 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
+import { resolveDatabaseUrl } from "./resolve-database-url";
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
-const configuredDatabaseUrl =
-  process.env.DATABASE_URL ??
-  process.env.beagle_db_develop_DATABASE_URL_UNPOOLED ??
-  process.env.beagle_db_develop_POSTGRES_PRISMA_URL ??
-  process.env.POSTGRES_PRISMA_URL ??
-  process.env.beagle_db_develop_POSTGRES_URL ??
-  process.env.POSTGRES_URL ??
-  process.env.beagle_db_develop_POSTGRES_URL_NO_SSL ??
-  process.env.POSTGRES_URL_NON_POOLING ??
-  "postgresql://postgres:password@127.0.0.1:5432/beagle_db_v2";
+const configuredDatabaseUrl = resolveDatabaseUrl();
 const adapter = new PrismaPg({ connectionString: configuredDatabaseUrl });
 
 export const prisma = globalForPrisma.prisma ?? new PrismaClient({ adapter });

--- a/packages/db/core/resolve-database-url.ts
+++ b/packages/db/core/resolve-database-url.ts
@@ -1,0 +1,81 @@
+type DatabaseTarget = "runtime" | "migration";
+type Scope = "develop" | "production";
+
+const LOCAL_DATABASE_URL =
+  "postgresql://postgres:password@127.0.0.1:5432/beagle_db_v2";
+
+function getScopeFromEnv(env: NodeJS.ProcessEnv): Scope {
+  return env.VERCEL_ENV === "production" ? "production" : "develop";
+}
+
+function scopedValue(
+  env: NodeJS.ProcessEnv,
+  scope: Scope,
+  key: string,
+): string | undefined {
+  return env[`beagle_db_${scope}_${key}`];
+}
+
+function pickRuntimeUrl(
+  env: NodeJS.ProcessEnv,
+  primaryScope: Scope,
+): string | undefined {
+  const fallbackScope =
+    primaryScope === "production" ? "develop" : "production";
+
+  return (
+    scopedValue(env, primaryScope, "DATABASE_URL_UNPOOLED") ??
+    scopedValue(env, primaryScope, "POSTGRES_PRISMA_URL") ??
+    scopedValue(env, primaryScope, "POSTGRES_URL") ??
+    scopedValue(env, primaryScope, "POSTGRES_URL_NO_SSL") ??
+    env.POSTGRES_PRISMA_URL ??
+    env.POSTGRES_URL ??
+    scopedValue(env, primaryScope, "POSTGRES_URL_NON_POOLING") ??
+    env.POSTGRES_URL_NON_POOLING ??
+    scopedValue(env, fallbackScope, "DATABASE_URL_UNPOOLED") ??
+    scopedValue(env, fallbackScope, "POSTGRES_PRISMA_URL") ??
+    scopedValue(env, fallbackScope, "POSTGRES_URL") ??
+    scopedValue(env, fallbackScope, "POSTGRES_URL_NO_SSL") ??
+    scopedValue(env, fallbackScope, "POSTGRES_URL_NON_POOLING")
+  );
+}
+
+function pickMigrationUrl(
+  env: NodeJS.ProcessEnv,
+  primaryScope: Scope,
+): string | undefined {
+  const fallbackScope =
+    primaryScope === "production" ? "develop" : "production";
+
+  return (
+    scopedValue(env, primaryScope, "DATABASE_URL_UNPOOLED") ??
+    scopedValue(env, primaryScope, "POSTGRES_URL_NON_POOLING") ??
+    env.POSTGRES_URL_NON_POOLING ??
+    scopedValue(env, primaryScope, "POSTGRES_PRISMA_URL") ??
+    scopedValue(env, primaryScope, "POSTGRES_URL") ??
+    scopedValue(env, primaryScope, "POSTGRES_URL_NO_SSL") ??
+    env.POSTGRES_PRISMA_URL ??
+    env.POSTGRES_URL ??
+    scopedValue(env, fallbackScope, "DATABASE_URL_UNPOOLED") ??
+    scopedValue(env, fallbackScope, "POSTGRES_URL_NON_POOLING") ??
+    scopedValue(env, fallbackScope, "POSTGRES_PRISMA_URL") ??
+    scopedValue(env, fallbackScope, "POSTGRES_URL") ??
+    scopedValue(env, fallbackScope, "POSTGRES_URL_NO_SSL")
+  );
+}
+
+export function resolveDatabaseUrl(
+  env: NodeJS.ProcessEnv = process.env,
+  target: DatabaseTarget = "runtime",
+): string {
+  const scope = getScopeFromEnv(env);
+
+  const resolvedUrl =
+    env.DATABASE_URL ??
+    (target === "runtime"
+      ? pickRuntimeUrl(env, scope)
+      : pickMigrationUrl(env, scope)) ??
+    LOCAL_DATABASE_URL;
+
+  return resolvedUrl;
+}

--- a/packages/db/prisma.config.ts
+++ b/packages/db/prisma.config.ts
@@ -1,17 +1,9 @@
 import { defineConfig } from "prisma/config";
+import { resolveDatabaseUrl } from "./core/resolve-database-url";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
   datasource: {
-    url:
-      process.env.DATABASE_URL ??
-      process.env.beagle_db_develop_DATABASE_URL_UNPOOLED ??
-      process.env.POSTGRES_URL_NON_POOLING ??
-      process.env.beagle_db_develop_POSTGRES_PRISMA_URL ??
-      process.env.POSTGRES_PRISMA_URL ??
-      process.env.beagle_db_develop_POSTGRES_URL ??
-      process.env.POSTGRES_URL ??
-      process.env.beagle_db_develop_POSTGRES_URL_NO_SSL ??
-      "postgresql://postgres:password@127.0.0.1:5432/beagle_db_v2",
+    url: resolveDatabaseUrl(process.env, "migration"),
   },
 });


### PR DESCRIPTION
Extract database URL selection into a shared resolver used by both Prisma runtime client and prisma config. Preserve intentional precedence differences between runtime and migration targets, support develop/production-scoped env aliases, keep local fallback for non-production, and fail fast in production when URL is missing. Add resolver tests to lock precedence and fallback behavior.

Files:
- packages/db/core/resolve-database-url.ts
- packages/db/core/prisma.ts
- packages/db/prisma.config.ts
- packages/db/core/__tests__/resolve-database-url.test.ts

## Summary

- Describe what changed and why.

## Checklist

- [ ] This PR includes user-visible changes.
- [ ] If user-visible, I updated `CHANGELOG.md` under a versioned block (e.g., `## [x.y.z] - YYYY-MM-DD`).
- [ ] If changelog update is not needed, this PR is internal-only (`refactor` / `test` / `chore`) and I explained why in the PR description.
