### PR TITLE
fix(queries): invalidate public caches and stop home polling

### DIFF
--- a/apps/web/queries/admin/dogs/__tests__/use-create-admin-dog-mutation.test.ts
+++ b/apps/web/queries/admin/dogs/__tests__/use-create-admin-dog-mutation.test.ts
@@ -1,6 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  beagleNewestQueryKeyRoot,
+  beagleSearchQueryKeyRoot,
+} from "@/queries/beagle-search/query-keys";
+import { homeStatisticsQueryKey } from "@/queries/home/query-keys";
 import { AdminMutationError } from "@/queries/admin/mutation-error";
-import { adminDogsQueryKeyRoot } from "../query-keys";
+import {
+  adminDogBreederOptionsQueryKeyRoot,
+  adminDogOwnerOptionsQueryKeyRoot,
+  adminDogParentOptionsQueryKeyRoot,
+  adminDogsQueryKeyRoot,
+} from "../query-keys";
 import { useCreateAdminDogMutation } from "../use-create-admin-dog-mutation";
 
 const {
@@ -92,7 +102,7 @@ describe("useCreateAdminDogMutation", () => {
     });
   });
 
-  it("invalidates admin dogs query on success", async () => {
+  it("invalidates admin and public dog query roots on success", async () => {
     useMutationMock.mockImplementation((options) => options);
 
     useCreateAdminDogMutation();
@@ -102,8 +112,27 @@ describe("useCreateAdminDogMutation", () => {
 
     await options.onSuccess();
 
+    expect(invalidateQueriesMock).toHaveBeenCalledTimes(7);
     expect(invalidateQueriesMock).toHaveBeenCalledWith({
       queryKey: adminDogsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: adminDogBreederOptionsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: adminDogOwnerOptionsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: adminDogParentOptionsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: beagleSearchQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: beagleNewestQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: homeStatisticsQueryKey,
     });
   });
 

--- a/apps/web/queries/admin/dogs/__tests__/use-delete-admin-dog-mutation.test.ts
+++ b/apps/web/queries/admin/dogs/__tests__/use-delete-admin-dog-mutation.test.ts
@@ -1,6 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  beagleNewestQueryKeyRoot,
+  beagleSearchQueryKeyRoot,
+} from "@/queries/beagle-search/query-keys";
+import { homeStatisticsQueryKey } from "@/queries/home/query-keys";
 import { AdminMutationError } from "@/queries/admin/mutation-error";
-import { adminDogsQueryKeyRoot } from "../query-keys";
+import {
+  adminDogBreederOptionsQueryKeyRoot,
+  adminDogOwnerOptionsQueryKeyRoot,
+  adminDogParentOptionsQueryKeyRoot,
+  adminDogsQueryKeyRoot,
+} from "../query-keys";
 import { useDeleteAdminDogMutation } from "../use-delete-admin-dog-mutation";
 
 const {
@@ -76,7 +86,7 @@ describe("useDeleteAdminDogMutation", () => {
     });
   });
 
-  it("invalidates admin dogs query on success", async () => {
+  it("invalidates admin and public dog query roots on success", async () => {
     useMutationMock.mockImplementation((options) => options);
 
     useDeleteAdminDogMutation();
@@ -86,8 +96,27 @@ describe("useDeleteAdminDogMutation", () => {
 
     await options.onSuccess();
 
+    expect(invalidateQueriesMock).toHaveBeenCalledTimes(7);
     expect(invalidateQueriesMock).toHaveBeenCalledWith({
       queryKey: adminDogsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: adminDogBreederOptionsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: adminDogOwnerOptionsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: adminDogParentOptionsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: beagleSearchQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: beagleNewestQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: homeStatisticsQueryKey,
     });
   });
 

--- a/apps/web/queries/admin/dogs/__tests__/use-update-admin-dog-mutation.test.ts
+++ b/apps/web/queries/admin/dogs/__tests__/use-update-admin-dog-mutation.test.ts
@@ -1,6 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  beagleNewestQueryKeyRoot,
+  beagleSearchQueryKeyRoot,
+} from "@/queries/beagle-search/query-keys";
+import { homeStatisticsQueryKey } from "@/queries/home/query-keys";
 import { AdminMutationError } from "@/queries/admin/mutation-error";
-import { adminDogsQueryKeyRoot } from "../query-keys";
+import {
+  adminDogBreederOptionsQueryKeyRoot,
+  adminDogOwnerOptionsQueryKeyRoot,
+  adminDogParentOptionsQueryKeyRoot,
+  adminDogsQueryKeyRoot,
+} from "../query-keys";
 import { useUpdateAdminDogMutation } from "../use-update-admin-dog-mutation";
 
 const {
@@ -94,7 +104,7 @@ describe("useUpdateAdminDogMutation", () => {
     });
   });
 
-  it("invalidates admin dogs query on success", async () => {
+  it("invalidates admin and public dog query roots on success", async () => {
     useMutationMock.mockImplementation((options) => options);
 
     useUpdateAdminDogMutation();
@@ -104,8 +114,27 @@ describe("useUpdateAdminDogMutation", () => {
 
     await options.onSuccess();
 
+    expect(invalidateQueriesMock).toHaveBeenCalledTimes(7);
     expect(invalidateQueriesMock).toHaveBeenCalledWith({
       queryKey: adminDogsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: adminDogBreederOptionsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: adminDogOwnerOptionsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: adminDogParentOptionsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: beagleSearchQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: beagleNewestQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: homeStatisticsQueryKey,
     });
   });
 

--- a/apps/web/queries/admin/dogs/use-create-admin-dog-mutation.ts
+++ b/apps/web/queries/admin/dogs/use-create-admin-dog-mutation.ts
@@ -13,6 +13,11 @@ import {
   adminDogParentOptionsQueryKeyRoot,
   adminDogsQueryKeyRoot,
 } from "./query-keys";
+import {
+  beagleNewestQueryKeyRoot,
+  beagleSearchQueryKeyRoot,
+} from "@/queries/beagle-search/query-keys";
+import { homeStatisticsQueryKey } from "@/queries/home/query-keys";
 
 export function useCreateAdminDogMutation() {
   const queryClient = useQueryClient();
@@ -43,6 +48,15 @@ export function useCreateAdminDogMutation() {
       });
       await queryClient.invalidateQueries({
         queryKey: adminDogParentOptionsQueryKeyRoot,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: beagleSearchQueryKeyRoot,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: beagleNewestQueryKeyRoot,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: homeStatisticsQueryKey,
       });
     },
   });

--- a/apps/web/queries/admin/dogs/use-delete-admin-dog-mutation.ts
+++ b/apps/web/queries/admin/dogs/use-delete-admin-dog-mutation.ts
@@ -13,6 +13,11 @@ import {
   adminDogParentOptionsQueryKeyRoot,
   adminDogsQueryKeyRoot,
 } from "./query-keys";
+import {
+  beagleNewestQueryKeyRoot,
+  beagleSearchQueryKeyRoot,
+} from "@/queries/beagle-search/query-keys";
+import { homeStatisticsQueryKey } from "@/queries/home/query-keys";
 
 export function useDeleteAdminDogMutation() {
   const queryClient = useQueryClient();
@@ -43,6 +48,15 @@ export function useDeleteAdminDogMutation() {
       });
       await queryClient.invalidateQueries({
         queryKey: adminDogParentOptionsQueryKeyRoot,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: beagleSearchQueryKeyRoot,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: beagleNewestQueryKeyRoot,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: homeStatisticsQueryKey,
       });
     },
   });

--- a/apps/web/queries/admin/dogs/use-update-admin-dog-mutation.ts
+++ b/apps/web/queries/admin/dogs/use-update-admin-dog-mutation.ts
@@ -13,6 +13,11 @@ import {
   adminDogParentOptionsQueryKeyRoot,
   adminDogsQueryKeyRoot,
 } from "./query-keys";
+import {
+  beagleNewestQueryKeyRoot,
+  beagleSearchQueryKeyRoot,
+} from "@/queries/beagle-search/query-keys";
+import { homeStatisticsQueryKey } from "@/queries/home/query-keys";
 
 export function useUpdateAdminDogMutation() {
   const queryClient = useQueryClient();
@@ -43,6 +48,15 @@ export function useUpdateAdminDogMutation() {
       });
       await queryClient.invalidateQueries({
         queryKey: adminDogParentOptionsQueryKeyRoot,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: beagleSearchQueryKeyRoot,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: beagleNewestQueryKeyRoot,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: homeStatisticsQueryKey,
       });
     },
   });

