### PR TITLE
refactor(dogs): unify dogId parsing across service entrypoints

### DIFF
--- a/apps/web/app/actions/public/beagle/dogs/profile/__tests__/get-dog-profile.test.ts
+++ b/apps/web/app/actions/public/beagle/dogs/profile/__tests__/get-dog-profile.test.ts
@@ -23,6 +23,10 @@ vi.mock("@beagle/server", () => ({
   dogsService: {
     getBeagleDogProfile: getBeagleDogProfileMock,
   },
+  parseDogId: (value: string) => {
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
+  },
   toErrorLog: (error: unknown) => ({ error }),
 }));
 
@@ -45,7 +49,7 @@ describe("getDogProfileAction", () => {
   });
 
   it("returns 400 for invalid dogId and skips service call", async () => {
-    await expect(getDogProfileAction("??")).resolves.toEqual({
+    await expect(getDogProfileAction("   ")).resolves.toEqual({
       data: null,
       hasError: true,
       status: 400,

--- a/apps/web/app/actions/public/beagle/dogs/profile/get-dog-profile.ts
+++ b/apps/web/app/actions/public/beagle/dogs/profile/get-dog-profile.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import type { BeagleDogProfileDto } from "@beagle/contracts";
-import { dogsService, toErrorLog } from "@beagle/server";
+import { dogsService, parseDogId, toErrorLog } from "@beagle/server";
 import { createActionLogger } from "@/lib/server/action-logger";
 
 export type GetDogProfileActionResult = {
@@ -10,17 +10,6 @@ export type GetDogProfileActionResult = {
   status: number;
   error?: string;
 };
-
-function parseDogId(value: string): string | null {
-  const normalized = value.trim();
-  if (!normalized) {
-    return null;
-  }
-  if (!/^[A-Za-z0-9_-]{3,64}$/u.test(normalized)) {
-    return null;
-  }
-  return normalized;
-}
 
 export async function getDogProfileAction(
   dogId: string,

--- a/packages/server/admin/dogs/manage/__tests__/delete-dog.test.ts
+++ b/packages/server/admin/dogs/manage/__tests__/delete-dog.test.ts
@@ -30,6 +30,8 @@ describe("deleteAdminDog", () => {
         code: "INVALID_DOG_ID",
       },
     });
+
+    expect(deleteAdminDogWriteDbMock).not.toHaveBeenCalled();
   });
 
   it("returns 404 when dog is not found", async () => {

--- a/packages/server/admin/dogs/manage/__tests__/update-dog.test.ts
+++ b/packages/server/admin/dogs/manage/__tests__/update-dog.test.ts
@@ -52,6 +52,9 @@ describe("updateAdminDog", () => {
         code: "INVALID_DOG_ID",
       },
     });
+
+    expect(updateAdminDogWriteDbMock).not.toHaveBeenCalled();
+    expect(findDogByIdDbMock).not.toHaveBeenCalled();
   });
 
   it("returns 400 for empty registration number", async () => {

--- a/packages/server/admin/dogs/manage/delete-dog.ts
+++ b/packages/server/admin/dogs/manage/delete-dog.ts
@@ -9,7 +9,7 @@ import type {
 } from "@beagle/contracts";
 import { toErrorLog, withLogContext } from "../../../core/logger";
 import type { ServiceResult } from "../../../core/result";
-import { normalizeRequiredText } from "./normalization";
+import { parseDogId } from "../../../dogs/core";
 
 export async function deleteAdminDog(
   input: DeleteAdminDogRequest,
@@ -26,7 +26,7 @@ export async function deleteAdminDog(
 
   log.info({ event: "start", dogId: input.id }, "admin dog delete started");
 
-  const id = normalizeRequiredText(input.id);
+  const id = parseDogId(input.id);
   if (!id) {
     log.warn(
       { event: "invalid_dog_id", durationMs: Date.now() - startedAt },

--- a/packages/server/admin/dogs/manage/update-dog.ts
+++ b/packages/server/admin/dogs/manage/update-dog.ts
@@ -11,6 +11,7 @@ import type {
 } from "@beagle/contracts";
 import { toErrorLog, withLogContext } from "../../../core/logger";
 import type { ServiceResult } from "../../../core/result";
+import { parseDogId } from "../../../dogs/core";
 import {
   hasMaxLength,
   isValidRegistrationNo,
@@ -83,7 +84,7 @@ export async function updateAdminDog(
     "admin dog update started",
   );
 
-  const id = normalizeRequiredText(input.id);
+  const id = parseDogId(input.id);
   if (!id) {
     log.warn(
       { event: "invalid_dog_id", durationMs: Date.now() - startedAt },

--- a/packages/server/dogs/__tests__/service.test.ts
+++ b/packages/server/dogs/__tests__/service.test.ts
@@ -466,6 +466,15 @@ describe("dogs service", () => {
     });
   });
 
+  it("trims dogId before profile DB call", async () => {
+    getBeagleDogProfileDbMock.mockResolvedValue(null);
+
+    const service = createDogsService();
+    await service.getBeagleDogProfile(" dog-casing ");
+
+    expect(getBeagleDogProfileDbMock).toHaveBeenCalledWith("dog-casing");
+  });
+
   it("returns 500 when profile DB call throws", async () => {
     getBeagleDogProfileDbMock.mockRejectedValue(new Error("db fail"));
     const service = createDogsService();

--- a/packages/server/dogs/core/__tests__/dog-id.test.ts
+++ b/packages/server/dogs/core/__tests__/dog-id.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { parseDogId } from "../dog-id";
+
+describe("parseDogId", () => {
+  it("returns null for whitespace-only input", () => {
+    expect(parseDogId("   ")).toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseDogId(" dog_1 ")).toBe("dog_1");
+  });
+
+  it("accepts legacy-like ids", () => {
+    expect(parseDogId("dog1")).toBe("dog1");
+    expect(parseDogId("dog_1")).toBe("dog_1");
+    expect(parseDogId("dog-casing")).toBe("dog-casing");
+  });
+});

--- a/packages/server/dogs/core/dog-id.ts
+++ b/packages/server/dogs/core/dog-id.ts
@@ -1,0 +1,4 @@
+export function parseDogId(value: string): string | null {
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}

--- a/packages/server/dogs/core/index.ts
+++ b/packages/server/dogs/core/index.ts
@@ -1,0 +1,1 @@
+export { parseDogId } from "./dog-id";

--- a/packages/server/dogs/index.ts
+++ b/packages/server/dogs/index.ts
@@ -3,3 +3,4 @@ export {
   getBeagleDogProfileService,
   type DogsServiceLogContext,
 } from "./profile/get-beagle-dog-profile";
+export { parseDogId } from "./core";

--- a/packages/server/dogs/profile/get-beagle-dog-profile.ts
+++ b/packages/server/dogs/profile/get-beagle-dog-profile.ts
@@ -5,6 +5,7 @@ import { formatTrialAward } from "../trial-results";
 import { toBusinessDateOnly } from "../../core/date-only";
 import { toErrorLog, withLogContext } from "../../core/logger";
 import type { ServiceResult } from "../../core/result";
+import { parseDogId } from "../core";
 
 export type DogsServiceLogContext = {
   requestId?: string;
@@ -58,12 +59,16 @@ export async function getBeagleDogProfileService(
     ...(context?.requestId ? { requestId: context.requestId } : {}),
     ...(context?.actorUserId ? { actorUserId: context.actorUserId } : {}),
   });
-  log.info({ event: "start", dogId }, "dog profile fetch started");
+  const parsedDogId = parseDogId(dogId);
+  log.info(
+    { event: "start", dogId: parsedDogId ?? dogId },
+    "dog profile fetch started",
+  );
 
-  if (!dogId) {
+  if (!parsedDogId) {
     log.warn(
-      { event: "invalid_input", durationMs: Date.now() - startedAt },
-      "dog profile fetch rejected: missing dogId",
+      { event: "invalid_dog_id", durationMs: Date.now() - startedAt },
+      "dog profile fetch rejected: invalid dogId",
     );
     return {
       status: 400,
@@ -72,10 +77,14 @@ export async function getBeagleDogProfileService(
   }
 
   try {
-    const data = await getBeagleDogProfileDb(dogId);
+    const data = await getBeagleDogProfileDb(parsedDogId);
     if (!data) {
       log.info(
-        { event: "not_found", dogId, durationMs: Date.now() - startedAt },
+        {
+          event: "not_found",
+          dogId: parsedDogId,
+          durationMs: Date.now() - startedAt,
+        },
         "dog profile not found",
       );
       return {
@@ -85,7 +94,11 @@ export async function getBeagleDogProfileService(
     }
 
     log.info(
-      { event: "success", dogId, durationMs: Date.now() - startedAt },
+      {
+        event: "success",
+        dogId: parsedDogId,
+        durationMs: Date.now() - startedAt,
+      },
       "dog profile fetch succeeded",
     );
     return {
@@ -96,7 +109,7 @@ export async function getBeagleDogProfileService(
     log.error(
       {
         event: "exception",
-        dogId,
+        dogId: parsedDogId,
         durationMs: Date.now() - startedAt,
         ...toErrorLog(error),
       },

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -15,6 +15,7 @@ export {
 } from "./admin";
 export { betterAuth } from "./auth";
 export { createDogsService, dogsService } from "./dogs";
+export { parseDogId } from "./dogs";
 export { createImportsService, importsService } from "./imports";
 export { createStatsService, statsService } from "./home";
 export type { ServiceResult } from "./core/result";


### PR DESCRIPTION
Add a shared server-side parseDogId helper and use it in public dog profile action plus server dog/admin entry points. This removes duplicated parsing, keeps backward-safe validation (trim + non-empty), and aligns invalid-dog-id logging behavior across layers.

Files:
- apps/web/app/actions/public/beagle/dogs/profile/__tests__/get-dog-profile.test.ts
- apps/web/app/actions/public/beagle/dogs/profile/get-dog-profile.ts
- packages/server/admin/dogs/manage/__tests__/delete-dog.test.ts
- packages/server/admin/dogs/manage/__tests__/update-dog.test.ts
- packages/server/admin/dogs/manage/delete-dog.ts
- packages/server/admin/dogs/manage/update-dog.ts
- packages/server/dogs/__tests__/service.test.ts
- packages/server/dogs/core/__tests__/dog-id.test.ts
- packages/server/dogs/core/dog-id.ts
- packages/server/dogs/core/index.ts
- packages/server/dogs/index.ts
- packages/server/dogs/profile/get-beagle-dog-profile.ts
- packages/server/index.ts

Ref BEJ-11

## Summary

- Describe what changed and why.

## Checklist

- [ ] This PR includes user-visible changes.
- [ ] If user-visible, I updated `CHANGELOG.md` under a versioned block (e.g., `## [x.y.z] - YYYY-MM-DD`).
- [ ] If changelog update is not needed, this PR is internal-only (`refactor` / `test` / `chore`) and I explained why in the PR description.