--- a/apps/web/queries/beagle-search/__tests__/query-keys.test.ts
+++ b/apps/web/queries/beagle-search/__tests__/query-keys.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { BeagleSearchQueryState } from "@/lib/beagle-search";
+import {
+  beagleNewestQueryKey,
+  beagleNewestQueryKeyRoot,
+  beagleSearchQueryKey,
+  beagleSearchQueryKeyRoot,
+} from "../query-keys";
+
+describe("beagle search query keys", () => {
+  it("builds beagle search key", () => {
+    const state: BeagleSearchQueryState = {
+      ek: "100",
+      reg: "FI-123",
+      name: "Kide",
+      sex: "female",
+      birthYearFrom: "2019",
+      birthYearTo: "2022",
+      ekOnly: false,
+      multipleRegsOnly: true,
+      page: 2,
+      pageSize: 25,
+      sort: "created-desc",
+      adv: true,
+    };
+
+    expect(beagleSearchQueryKey(state)).toEqual([
+      ...beagleSearchQueryKeyRoot,
+      "100",
+      "FI-123",
+      "Kide",
+      "female",
+      "2019",
+      "2022",
+      false,
+      true,
+      2,
+      25,
+      "created-desc",
+    ]);
+  });
+
+  it("builds newest key", () => {
+    expect(beagleNewestQueryKey(10)).toEqual([...beagleNewestQueryKeyRoot, 10]);
+  });
+});

--- a/apps/web/queries/beagle-search/__tests__/use-beagle-newest-query.test.ts
+++ b/apps/web/queries/beagle-search/__tests__/use-beagle-newest-query.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beagleNewestQueryKey } from "../query-keys";
 import { useBeagleNewestQuery } from "../use-beagle-newest-query";
 
 const { useQueryMock, getNewestDogsActionMock } = vi.hoisted(() => ({
@@ -32,7 +33,7 @@ describe("useBeagleNewestQuery", () => {
       refetchOnWindowFocus: boolean;
     };
 
-    expect(options.queryKey).toEqual(["beagle-newest", 5]);
+    expect(options.queryKey).toEqual(beagleNewestQueryKey(5));
     expect(options.staleTime).toBe(300_000);
     expect(options.refetchInterval).toBe(300_000);
     expect(options.refetchOnWindowFocus).toBe(true);

--- a/apps/web/queries/beagle-search/__tests__/use-beagle-search-query.test.ts
+++ b/apps/web/queries/beagle-search/__tests__/use-beagle-search-query.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BeagleSearchQueryState } from "@/lib/beagle-search";
+import { beagleSearchQueryKey } from "../query-keys";
 import { useBeagleSearchQuery } from "../use-beagle-search-query";
 
 const { useQueryMock, searchDogsActionMock } = vi.hoisted(() => ({
@@ -76,20 +77,16 @@ describe("useBeagleSearchQuery", () => {
     });
 
     const options = useQueryMock.mock.calls[0]?.[0] as { queryKey: unknown[] };
-    expect(options.queryKey).toEqual([
-      "beagle-search",
-      "100",
-      "",
-      "",
-      "any",
-      "",
-      "",
-      false,
-      true,
-      3,
-      25,
-      "ek-asc",
-    ]);
+    expect(options.queryKey).toEqual(
+      beagleSearchQueryKey({
+        ...baseState,
+        ek: "100",
+        page: 3,
+        pageSize: 25,
+        sort: "ek-asc",
+        multipleRegsOnly: true,
+      }),
+    );
   });
 
   it("maps payload and omits sex when value is any", async () => {

--- a/apps/web/queries/beagle-search/index.ts
+++ b/apps/web/queries/beagle-search/index.ts
@@ -1,0 +1,8 @@
+export {
+  beagleNewestQueryKey,
+  beagleNewestQueryKeyRoot,
+  beagleSearchQueryKey,
+  beagleSearchQueryKeyRoot,
+} from "./query-keys";
+export { useBeagleNewestQuery } from "./use-beagle-newest-query";
+export { useBeagleSearchQuery } from "./use-beagle-search-query";

--- a/apps/web/queries/beagle-search/query-keys.ts
+++ b/apps/web/queries/beagle-search/query-keys.ts
@@ -1,0 +1,25 @@
+import type { BeagleSearchQueryState } from "@/lib/beagle-search";
+
+export const beagleSearchQueryKeyRoot = ["beagle-search"] as const;
+export const beagleNewestQueryKeyRoot = ["beagle-newest"] as const;
+
+export function beagleSearchQueryKey(state: BeagleSearchQueryState) {
+  return [
+    ...beagleSearchQueryKeyRoot,
+    state.ek,
+    state.reg,
+    state.name,
+    state.sex,
+    state.birthYearFrom,
+    state.birthYearTo,
+    state.ekOnly,
+    state.multipleRegsOnly,
+    state.page,
+    state.pageSize,
+    state.sort,
+  ] as const;
+}
+
+export function beagleNewestQueryKey(limit: number) {
+  return [...beagleNewestQueryKeyRoot, limit] as const;
+}

--- a/apps/web/queries/beagle-search/use-beagle-newest-query.ts
+++ b/apps/web/queries/beagle-search/use-beagle-newest-query.ts
@@ -3,12 +3,13 @@
 import type { BeagleSearchRow } from "@beagle/contracts";
 import { useQuery } from "@tanstack/react-query";
 import { getNewestDogsAction } from "@/app/actions/beagle-search/get-newest-dogs";
+import { beagleNewestQueryKey } from "./query-keys";
 
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
 export function useBeagleNewestQuery(limit = 5) {
   return useQuery<BeagleSearchRow[]>({
-    queryKey: ["beagle-newest", limit],
+    queryKey: beagleNewestQueryKey(limit),
     queryFn: async () => {
       const result = await getNewestDogsAction({ limit });
       if (result.hasError || !result.data) {

--- a/apps/web/queries/beagle-search/use-beagle-search-query.ts
+++ b/apps/web/queries/beagle-search/use-beagle-search-query.ts
@@ -7,6 +7,7 @@ import {
   parseBirthYearInput,
   type BeagleSearchQueryState,
 } from "@/lib/beagle-search";
+import { beagleSearchQueryKey } from "./query-keys";
 
 export function useBeagleSearchQuery(state: BeagleSearchQueryState) {
   const birthYearFrom = parseBirthYearInput(state.birthYearFrom);
@@ -22,20 +23,7 @@ export function useBeagleSearchQuery(state: BeagleSearchQueryState) {
     state.multipleRegsOnly;
 
   return useQuery<BeagleSearchResponse>({
-    queryKey: [
-      "beagle-search",
-      state.ek,
-      state.reg,
-      state.name,
-      state.sex,
-      state.birthYearFrom,
-      state.birthYearTo,
-      state.ekOnly,
-      state.multipleRegsOnly,
-      state.page,
-      state.pageSize,
-      state.sort,
-    ],
+    queryKey: beagleSearchQueryKey(state),
     enabled: hasSearchInput,
     queryFn: async () => {
       const result = await searchDogsAction({

--- a/apps/web/queries/home/__tests__/use-home-statistics-query.test.ts
+++ b/apps/web/queries/home/__tests__/use-home-statistics-query.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HomeStatisticsResponse } from "@beagle/contracts";
+import { homeStatisticsQueryKey } from "../query-keys";
 import { useHomeStatisticsQuery } from "../use-home-statistics-query";
 
 const { useQueryMock, getHomeStatisticsActionMock } = vi.hoisted(() => ({
@@ -30,9 +31,8 @@ describe("useHomeStatisticsQuery", () => {
 
     expect(useQueryMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        queryKey: ["home-statistics"],
+        queryKey: homeStatisticsQueryKey,
         staleTime: 5 * 60 * 1000,
-        refetchInterval: 5 * 60 * 1000,
         refetchOnWindowFocus: true,
         queryFn: expect.any(Function),
       }),

--- a/apps/web/queries/home/query-keys.ts
+++ b/apps/web/queries/home/query-keys.ts
@@ -1,0 +1,1 @@
+export const homeStatisticsQueryKey = ["home-statistics"] as const;

--- a/apps/web/queries/home/use-home-statistics-query.ts
+++ b/apps/web/queries/home/use-home-statistics-query.ts
@@ -3,12 +3,13 @@
 import type { HomeStatisticsResponse } from "@beagle/contracts";
 import { useQuery } from "@tanstack/react-query";
 import { getHomeStatisticsAction } from "@/app/actions/home/get-home-statistics";
+import { homeStatisticsQueryKey } from "./query-keys";
 
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
 export function useHomeStatisticsQuery() {
   return useQuery<HomeStatisticsResponse | null>({
-    queryKey: ["home-statistics"],
+    queryKey: homeStatisticsQueryKey,
     queryFn: async () => {
       const result = await getHomeStatisticsAction();
       if (result.hasError) {
@@ -17,7 +18,6 @@ export function useHomeStatisticsQuery() {
       return result.data;
     },
     staleTime: REFRESH_INTERVAL_MS,
-    refetchInterval: REFRESH_INTERVAL_MS,
     refetchOnWindowFocus: true,
   });
 }


### PR DESCRIPTION
Ensure admin dog create/update/delete mutations also invalidate public-facing query caches so beagle search, newest dogs, and home statistics reflect changes immediately. Centralize query keys for beagle search and home statistics to avoid inline key drift and align hook tests with shared key factories/constants. Remove home statistics polling by dropping interval refetch while keeping stale time and refetch-on-focus behavior.

Files:
- apps/web/queries/admin/dogs/__tests__/use-create-admin-dog-mutation.test.ts
- apps/web/queries/admin/dogs/__tests__/use-delete-admin-dog-mutation.test.ts
- apps/web/queries/admin/dogs/__tests__/use-update-admin-dog-mutation.test.ts
- apps/web/queries/admin/dogs/use-create-admin-dog-mutation.ts
- apps/web/queries/admin/dogs/use-delete-admin-dog-mutation.ts
- apps/web/queries/admin/dogs/use-update-admin-dog-mutation.ts
- apps/web/queries/beagle-search/__tests__/query-keys.test.ts
- apps/web/queries/beagle-search/__tests__/use-beagle-newest-query.test.ts
- apps/web/queries/beagle-search/__tests__/use-beagle-search-query.test.ts
- apps/web/queries/beagle-search/index.ts
- apps/web/queries/beagle-search/query-keys.ts
- apps/web/queries/beagle-search/use-beagle-newest-query.ts
- apps/web/queries/beagle-search/use-beagle-search-query.ts
- apps/web/queries/home/__tests__/use-home-statistics-query.test.ts
- apps/web/queries/home/query-keys.ts
- apps/web/queries/home/use-home-statistics-query.ts

ref #61



## Checklist

- [ ] This PR includes user-visible changes.
- [ ] If user-visible, I updated `CHANGELOG.md` under a versioned block (e.g., `## [x.y.z] - YYYY-MM-DD`).
- [x] If changelog update is not needed, this PR is internal-only (`refactor` / `test` / `chore`) and I explained why in the PR description.
