### PR TITLE
Refactor admin dog manage use-cases into internal helpers

### DIFF
--- a/packages/db/admin/dogs/lookups/list-breeder-options.ts
+++ b/packages/db/admin/dogs/lookups/list-breeder-options.ts
@@ -1,5 +1,8 @@
-import { prisma } from "../../../core/prisma";
-import { normalizeQuery, parseLookupLimit } from "../manage/normalization";
+import { prisma } from "@db/core/prisma";
+import {
+  normalizeQuery,
+  parseLookupLimit,
+} from "@db/admin/dogs/manage/normalization";
 
 export type AdminBreederLookupRequestDb = {
   query?: string;

--- a/packages/db/admin/dogs/lookups/list-owner-options.ts
+++ b/packages/db/admin/dogs/lookups/list-owner-options.ts
@@ -1,5 +1,8 @@
-import { prisma } from "../../../core/prisma";
-import { normalizeQuery, parseLookupLimit } from "../manage/normalization";
+import { prisma } from "@db/core/prisma";
+import {
+  normalizeQuery,
+  parseLookupLimit,
+} from "@db/admin/dogs/manage/normalization";
 
 export type AdminOwnerLookupRequestDb = {
   query?: string;

--- a/packages/db/admin/dogs/lookups/list-parent-options.ts
+++ b/packages/db/admin/dogs/lookups/list-parent-options.ts
@@ -1,6 +1,9 @@
 import type { DogSex } from "@prisma/client";
-import { prisma } from "../../../core/prisma";
-import { normalizeQuery, parseLookupLimit } from "../manage/normalization";
+import { prisma } from "@db/core/prisma";
+import {
+  normalizeQuery,
+  parseLookupLimit,
+} from "@db/admin/dogs/manage/normalization";
 
 export type AdminDogParentLookupRequestDb = {
   query?: string;

--- a/packages/db/admin/dogs/manage/create-dog.ts
+++ b/packages/db/admin/dogs/manage/create-dog.ts
@@ -2,7 +2,7 @@ import type { Prisma } from "@prisma/client";
 import {
   runInAuditContextDb,
   type AuditContextDb,
-} from "../../../core/audit-context";
+} from "@db/core/audit-context";
 import { uniqueNonEmptyNames } from "./normalization";
 
 export type CreateAdminDogDbInput = {

--- a/packages/db/admin/dogs/manage/find-dog-by-id.ts
+++ b/packages/db/admin/dogs/manage/find-dog-by-id.ts
@@ -1,5 +1,5 @@
 import type { DogSex, Prisma } from "@prisma/client";
-import { prisma } from "../../../core/prisma";
+import { prisma } from "@db/core/prisma";
 
 type AdminDogDbClient = Prisma.TransactionClient | typeof prisma;
 

--- a/packages/db/admin/dogs/manage/find-dog-by-registration.ts
+++ b/packages/db/admin/dogs/manage/find-dog-by-registration.ts
@@ -1,5 +1,5 @@
 import type { DogSex, Prisma } from "@prisma/client";
-import { prisma } from "../../../core/prisma";
+import { prisma } from "@db/core/prisma";
 
 type AdminDogDbClient = Prisma.TransactionClient | typeof prisma;
 

--- a/packages/db/admin/dogs/manage/list-dogs.ts
+++ b/packages/db/admin/dogs/manage/list-dogs.ts
@@ -1,5 +1,5 @@
 import { DogSex, type Prisma } from "@prisma/client";
-import { prisma } from "../../../core/prisma";
+import { prisma } from "@db/core/prisma";
 import { normalizeQuery, uniqueNonEmptyNames } from "./normalization";
 
 export type AdminDogListSortDb = "name-asc" | "birth-desc" | "created-desc";

--- a/packages/server/admin/dogs/lookups/list-breeder-options.ts
+++ b/packages/server/admin/dogs/lookups/list-breeder-options.ts
@@ -4,10 +4,13 @@ import type {
   AdminDogLookupRequest,
   CurrentUserDto,
 } from "@beagle/contracts";
-import { toErrorLog, withLogContext } from "../../../core/logger";
-import type { ServiceResult } from "../../../core/result";
-import { requireAdmin } from "../../core/service";
-import { normalizeQuery, parseLookupLimit } from "../manage/normalization";
+import { requireAdmin } from "@server/admin/core/service";
+import { toErrorLog, withLogContext } from "@server/core/logger";
+import type { ServiceResult } from "@server/core/result";
+import {
+  normalizeQuery,
+  parseLookupLimit,
+} from "@server/admin/dogs/manage/normalization";
 
 type ServiceLogContext = {
   requestId?: string;

--- a/packages/server/admin/dogs/lookups/list-owner-options.ts
+++ b/packages/server/admin/dogs/lookups/list-owner-options.ts
@@ -4,10 +4,13 @@ import type {
   AdminOwnerLookupResponse,
   CurrentUserDto,
 } from "@beagle/contracts";
-import { toErrorLog, withLogContext } from "../../../core/logger";
-import type { ServiceResult } from "../../../core/result";
-import { requireAdmin } from "../../core/service";
-import { normalizeQuery, parseLookupLimit } from "../manage/normalization";
+import { requireAdmin } from "@server/admin/core/service";
+import { toErrorLog, withLogContext } from "@server/core/logger";
+import type { ServiceResult } from "@server/core/result";
+import {
+  normalizeQuery,
+  parseLookupLimit,
+} from "@server/admin/dogs/manage/normalization";
 
 type ServiceLogContext = {
   requestId?: string;

--- a/packages/server/admin/dogs/lookups/list-parent-options.ts
+++ b/packages/server/admin/dogs/lookups/list-parent-options.ts
@@ -4,10 +4,13 @@ import type {
   AdminDogParentLookupResponse,
   CurrentUserDto,
 } from "@beagle/contracts";
-import { toErrorLog, withLogContext } from "../../../core/logger";
-import type { ServiceResult } from "../../../core/result";
-import { requireAdmin } from "../../core/service";
-import { normalizeQuery, parseLookupLimit } from "../manage/normalization";
+import { requireAdmin } from "@server/admin/core/service";
+import { toErrorLog, withLogContext } from "@server/core/logger";
+import type { ServiceResult } from "@server/core/result";
+import {
+  normalizeQuery,
+  parseLookupLimit,
+} from "@server/admin/dogs/manage/normalization";
 
 type ServiceLogContext = {
   requestId?: string;

--- a/packages/server/admin/dogs/manage/create-dog.ts
+++ b/packages/server/admin/dogs/manage/create-dog.ts
@@ -7,23 +7,20 @@ import type {
   CreateAdminDogRequest,
   CreateAdminDogResponse,
 } from "@beagle/contracts";
-import { toErrorLog, withLogContext } from "../../../core/logger";
-import type { ServiceResult } from "../../../core/result";
-import {
-  hasMaxLength,
-  isValidRegistrationNo,
-  normalizeDistinctNames,
-  normalizeOptionalText,
-  normalizeRegistrationNo,
-  normalizeRegistrationNos,
-  normalizeRequiredText,
-  parseBirthDate,
-  parseDogSex,
-  parsePositiveInteger,
-} from "./normalization";
-import { resolveParentByRegistration } from "./internal/parent-resolution";
+import { toErrorLog, withLogContext } from "@server/core/logger";
+import type { ServiceResult } from "@server/core/result";
+import { normalizeDistinctNames } from "./normalization";
 import { isPrismaUniqueConstraintError } from "./internal/prisma-errors";
-import { validateDogTitles } from "./internal/title-validation";
+import {
+  createInternalErrorResponse,
+  createSuccessResponse,
+  duplicateDogResponse,
+} from "./internal/manage-responses";
+import {
+  validateCreateInTry,
+  validateCreatePreflight,
+} from "./internal/create-input-validation";
+import { resolveAndValidateCreateParents } from "./internal/create-parent-validation";
 
 const DOG_NAME_MAX_LENGTH = 120;
 const DOG_REGISTRATION_NO_MAX_LENGTH = 40;
@@ -53,306 +50,56 @@ export async function createAdminDog(
     "admin dog create started",
   );
 
-  const name = normalizeRequiredText(input.name);
-  if (!name) {
-    log.warn(
-      { event: "invalid_name", durationMs: Date.now() - startedAt },
-      "admin dog create rejected because name is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Name is required.",
-        code: "INVALID_NAME",
-      },
-    };
-  }
-  if (!hasMaxLength(name, DOG_NAME_MAX_LENGTH)) {
-    log.warn(
-      { event: "name_too_long", durationMs: Date.now() - startedAt },
-      "admin dog create rejected because name is too long",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: `Name cannot exceed ${DOG_NAME_MAX_LENGTH} characters.`,
-        code: "NAME_TOO_LONG",
-      },
-    };
-  }
-
-  const sex = parseDogSex(input.sex);
-  if (!sex) {
-    log.warn(
-      {
-        event: "invalid_sex",
-        sex: input.sex,
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog create rejected because sex is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Invalid sex value.",
-        code: "INVALID_SEX",
-      },
-    };
-  }
-
-  const birthDate = parseBirthDate(input.birthDate);
-  if (birthDate === "INVALID") {
-    log.warn(
-      {
-        event: "invalid_birth_date",
-        birthDate: input.birthDate,
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog create rejected because birth date is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Birth date must use YYYY-MM-DD format.",
-        code: "INVALID_BIRTH_DATE",
-      },
-    };
-  }
-
-  const ekNo = parsePositiveInteger(input.ekNo);
-  if (ekNo === "INVALID") {
-    log.warn(
-      {
-        event: "invalid_ek_no",
-        ekNo: input.ekNo,
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog create rejected because EK number is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "EK number must be a positive integer.",
-        code: "INVALID_EK_NO",
-      },
-    };
-  }
-
-  const registrationNo = normalizeRequiredText(input.registrationNo);
-  if (!registrationNo) {
-    log.warn(
-      {
-        event: "invalid_registration_no",
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog create rejected because registration number is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Registration number is required.",
-        code: "INVALID_REGISTRATION_NO",
-      },
-    };
-  }
-  const normalizedPrimaryRegistrationNo =
-    normalizeRegistrationNo(registrationNo);
-  if (!normalizedPrimaryRegistrationNo) {
-    log.warn(
-      {
-        event: "invalid_registration_no",
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog create rejected because registration number is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Registration number is required.",
-        code: "INVALID_REGISTRATION_NO",
-      },
-    };
-  }
-  const secondaryRegistrationNos = normalizeRegistrationNos(
-    input.secondaryRegistrationNos,
+  const preflight = validateCreatePreflight(
+    input,
+    DOG_NAME_MAX_LENGTH,
+    DOG_REGISTRATION_NO_MAX_LENGTH,
   );
-  const allRegistrationNos = [
-    normalizedPrimaryRegistrationNo,
-    ...secondaryRegistrationNos,
-  ];
+  if (!preflight.ok) {
+    log.warn(
+      {
+        ...preflight.logContext,
+        durationMs: Date.now() - startedAt,
+      },
+      preflight.logMessage,
+    );
+    return preflight.response;
+  }
 
   try {
-    if (
-      allRegistrationNos.some(
-        (value) => !hasMaxLength(value, DOG_REGISTRATION_NO_MAX_LENGTH),
-      )
-    ) {
+    const inTryValidation = validateCreateInTry(input, DOG_NOTE_MAX_LENGTH);
+    if (!inTryValidation.ok) {
       log.warn(
         {
-          event: "registration_no_too_long",
-          registrationCount: allRegistrationNos.length,
+          ...inTryValidation.logContext,
           durationMs: Date.now() - startedAt,
         },
-        "admin dog create rejected because registration number is too long",
+        inTryValidation.logMessage,
       );
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: `Registration number cannot exceed ${DOG_REGISTRATION_NO_MAX_LENGTH} characters.`,
-          code: "REGISTRATION_NO_TOO_LONG",
-        },
-      };
-    }
-    if (allRegistrationNos.some((value) => !isValidRegistrationNo(value))) {
-      log.warn(
-        {
-          event: "invalid_registration_no_format",
-          registrationCount: allRegistrationNos.length,
-          durationMs: Date.now() - startedAt,
-        },
-        "admin dog create rejected because registration number format is invalid",
-      );
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Registration number format is invalid.",
-          code: "INVALID_REGISTRATION_NO",
-        },
-      };
-    }
-    if (new Set(allRegistrationNos).size !== allRegistrationNos.length) {
-      log.warn(
-        {
-          event: "duplicate_registration_no_payload",
-          registrationCount: allRegistrationNos.length,
-          durationMs: Date.now() - startedAt,
-        },
-        "admin dog create rejected because duplicate registration numbers were provided",
-      );
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Registration numbers must be unique.",
-          code: "DUPLICATE_REGISTRATION_NO",
-        },
-      };
+      return inTryValidation.response;
     }
 
-    const note = normalizeOptionalText(input.note);
-    if (!hasMaxLength(note, DOG_NOTE_MAX_LENGTH)) {
-      log.warn(
-        { event: "note_too_long", durationMs: Date.now() - startedAt },
-        "admin dog create rejected because note is too long",
-      );
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: `Note cannot exceed ${DOG_NOTE_MAX_LENGTH} characters.`,
-          code: "NOTE_TOO_LONG",
-        },
-      };
-    }
-
-    const parsedTitles = validateDogTitles(input.titles);
-    if (!parsedTitles.ok) {
-      log.warn(
-        {
-          event: "invalid_titles",
-          code: parsedTitles.response.body.code,
-          durationMs: Date.now() - startedAt,
-        },
-        "admin dog create rejected because title rows are invalid",
-      );
-      return parsedTitles.response;
-    }
-
-    const sireRegistrationNo = normalizeOptionalText(input.sireRegistrationNo);
-    const damRegistrationNo = normalizeOptionalText(input.damRegistrationNo);
-
-    const sire = await resolveParentByRegistration(sireRegistrationNo);
-    if (sireRegistrationNo && !sire) {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Sire registration number was not found.",
-          code: "INVALID_SIRE_REGISTRATION",
-        },
-      };
-    }
-
-    const dam = await resolveParentByRegistration(damRegistrationNo);
-    if (damRegistrationNo && !dam) {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Dam registration number was not found.",
-          code: "INVALID_DAM_REGISTRATION",
-        },
-      };
-    }
-
-    if (sire && dam && sire.id === dam.id) {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Sire and dam must be different dogs.",
-          code: "INVALID_PARENT_COMBINATION",
-        },
-      };
-    }
-
-    if (sire && sire.sex !== "MALE") {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Selected sire must be a male dog.",
-          code: "INVALID_SIRE_SEX",
-        },
-      };
-    }
-
-    if (dam && dam.sex !== "FEMALE") {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Selected dam must be a female dog.",
-          code: "INVALID_DAM_SEX",
-        },
-      };
+    const parentValidation = await resolveAndValidateCreateParents(input);
+    if (!parentValidation.ok) {
+      return parentValidation.response;
     }
 
     const createdDog = await runAdminDogWriteTransactionDb(
       async (tx) =>
         createAdminDogWriteDb(
           {
-            name,
-            sex,
-            birthDate,
-            breederNameText: normalizeOptionalText(input.breederNameText),
-            sireId: sire?.id ?? null,
-            damId: dam?.id ?? null,
-            ownerNames: normalizeDistinctNames(input.ownerNames),
-            ekNo,
-            note,
-            registrationNo: normalizedPrimaryRegistrationNo,
-            secondaryRegistrationNos,
-            titles: parsedTitles.titles,
+            name: preflight.data.name,
+            sex: preflight.data.sex,
+            birthDate: preflight.data.birthDate,
+            breederNameText: inTryValidation.data.breederNameText,
+            sireId: parentValidation.data.sire?.id ?? null,
+            damId: parentValidation.data.dam?.id ?? null,
+            ownerNames: inTryValidation.data.ownerNames,
+            ekNo: preflight.data.ekNo,
+            note: inTryValidation.data.note,
+            registrationNo: preflight.data.primaryRegistrationNo,
+            secondaryRegistrationNos: preflight.data.secondaryRegistrationNos,
+            titles: inTryValidation.data.parsedTitles.titles,
           },
           tx,
         ),
@@ -368,33 +115,14 @@ export async function createAdminDog(
       "admin dog create succeeded",
     );
 
-    return {
-      status: 201,
-      body: {
-        ok: true,
-        data: {
-          id: createdDog.id,
-          name: createdDog.name,
-          sex: createdDog.sex,
-          registrationNo: createdDog.registrationNo,
-        },
-      },
-    };
+    return createSuccessResponse(createdDog);
   } catch (error) {
     if (isPrismaUniqueConstraintError(error)) {
       log.warn(
         { event: "duplicate_dog", durationMs: Date.now() - startedAt },
         "admin dog create rejected because duplicate dog exists",
       );
-      return {
-        status: 409,
-        body: {
-          ok: false,
-          error:
-            "Dog with same EK number or registration number already exists.",
-          code: "DUPLICATE_DOG",
-        },
-      };
+      return duplicateDogResponse();
     }
 
     log.error(
@@ -406,13 +134,6 @@ export async function createAdminDog(
       "admin dog create failed",
     );
 
-    return {
-      status: 500,
-      body: {
-        ok: false,
-        error: "Failed to create dog.",
-        code: "INTERNAL_ERROR",
-      },
-    };
+    return createInternalErrorResponse();
   }
 }

--- a/packages/server/admin/dogs/manage/delete-dog.ts
+++ b/packages/server/admin/dogs/manage/delete-dog.ts
@@ -7,9 +7,9 @@ import type {
   DeleteAdminDogRequest,
   DeleteAdminDogResponse,
 } from "@beagle/contracts";
-import { toErrorLog, withLogContext } from "../../../core/logger";
-import type { ServiceResult } from "../../../core/result";
-import { parseDogId } from "../../../dogs/core";
+import { toErrorLog, withLogContext } from "@server/core/logger";
+import type { ServiceResult } from "@server/core/result";
+import { parseDogId } from "@server/dogs/core";
 
 export async function deleteAdminDog(
   input: DeleteAdminDogRequest,

--- a/packages/server/admin/dogs/manage/internal/create-input-validation.ts
+++ b/packages/server/admin/dogs/manage/internal/create-input-validation.ts
@@ -1,0 +1,223 @@
+import type {
+  CreateAdminDogRequest,
+  CreateAdminDogResponse,
+} from "@beagle/contracts";
+import type { ServiceResult } from "@server/core/result";
+import {
+  normalizeDistinctNames,
+  normalizeOptionalText,
+  normalizeRequiredText,
+  parseBirthDate,
+  parseDogSex,
+  parsePositiveInteger,
+} from "../normalization";
+import {
+  duplicateRegistrationNoResponse,
+  invalidBirthDateResponse,
+  invalidEkNoResponse,
+  invalidNameResponse,
+  invalidRegistrationNoFormatResponse,
+  invalidRegistrationNoResponse,
+  invalidSexResponse,
+  nameTooLongResponse,
+  noteTooLongResponse,
+  registrationNoTooLongResponse,
+} from "./manage-responses";
+import { validateRegistrationInput } from "./registration-validation";
+import {
+  validateDogTitles,
+  type DogTitleValidationResult,
+} from "./title-validation";
+
+type CreateValidationFailure = {
+  ok: false;
+  logContext: Record<string, unknown>;
+  logMessage: string;
+  response: ServiceResult<CreateAdminDogResponse>;
+};
+
+type CreateValidationSuccess<T> = {
+  ok: true;
+  data: T;
+};
+
+export type CreatePreflightValidationResult =
+  | CreateValidationSuccess<{
+      name: string;
+      sex: "MALE" | "FEMALE" | "UNKNOWN";
+      birthDate: Date | null;
+      ekNo: number | null;
+      primaryRegistrationNo: string;
+      secondaryRegistrationNos: string[];
+      allRegistrationNos: string[];
+    }>
+  | CreateValidationFailure;
+
+export type CreateInTryValidationResult =
+  | CreateValidationSuccess<{
+      note: string | null;
+      breederNameText: string | null;
+      ownerNames: string[];
+      parsedTitles: Extract<DogTitleValidationResult, { ok: true }>;
+    }>
+  | CreateValidationFailure;
+
+export function validateCreatePreflight(
+  input: CreateAdminDogRequest,
+  maxNameLength: number,
+  maxRegistrationNoLength: number,
+): CreatePreflightValidationResult {
+  const name = normalizeRequiredText(input.name);
+  if (!name) {
+    return {
+      ok: false,
+      logContext: { event: "invalid_name" },
+      logMessage: "admin dog create rejected because name is invalid",
+      response: invalidNameResponse(),
+    };
+  }
+
+  if (name.length > maxNameLength) {
+    return {
+      ok: false,
+      logContext: { event: "name_too_long" },
+      logMessage: "admin dog create rejected because name is too long",
+      response: nameTooLongResponse(maxNameLength),
+    };
+  }
+
+  const sex = parseDogSex(input.sex);
+  if (!sex) {
+    return {
+      ok: false,
+      logContext: { event: "invalid_sex", sex: input.sex },
+      logMessage: "admin dog create rejected because sex is invalid",
+      response: invalidSexResponse(),
+    };
+  }
+
+  const birthDate = parseBirthDate(input.birthDate);
+  if (birthDate === "INVALID") {
+    return {
+      ok: false,
+      logContext: { event: "invalid_birth_date", birthDate: input.birthDate },
+      logMessage: "admin dog create rejected because birth date is invalid",
+      response: invalidBirthDateResponse(),
+    };
+  }
+
+  const ekNo = parsePositiveInteger(input.ekNo);
+  if (ekNo === "INVALID") {
+    return {
+      ok: false,
+      logContext: { event: "invalid_ek_no", ekNo: input.ekNo },
+      logMessage: "admin dog create rejected because EK number is invalid",
+      response: invalidEkNoResponse(),
+    };
+  }
+
+  const registration = validateRegistrationInput(
+    input.registrationNo,
+    input.secondaryRegistrationNos,
+    maxRegistrationNoLength,
+  );
+  if (!registration.ok) {
+    if (registration.code === "INVALID_REGISTRATION_NO") {
+      return {
+        ok: false,
+        logContext: { event: "invalid_registration_no" },
+        logMessage:
+          "admin dog create rejected because registration number is invalid",
+        response: invalidRegistrationNoResponse(),
+      };
+    }
+
+    if (registration.code === "REGISTRATION_NO_TOO_LONG") {
+      return {
+        ok: false,
+        logContext: {
+          event: "registration_no_too_long",
+          registrationCount: registration.registrationCount,
+        },
+        logMessage:
+          "admin dog create rejected because registration number is too long",
+        response: registrationNoTooLongResponse(maxRegistrationNoLength),
+      };
+    }
+
+    if (registration.code === "INVALID_REGISTRATION_NO_FORMAT") {
+      return {
+        ok: false,
+        logContext: {
+          event: "invalid_registration_no_format",
+          registrationCount: registration.registrationCount,
+        },
+        logMessage:
+          "admin dog create rejected because registration number format is invalid",
+        response: invalidRegistrationNoFormatResponse(),
+      };
+    }
+
+    return {
+      ok: false,
+      logContext: {
+        event: "duplicate_registration_no_payload",
+        registrationCount: registration.registrationCount,
+      },
+      logMessage:
+        "admin dog create rejected because duplicate registration numbers were provided",
+      response: duplicateRegistrationNoResponse(),
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      name,
+      sex,
+      birthDate,
+      ekNo,
+      primaryRegistrationNo: registration.primaryRegistrationNo,
+      secondaryRegistrationNos: registration.secondaryRegistrationNos,
+      allRegistrationNos: registration.allRegistrationNos,
+    },
+  };
+}
+
+export function validateCreateInTry(
+  input: CreateAdminDogRequest,
+  maxNoteLength: number,
+): CreateInTryValidationResult {
+  const note = normalizeOptionalText(input.note);
+  if (note !== null && note.length > maxNoteLength) {
+    return {
+      ok: false,
+      logContext: { event: "note_too_long" },
+      logMessage: "admin dog create rejected because note is too long",
+      response: noteTooLongResponse(maxNoteLength),
+    };
+  }
+
+  const parsedTitles = validateDogTitles(input.titles);
+  if (!parsedTitles.ok) {
+    return {
+      ok: false,
+      logContext: {
+        event: "invalid_titles",
+        code: parsedTitles.response.body.code,
+      },
+      logMessage: "admin dog create rejected because title rows are invalid",
+      response: parsedTitles.response,
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      note,
+      breederNameText: normalizeOptionalText(input.breederNameText),
+      ownerNames: normalizeDistinctNames(input.ownerNames),
+      parsedTitles,
+    },
+  };
+}

--- a/packages/server/admin/dogs/manage/internal/create-parent-validation.ts
+++ b/packages/server/admin/dogs/manage/internal/create-parent-validation.ts
@@ -1,0 +1,88 @@
+import type { CreateAdminDogResponse } from "@beagle/contracts";
+import type { ServiceResult } from "@server/core/result";
+import { normalizeOptionalText } from "../normalization";
+import {
+  invalidDamRegistrationResponse,
+  invalidDamSexResponse,
+  invalidParentCombinationResponse,
+  invalidSireRegistrationResponse,
+  invalidSireSexResponse,
+} from "./manage-responses";
+import {
+  resolveParentByRegistration,
+  type ParentRef,
+} from "./parent-resolution";
+
+type CreateParentValidationFailure = {
+  ok: false;
+  response: ServiceResult<CreateAdminDogResponse>;
+};
+
+type CreateParentValidationSuccess = {
+  ok: true;
+  data: {
+    sire: ParentRef | null;
+    dam: ParentRef | null;
+  };
+};
+
+export type CreateParentValidationResult =
+  | CreateParentValidationSuccess
+  | CreateParentValidationFailure;
+
+export async function resolveAndValidateCreateParents(input: {
+  sireRegistrationNo?: string | null;
+  damRegistrationNo?: string | null;
+}): Promise<CreateParentValidationResult> {
+  const sireRegistrationNo = normalizeOptionalText(
+    input.sireRegistrationNo ?? undefined,
+  );
+  const damRegistrationNo = normalizeOptionalText(
+    input.damRegistrationNo ?? undefined,
+  );
+
+  const sire = await resolveParentByRegistration(sireRegistrationNo);
+  if (sireRegistrationNo && !sire) {
+    return {
+      ok: false,
+      response: invalidSireRegistrationResponse(),
+    };
+  }
+
+  const dam = await resolveParentByRegistration(damRegistrationNo);
+  if (damRegistrationNo && !dam) {
+    return {
+      ok: false,
+      response: invalidDamRegistrationResponse(),
+    };
+  }
+
+  if (sire && dam && sire.id === dam.id) {
+    return {
+      ok: false,
+      response: invalidParentCombinationResponse(),
+    };
+  }
+
+  if (sire && sire.sex !== "MALE") {
+    return {
+      ok: false,
+      response: invalidSireSexResponse(),
+    };
+  }
+
+  if (dam && dam.sex !== "FEMALE") {
+    return {
+      ok: false,
+      response: invalidDamSexResponse(),
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      sire,
+      dam,
+    },
+  };
+}

--- a/packages/server/admin/dogs/manage/internal/manage-responses.ts
+++ b/packages/server/admin/dogs/manage/internal/manage-responses.ts
@@ -1,0 +1,327 @@
+import type {
+  CreateAdminDogResponse,
+  UpdateAdminDogResponse,
+} from "@beagle/contracts";
+import type { ServiceResult } from "@server/core/result";
+
+type CreateResult = ServiceResult<CreateAdminDogResponse>;
+type UpdateResult = ServiceResult<UpdateAdminDogResponse>;
+type ManageErrorTarget = CreateAdminDogResponse | UpdateAdminDogResponse;
+
+type CreateDogSummary = {
+  id: string;
+  name: string;
+  sex: "MALE" | "FEMALE" | "UNKNOWN";
+  registrationNo: string;
+};
+
+type UpdateDogSummary = {
+  id: string;
+  name: string;
+  sex: "MALE" | "FEMALE" | "UNKNOWN";
+  registrationNo: string | null;
+};
+
+export function invalidDogIdResponse(): UpdateResult {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Dog id is required.",
+      code: "INVALID_DOG_ID",
+    },
+  };
+}
+
+export function invalidNameResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Name is required.",
+      code: "INVALID_NAME",
+    },
+  } as ServiceResult<T>;
+}
+
+export function nameTooLongResponse<T extends ManageErrorTarget>(
+  maxLength: number,
+): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: `Name cannot exceed ${maxLength} characters.`,
+      code: "NAME_TOO_LONG",
+    },
+  } as ServiceResult<T>;
+}
+
+export function invalidSexResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Invalid sex value.",
+      code: "INVALID_SEX",
+    },
+  } as ServiceResult<T>;
+}
+
+export function invalidBirthDateResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Birth date must use YYYY-MM-DD format.",
+      code: "INVALID_BIRTH_DATE",
+    },
+  } as ServiceResult<T>;
+}
+
+export function invalidEkNoResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "EK number must be a positive integer.",
+      code: "INVALID_EK_NO",
+    },
+  } as ServiceResult<T>;
+}
+
+export function invalidRegistrationNoResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Registration number is required.",
+      code: "INVALID_REGISTRATION_NO",
+    },
+  } as ServiceResult<T>;
+}
+
+export function registrationNoTooLongResponse<T extends ManageErrorTarget>(
+  maxLength: number,
+): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: `Registration number cannot exceed ${maxLength} characters.`,
+      code: "REGISTRATION_NO_TOO_LONG",
+    },
+  } as ServiceResult<T>;
+}
+
+export function invalidRegistrationNoFormatResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Registration number format is invalid.",
+      code: "INVALID_REGISTRATION_NO",
+    },
+  } as ServiceResult<T>;
+}
+
+export function duplicateRegistrationNoResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Registration numbers must be unique.",
+      code: "DUPLICATE_REGISTRATION_NO",
+    },
+  } as ServiceResult<T>;
+}
+
+export function noteTooLongResponse<T extends ManageErrorTarget>(
+  maxLength: number,
+): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: `Note cannot exceed ${maxLength} characters.`,
+      code: "NOTE_TOO_LONG",
+    },
+  } as ServiceResult<T>;
+}
+
+export function invalidSireRegistrationResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Sire registration number was not found.",
+      code: "INVALID_SIRE_REGISTRATION",
+    },
+  } as ServiceResult<T>;
+}
+
+export function invalidDamRegistrationResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Dam registration number was not found.",
+      code: "INVALID_DAM_REGISTRATION",
+    },
+  } as ServiceResult<T>;
+}
+
+export function invalidParentCombinationResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Sire and dam must be different dogs.",
+      code: "INVALID_PARENT_COMBINATION",
+    },
+  } as ServiceResult<T>;
+}
+
+export function invalidSelfParentResponse(): UpdateResult {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Dog cannot be its own sire.",
+      code: "INVALID_SELF_PARENT",
+    },
+  };
+}
+
+export function invalidSelfParentDamResponse(): UpdateResult {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Dog cannot be its own dam.",
+      code: "INVALID_SELF_PARENT",
+    },
+  };
+}
+
+export function invalidSireSexResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Selected sire must be a male dog.",
+      code: "INVALID_SIRE_SEX",
+    },
+  } as ServiceResult<T>;
+}
+
+export function invalidDamSexResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: "Selected dam must be a female dog.",
+      code: "INVALID_DAM_SEX",
+    },
+  } as ServiceResult<T>;
+}
+
+export function dogNotFoundResponse(): UpdateResult {
+  return {
+    status: 404,
+    body: {
+      ok: false,
+      error: "Dog not found.",
+      code: "DOG_NOT_FOUND",
+    },
+  };
+}
+
+export function duplicateDogResponse<
+  T extends ManageErrorTarget,
+>(): ServiceResult<T> {
+  return {
+    status: 409,
+    body: {
+      ok: false,
+      error: "Dog with same EK number or registration number already exists.",
+      code: "DUPLICATE_DOG",
+    },
+  } as ServiceResult<T>;
+}
+
+export function createInternalErrorResponse(): CreateResult {
+  return {
+    status: 500,
+    body: {
+      ok: false,
+      error: "Failed to create dog.",
+      code: "INTERNAL_ERROR",
+    },
+  };
+}
+
+export function updateInternalErrorResponse(): UpdateResult {
+  return {
+    status: 500,
+    body: {
+      ok: false,
+      error: "Failed to update dog.",
+      code: "INTERNAL_ERROR",
+    },
+  };
+}
+
+export function createSuccessResponse(dog: CreateDogSummary): CreateResult {
+  return {
+    status: 201,
+    body: {
+      ok: true,
+      data: {
+        id: dog.id,
+        name: dog.name,
+        sex: dog.sex,
+        registrationNo: dog.registrationNo,
+      },
+    },
+  };
+}
+
+export function updateSuccessResponse(dog: UpdateDogSummary): UpdateResult {
+  return {
+    status: 200,
+    body: {
+      ok: true,
+      data: {
+        id: dog.id,
+        name: dog.name,
+        sex: dog.sex,
+        registrationNo: dog.registrationNo,
+      },
+    },
+  };
+}

--- a/packages/server/admin/dogs/manage/internal/registration-validation.ts
+++ b/packages/server/admin/dogs/manage/internal/registration-validation.ts
@@ -1,0 +1,87 @@
+import {
+  hasMaxLength,
+  isValidRegistrationNo,
+  normalizeRegistrationNo,
+  normalizeRegistrationNos,
+  normalizeRequiredText,
+} from "../normalization";
+
+export type RegistrationValidationFailureCode =
+  | "INVALID_REGISTRATION_NO"
+  | "REGISTRATION_NO_TOO_LONG"
+  | "INVALID_REGISTRATION_NO_FORMAT"
+  | "DUPLICATE_REGISTRATION_NO";
+
+export type RegistrationValidationResult =
+  | {
+      ok: true;
+      primaryRegistrationNo: string;
+      secondaryRegistrationNos: string[];
+      allRegistrationNos: string[];
+    }
+  | {
+      ok: false;
+      code: RegistrationValidationFailureCode;
+      registrationCount?: number;
+    };
+
+export function validateRegistrationInput(
+  registrationNoInput: string,
+  secondaryRegistrationNosInput: string[] | undefined,
+  maxLength: number,
+): RegistrationValidationResult {
+  const registrationNo = normalizeRequiredText(registrationNoInput);
+  if (!registrationNo) {
+    return {
+      ok: false,
+      code: "INVALID_REGISTRATION_NO",
+    };
+  }
+
+  const primaryRegistrationNo = normalizeRegistrationNo(registrationNo);
+  if (!primaryRegistrationNo) {
+    return {
+      ok: false,
+      code: "INVALID_REGISTRATION_NO",
+    };
+  }
+
+  const secondaryRegistrationNos = normalizeRegistrationNos(
+    secondaryRegistrationNosInput,
+  );
+  const allRegistrationNos = [
+    primaryRegistrationNo,
+    ...secondaryRegistrationNos,
+  ];
+
+  if (allRegistrationNos.some((value) => !hasMaxLength(value, maxLength))) {
+    return {
+      ok: false,
+      code: "REGISTRATION_NO_TOO_LONG",
+      registrationCount: allRegistrationNos.length,
+    };
+  }
+
+  if (allRegistrationNos.some((value) => !isValidRegistrationNo(value))) {
+    return {
+      ok: false,
+      code: "INVALID_REGISTRATION_NO_FORMAT",
+      registrationCount: allRegistrationNos.length,
+    };
+  }
+
+  if (new Set(allRegistrationNos).size !== allRegistrationNos.length) {
+    return {
+      ok: false,
+      code: "DUPLICATE_REGISTRATION_NO",
+      registrationCount: allRegistrationNos.length,
+    };
+  }
+
+  return {
+    ok: true,
+    primaryRegistrationNo,
+    secondaryRegistrationNos,
+    allRegistrationNos,
+  };
+}

--- a/packages/server/admin/dogs/manage/internal/update-input-validation.ts
+++ b/packages/server/admin/dogs/manage/internal/update-input-validation.ts
@@ -1,0 +1,268 @@
+import type {
+  UpdateAdminDogRequest,
+  UpdateAdminDogResponse,
+} from "@beagle/contracts";
+import type { ServiceResult } from "@server/core/result";
+import { parseDogId } from "@server/dogs/core";
+import {
+  normalizeDistinctNames,
+  normalizeOptionalText,
+  normalizeRequiredText,
+  parseBirthDate,
+  parseDogSex,
+  parsePositiveInteger,
+} from "../normalization";
+import {
+  duplicateRegistrationNoResponse,
+  invalidBirthDateResponse,
+  invalidDogIdResponse,
+  invalidEkNoResponse,
+  invalidNameResponse,
+  invalidRegistrationNoFormatResponse,
+  invalidRegistrationNoResponse,
+  invalidSexResponse,
+  nameTooLongResponse,
+  noteTooLongResponse,
+  registrationNoTooLongResponse,
+} from "./manage-responses";
+import { validateRegistrationInput } from "./registration-validation";
+import {
+  validateDogTitles,
+  type DogTitleValidationResult,
+} from "./title-validation";
+
+type UpdateValidationFailure = {
+  ok: false;
+  logContext: Record<string, unknown>;
+  logMessage: string;
+  response: ServiceResult<UpdateAdminDogResponse>;
+};
+
+type UpdateValidationSuccess<T> = {
+  ok: true;
+  data: T;
+};
+
+export type UpdatePreflightValidationResult =
+  | UpdateValidationSuccess<{
+      id: string;
+      name: string;
+      sex: "MALE" | "FEMALE" | "UNKNOWN";
+      birthDate: Date | null | undefined;
+      ekNo: number | null | undefined;
+      primaryRegistrationNo: string;
+      secondaryRegistrationNos: string[];
+      allRegistrationNos: string[];
+    }>
+  | UpdateValidationFailure;
+
+export type UpdateInTryValidationResult =
+  | UpdateValidationSuccess<{
+      note: string | null | undefined;
+      breederNameText: string | null | undefined;
+      ownerNames: string[] | undefined;
+      parsedTitles: Extract<DogTitleValidationResult, { ok: true }> | undefined;
+      sireRegistrationNo: string | null | undefined;
+      damRegistrationNo: string | null | undefined;
+    }>
+  | UpdateValidationFailure;
+
+export function validateUpdatePreflight(
+  input: UpdateAdminDogRequest,
+  maxNameLength: number,
+  maxRegistrationNoLength: number,
+): UpdatePreflightValidationResult {
+  const id = parseDogId(input.id);
+  if (!id) {
+    return {
+      ok: false,
+      logContext: { event: "invalid_dog_id" },
+      logMessage: "admin dog update rejected because dog id is invalid",
+      response: invalidDogIdResponse(),
+    };
+  }
+
+  const name = normalizeRequiredText(input.name);
+  if (!name) {
+    return {
+      ok: false,
+      logContext: { event: "invalid_name", dogId: id },
+      logMessage: "admin dog update rejected because name is invalid",
+      response: invalidNameResponse(),
+    };
+  }
+
+  if (name.length > maxNameLength) {
+    return {
+      ok: false,
+      logContext: { event: "name_too_long", dogId: id },
+      logMessage: "admin dog update rejected because name is too long",
+      response: nameTooLongResponse(maxNameLength),
+    };
+  }
+
+  const registration = validateRegistrationInput(
+    input.registrationNo,
+    input.secondaryRegistrationNos,
+    maxRegistrationNoLength,
+  );
+  if (!registration.ok) {
+    if (registration.code === "INVALID_REGISTRATION_NO") {
+      return {
+        ok: false,
+        logContext: { event: "invalid_registration_no", dogId: id },
+        logMessage:
+          "admin dog update rejected because registration number is invalid",
+        response: invalidRegistrationNoResponse(),
+      };
+    }
+
+    if (registration.code === "REGISTRATION_NO_TOO_LONG") {
+      return {
+        ok: false,
+        logContext: {
+          event: "registration_no_too_long",
+          dogId: id,
+          registrationCount: registration.registrationCount,
+        },
+        logMessage:
+          "admin dog update rejected because registration number is too long",
+        response: registrationNoTooLongResponse(maxRegistrationNoLength),
+      };
+    }
+
+    if (registration.code === "INVALID_REGISTRATION_NO_FORMAT") {
+      return {
+        ok: false,
+        logContext: {
+          event: "invalid_registration_no_format",
+          dogId: id,
+          registrationCount: registration.registrationCount,
+        },
+        logMessage:
+          "admin dog update rejected because registration number format is invalid",
+        response: invalidRegistrationNoFormatResponse(),
+      };
+    }
+
+    return {
+      ok: false,
+      logContext: {
+        event: "duplicate_registration_no_payload",
+        dogId: id,
+        registrationCount: registration.registrationCount,
+      },
+      logMessage:
+        "admin dog update rejected because duplicate registration numbers were provided",
+      response: duplicateRegistrationNoResponse(),
+    };
+  }
+
+  const sex = parseDogSex(input.sex);
+  if (!sex) {
+    return {
+      ok: false,
+      logContext: { event: "invalid_sex", dogId: id, sex: input.sex },
+      logMessage: "admin dog update rejected because sex is invalid",
+      response: invalidSexResponse(),
+    };
+  }
+
+  const birthDate =
+    input.birthDate === undefined ? undefined : parseBirthDate(input.birthDate);
+  if (birthDate === "INVALID") {
+    return {
+      ok: false,
+      logContext: {
+        event: "invalid_birth_date",
+        dogId: id,
+        birthDate: input.birthDate,
+      },
+      logMessage: "admin dog update rejected because birth date is invalid",
+      response: invalidBirthDateResponse(),
+    };
+  }
+
+  const ekNo =
+    input.ekNo === undefined ? undefined : parsePositiveInteger(input.ekNo);
+  if (ekNo === "INVALID") {
+    return {
+      ok: false,
+      logContext: { event: "invalid_ek_no", dogId: id, ekNo: input.ekNo },
+      logMessage: "admin dog update rejected because EK number is invalid",
+      response: invalidEkNoResponse(),
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      id,
+      name,
+      sex,
+      birthDate,
+      ekNo,
+      primaryRegistrationNo: registration.primaryRegistrationNo,
+      secondaryRegistrationNos: registration.secondaryRegistrationNos,
+      allRegistrationNos: registration.allRegistrationNos,
+    },
+  };
+}
+
+export function validateUpdateInTry(
+  input: UpdateAdminDogRequest,
+  id: string,
+  maxNoteLength: number,
+): UpdateInTryValidationResult {
+  const note =
+    input.note === undefined
+      ? undefined
+      : normalizeOptionalText(input.note ?? undefined);
+  if (note !== undefined && note !== null && note.length > maxNoteLength) {
+    return {
+      ok: false,
+      logContext: { event: "note_too_long", dogId: id },
+      logMessage: "admin dog update rejected because note is too long",
+      response: noteTooLongResponse(maxNoteLength),
+    };
+  }
+
+  const parsedTitles =
+    input.titles === undefined ? undefined : validateDogTitles(input.titles);
+  if (parsedTitles !== undefined && !parsedTitles.ok) {
+    return {
+      ok: false,
+      logContext: {
+        event: "invalid_titles",
+        dogId: id,
+        code: parsedTitles.response.body.code,
+      },
+      logMessage: "admin dog update rejected because title rows are invalid",
+      response: parsedTitles.response,
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      note,
+      breederNameText:
+        input.breederNameText === undefined
+          ? undefined
+          : normalizeOptionalText(input.breederNameText ?? undefined),
+      ownerNames:
+        input.ownerNames === undefined
+          ? undefined
+          : normalizeDistinctNames(input.ownerNames),
+      parsedTitles,
+      sireRegistrationNo:
+        input.sireRegistrationNo === undefined
+          ? undefined
+          : normalizeOptionalText(input.sireRegistrationNo ?? undefined),
+      damRegistrationNo:
+        input.damRegistrationNo === undefined
+          ? undefined
+          : normalizeOptionalText(input.damRegistrationNo ?? undefined),
+    },
+  };
+}

--- a/packages/server/admin/dogs/manage/internal/update-parent-validation.ts
+++ b/packages/server/admin/dogs/manage/internal/update-parent-validation.ts
@@ -1,0 +1,136 @@
+import type { UpdateAdminDogResponse } from "@beagle/contracts";
+import type { ServiceResult } from "@server/core/result";
+import {
+  invalidDamRegistrationResponse,
+  invalidDamSexResponse,
+  invalidParentCombinationResponse,
+  invalidSelfParentDamResponse,
+  invalidSelfParentResponse,
+  invalidSireRegistrationResponse,
+  invalidSireSexResponse,
+} from "./manage-responses";
+import {
+  resolveParentByRegistration,
+  type ParentRef,
+} from "./parent-resolution";
+
+type UpdateParentValidationFailure = {
+  ok: false;
+  response: ServiceResult<UpdateAdminDogResponse>;
+};
+
+type UpdateParentValidationSuccess<T> = {
+  ok: true;
+  data: T;
+};
+
+type ExistingDogParentState = {
+  sire: ParentRef | null;
+  dam: ParentRef | null;
+};
+
+export type UpdateParentResolutionResult =
+  | UpdateParentValidationSuccess<{
+      sire: ParentRef | null | undefined;
+      dam: ParentRef | null | undefined;
+    }>
+  | UpdateParentValidationFailure;
+
+export type UpdateParentGuardResult =
+  | UpdateParentValidationSuccess<{
+      effectiveSire: ParentRef | null;
+      effectiveDam: ParentRef | null;
+    }>
+  | UpdateParentValidationFailure;
+
+export async function resolveUpdateParents(
+  sireRegistrationNo: string | null | undefined,
+  damRegistrationNo: string | null | undefined,
+): Promise<UpdateParentResolutionResult> {
+  let sire: ParentRef | null | undefined;
+  if (sireRegistrationNo !== undefined) {
+    sire = await resolveParentByRegistration(sireRegistrationNo);
+  }
+
+  if (sireRegistrationNo && !sire) {
+    return {
+      ok: false,
+      response: invalidSireRegistrationResponse(),
+    };
+  }
+
+  let dam: ParentRef | null | undefined;
+  if (damRegistrationNo !== undefined) {
+    dam = await resolveParentByRegistration(damRegistrationNo);
+  }
+
+  if (damRegistrationNo && !dam) {
+    return {
+      ok: false,
+      response: invalidDamRegistrationResponse(),
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      sire,
+      dam,
+    },
+  };
+}
+
+export function validateUpdateParentGuards(
+  dogId: string,
+  existingDog: ExistingDogParentState,
+  sire: ParentRef | null | undefined,
+  dam: ParentRef | null | undefined,
+): UpdateParentGuardResult {
+  const effectiveSire: ParentRef | null =
+    sire === undefined ? existingDog.sire : sire;
+  const effectiveDam: ParentRef | null =
+    dam === undefined ? existingDog.dam : dam;
+
+  if (effectiveSire && effectiveDam && effectiveSire.id === effectiveDam.id) {
+    return {
+      ok: false,
+      response: invalidParentCombinationResponse(),
+    };
+  }
+
+  if (effectiveSire && effectiveSire.id === dogId) {
+    return {
+      ok: false,
+      response: invalidSelfParentResponse(),
+    };
+  }
+
+  if (effectiveDam && effectiveDam.id === dogId) {
+    return {
+      ok: false,
+      response: invalidSelfParentDamResponse(),
+    };
+  }
+
+  if (effectiveSire && effectiveSire.sex !== "MALE") {
+    return {
+      ok: false,
+      response: invalidSireSexResponse(),
+    };
+  }
+
+  if (effectiveDam && effectiveDam.sex !== "FEMALE") {
+    return {
+      ok: false,
+      response: invalidDamSexResponse(),
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      effectiveSire,
+      effectiveDam,
+    },
+  };
+}

--- a/packages/server/admin/dogs/manage/list-dogs.ts
+++ b/packages/server/admin/dogs/manage/list-dogs.ts
@@ -4,10 +4,10 @@ import type {
   AdminDogListResponse,
   CurrentUserDto,
 } from "@beagle/contracts";
-import { toBusinessDateOnly } from "../../../core/date-only";
-import type { ServiceResult } from "../../../core/result";
-import { requireAdmin } from "../../core/service";
-import { toErrorLog, withLogContext } from "../../../core/logger";
+import { toBusinessDateOnly } from "@server/core/date-only";
+import { toErrorLog, withLogContext } from "@server/core/logger";
+import type { ServiceResult } from "@server/core/result";
+import { requireAdmin } from "@server/admin/core/service";
 import { normalizeQuery } from "./normalization";
 
 type ServiceLogContext = {

--- a/packages/server/admin/dogs/manage/update-dog.ts
+++ b/packages/server/admin/dogs/manage/update-dog.ts
@@ -8,27 +8,24 @@ import type {
   UpdateAdminDogRequest,
   UpdateAdminDogResponse,
 } from "@beagle/contracts";
-import { toErrorLog, withLogContext } from "../../../core/logger";
-import type { ServiceResult } from "../../../core/result";
-import { parseDogId } from "../../../dogs/core";
-import {
-  hasMaxLength,
-  isValidRegistrationNo,
-  normalizeDistinctNames,
-  normalizeOptionalText,
-  normalizeRegistrationNo,
-  normalizeRegistrationNos,
-  normalizeRequiredText,
-  parseBirthDate,
-  parseDogSex,
-  parsePositiveInteger,
-} from "./normalization";
-import {
-  resolveParentByRegistration,
-  type ParentRef,
-} from "./internal/parent-resolution";
+import { toErrorLog, withLogContext } from "@server/core/logger";
+import type { ServiceResult } from "@server/core/result";
+import { normalizeDistinctNames } from "./normalization";
 import { isPrismaUniqueConstraintError } from "./internal/prisma-errors";
-import { validateDogTitles } from "./internal/title-validation";
+import {
+  dogNotFoundResponse,
+  duplicateDogResponse,
+  updateInternalErrorResponse,
+  updateSuccessResponse,
+} from "./internal/manage-responses";
+import {
+  validateUpdateInTry,
+  validateUpdatePreflight,
+} from "./internal/update-input-validation";
+import {
+  resolveUpdateParents,
+  validateUpdateParentGuards,
+} from "./internal/update-parent-validation";
 
 const DOG_NAME_MAX_LENGTH = 120;
 const DOG_REGISTRATION_NO_MAX_LENGTH = 40;
@@ -64,404 +61,91 @@ export async function updateAdminDog(
     "admin dog update started",
   );
 
-  const id = parseDogId(input.id);
-  if (!id) {
-    log.warn(
-      { event: "invalid_dog_id", durationMs: Date.now() - startedAt },
-      "admin dog update rejected because dog id is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Dog id is required.",
-        code: "INVALID_DOG_ID",
-      },
-    };
-  }
-
-  const name = normalizeRequiredText(input.name);
-  if (!name) {
-    log.warn(
-      { event: "invalid_name", dogId: id, durationMs: Date.now() - startedAt },
-      "admin dog update rejected because name is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Name is required.",
-        code: "INVALID_NAME",
-      },
-    };
-  }
-  if (!hasMaxLength(name, DOG_NAME_MAX_LENGTH)) {
-    log.warn(
-      { event: "name_too_long", dogId: id, durationMs: Date.now() - startedAt },
-      "admin dog update rejected because name is too long",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: `Name cannot exceed ${DOG_NAME_MAX_LENGTH} characters.`,
-        code: "NAME_TOO_LONG",
-      },
-    };
-  }
-
-  const registrationNo = normalizeRequiredText(input.registrationNo);
-  if (!registrationNo) {
-    log.warn(
-      {
-        event: "invalid_registration_no",
-        dogId: id,
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog update rejected because registration number is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Registration number is required.",
-        code: "INVALID_REGISTRATION_NO",
-      },
-    };
-  }
-  const normalizedPrimaryRegistrationNo =
-    normalizeRegistrationNo(registrationNo);
-  if (!normalizedPrimaryRegistrationNo) {
-    log.warn(
-      {
-        event: "invalid_registration_no",
-        dogId: id,
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog update rejected because registration number is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Registration number is required.",
-        code: "INVALID_REGISTRATION_NO",
-      },
-    };
-  }
-  const secondaryRegistrationNos = normalizeRegistrationNos(
-    input.secondaryRegistrationNos,
+  const preflight = validateUpdatePreflight(
+    input,
+    DOG_NAME_MAX_LENGTH,
+    DOG_REGISTRATION_NO_MAX_LENGTH,
   );
-  const allRegistrationNos = [
-    normalizedPrimaryRegistrationNo,
-    ...secondaryRegistrationNos,
-  ];
-  if (
-    allRegistrationNos.some(
-      (value) => !hasMaxLength(value, DOG_REGISTRATION_NO_MAX_LENGTH),
-    )
-  ) {
+  if (!preflight.ok) {
     log.warn(
       {
-        event: "registration_no_too_long",
-        dogId: id,
-        registrationCount: allRegistrationNos.length,
+        ...preflight.logContext,
         durationMs: Date.now() - startedAt,
       },
-      "admin dog update rejected because registration number is too long",
+      preflight.logMessage,
     );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: `Registration number cannot exceed ${DOG_REGISTRATION_NO_MAX_LENGTH} characters.`,
-        code: "REGISTRATION_NO_TOO_LONG",
-      },
-    };
-  }
-  if (allRegistrationNos.some((value) => !isValidRegistrationNo(value))) {
-    log.warn(
-      {
-        event: "invalid_registration_no_format",
-        dogId: id,
-        registrationCount: allRegistrationNos.length,
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog update rejected because registration number format is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Registration number format is invalid.",
-        code: "INVALID_REGISTRATION_NO",
-      },
-    };
-  }
-  if (new Set(allRegistrationNos).size !== allRegistrationNos.length) {
-    log.warn(
-      {
-        event: "duplicate_registration_no_payload",
-        dogId: id,
-        registrationCount: allRegistrationNos.length,
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog update rejected because duplicate registration numbers were provided",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Registration numbers must be unique.",
-        code: "DUPLICATE_REGISTRATION_NO",
-      },
-    };
-  }
-
-  const sex = parseDogSex(input.sex);
-  if (!sex) {
-    log.warn(
-      {
-        event: "invalid_sex",
-        dogId: id,
-        sex: input.sex,
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog update rejected because sex is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Invalid sex value.",
-        code: "INVALID_SEX",
-      },
-    };
-  }
-
-  const birthDate =
-    input.birthDate === undefined ? undefined : parseBirthDate(input.birthDate);
-  if (birthDate === "INVALID") {
-    log.warn(
-      {
-        event: "invalid_birth_date",
-        dogId: id,
-        birthDate: input.birthDate,
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog update rejected because birth date is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "Birth date must use YYYY-MM-DD format.",
-        code: "INVALID_BIRTH_DATE",
-      },
-    };
-  }
-
-  const ekNo =
-    input.ekNo === undefined ? undefined : parsePositiveInteger(input.ekNo);
-  if (ekNo === "INVALID") {
-    log.warn(
-      {
-        event: "invalid_ek_no",
-        dogId: id,
-        ekNo: input.ekNo,
-        durationMs: Date.now() - startedAt,
-      },
-      "admin dog update rejected because EK number is invalid",
-    );
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        error: "EK number must be a positive integer.",
-        code: "INVALID_EK_NO",
-      },
-    };
+    return preflight.response;
   }
 
   try {
-    const note =
-      input.note === undefined
-        ? undefined
-        : normalizeOptionalText(input.note ?? undefined);
-    if (note !== undefined && !hasMaxLength(note, DOG_NOTE_MAX_LENGTH)) {
+    const inTryValidation = validateUpdateInTry(
+      input,
+      preflight.data.id,
+      DOG_NOTE_MAX_LENGTH,
+    );
+    if (!inTryValidation.ok) {
       log.warn(
         {
-          event: "note_too_long",
-          dogId: id,
+          ...inTryValidation.logContext,
           durationMs: Date.now() - startedAt,
         },
-        "admin dog update rejected because note is too long",
+        inTryValidation.logMessage,
       );
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: `Note cannot exceed ${DOG_NOTE_MAX_LENGTH} characters.`,
-          code: "NOTE_TOO_LONG",
-        },
-      };
+      return inTryValidation.response;
     }
 
-    const breederNameText =
-      input.breederNameText === undefined
-        ? undefined
-        : normalizeOptionalText(input.breederNameText ?? undefined);
-
-    const parsedTitles =
-      input.titles === undefined ? undefined : validateDogTitles(input.titles);
-    if (parsedTitles !== undefined && !parsedTitles.ok) {
-      log.warn(
-        {
-          event: "invalid_titles",
-          dogId: id,
-          code: parsedTitles.response.body.code,
-          durationMs: Date.now() - startedAt,
-        },
-        "admin dog update rejected because title rows are invalid",
-      );
-      return parsedTitles.response;
+    const resolvedParents = await resolveUpdateParents(
+      inTryValidation.data.sireRegistrationNo,
+      inTryValidation.data.damRegistrationNo,
+    );
+    if (!resolvedParents.ok) {
+      return resolvedParents.response;
     }
 
-    const sireRegistrationNo =
-      input.sireRegistrationNo === undefined
-        ? undefined
-        : normalizeOptionalText(input.sireRegistrationNo ?? undefined);
-    const damRegistrationNo =
-      input.damRegistrationNo === undefined
-        ? undefined
-        : normalizeOptionalText(input.damRegistrationNo ?? undefined);
-
-    let sire: ParentRef | null | undefined;
-    if (sireRegistrationNo !== undefined) {
-      sire = await resolveParentByRegistration(sireRegistrationNo);
-    }
-    if (sireRegistrationNo && !sire) {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Sire registration number was not found.",
-          code: "INVALID_SIRE_REGISTRATION",
-        },
-      };
-    }
-
-    let dam: ParentRef | null | undefined;
-    if (damRegistrationNo !== undefined) {
-      dam = await resolveParentByRegistration(damRegistrationNo);
-    }
-    if (damRegistrationNo && !dam) {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Dam registration number was not found.",
-          code: "INVALID_DAM_REGISTRATION",
-        },
-      };
-    }
-
-    const existingDog = await findDogByIdDb(id);
+    const existingDog = await findDogByIdDb(preflight.data.id);
     if (!existingDog) {
-      return {
-        status: 404,
-        body: {
-          ok: false,
-          error: "Dog not found.",
-          code: "DOG_NOT_FOUND",
-        },
-      };
+      return dogNotFoundResponse();
     }
 
-    const effectiveSire: ParentRef | null =
-      sire === undefined ? existingDog.sire : sire;
-    const effectiveDam: ParentRef | null =
-      dam === undefined ? existingDog.dam : dam;
-
-    if (effectiveSire && effectiveDam && effectiveSire.id === effectiveDam.id) {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Sire and dam must be different dogs.",
-          code: "INVALID_PARENT_COMBINATION",
-        },
-      };
-    }
-
-    if (effectiveSire && effectiveSire.id === id) {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Dog cannot be its own sire.",
-          code: "INVALID_SELF_PARENT",
-        },
-      };
-    }
-
-    if (effectiveDam && effectiveDam.id === id) {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Dog cannot be its own dam.",
-          code: "INVALID_SELF_PARENT",
-        },
-      };
-    }
-
-    if (effectiveSire && effectiveSire.sex !== "MALE") {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Selected sire must be a male dog.",
-          code: "INVALID_SIRE_SEX",
-        },
-      };
-    }
-
-    if (effectiveDam && effectiveDam.sex !== "FEMALE") {
-      return {
-        status: 400,
-        body: {
-          ok: false,
-          error: "Selected dam must be a female dog.",
-          code: "INVALID_DAM_SEX",
-        },
-      };
+    const parentGuardResult = validateUpdateParentGuards(
+      preflight.data.id,
+      existingDog,
+      resolvedParents.data.sire,
+      resolvedParents.data.dam,
+    );
+    if (!parentGuardResult.ok) {
+      return parentGuardResult.response;
     }
 
     const updatedDog = await runAdminDogWriteTransactionDb(
       async (tx) =>
         updateAdminDogWriteDb(
           {
-            id,
-            name,
-            sex,
-            birthDate,
-            breederNameText,
-            sireId: sire === undefined ? undefined : (sire?.id ?? null),
-            damId: dam === undefined ? undefined : (dam?.id ?? null),
-            ownerNames:
-              input.ownerNames === undefined
+            id: preflight.data.id,
+            name: preflight.data.name,
+            sex: preflight.data.sex,
+            birthDate: preflight.data.birthDate,
+            breederNameText: inTryValidation.data.breederNameText,
+            sireId:
+              resolvedParents.data.sire === undefined
                 ? undefined
-                : normalizeDistinctNames(input.ownerNames),
-            ekNo,
-            note,
-            registrationNo: normalizedPrimaryRegistrationNo,
+                : (resolvedParents.data.sire?.id ?? null),
+            damId:
+              resolvedParents.data.dam === undefined
+                ? undefined
+                : (resolvedParents.data.dam?.id ?? null),
+            ownerNames: inTryValidation.data.ownerNames,
+            ekNo: preflight.data.ekNo,
+            note: inTryValidation.data.note,
+            registrationNo: preflight.data.primaryRegistrationNo,
             secondaryRegistrationNos:
               input.secondaryRegistrationNos === undefined
                 ? undefined
-                : secondaryRegistrationNos,
+                : preflight.data.secondaryRegistrationNos,
             titles:
-              parsedTitles === undefined ? undefined : parsedTitles.titles,
+              inTryValidation.data.parsedTitles === undefined
+                ? undefined
+                : inTryValidation.data.parsedTitles.titles,
           },
           tx,
         ),
@@ -477,75 +161,42 @@ export async function updateAdminDog(
       "admin dog update succeeded",
     );
 
-    return {
-      status: 200,
-      body: {
-        ok: true,
-        data: {
-          id: updatedDog.id,
-          name: updatedDog.name,
-          sex: updatedDog.sex,
-          registrationNo: updatedDog.registrationNo,
-        },
-      },
-    };
+    return updateSuccessResponse(updatedDog);
   } catch (error) {
     if (isDogNotFoundError(error)) {
       log.warn(
         {
           event: "dog_not_found",
-          dogId: id,
+          dogId: preflight.data.id,
           durationMs: Date.now() - startedAt,
         },
         "admin dog update failed because dog was not found",
       );
-      return {
-        status: 404,
-        body: {
-          ok: false,
-          error: "Dog not found.",
-          code: "DOG_NOT_FOUND",
-        },
-      };
+      return dogNotFoundResponse();
     }
 
     if (isPrismaUniqueConstraintError(error)) {
       log.warn(
         {
           event: "duplicate_dog",
-          dogId: id,
+          dogId: preflight.data.id,
           durationMs: Date.now() - startedAt,
         },
         "admin dog update rejected because duplicate dog exists",
       );
-      return {
-        status: 409,
-        body: {
-          ok: false,
-          error:
-            "Dog with same EK number or registration number already exists.",
-          code: "DUPLICATE_DOG",
-        },
-      };
+      return duplicateDogResponse();
     }
 
     log.error(
       {
         event: "exception",
-        dogId: id,
+        dogId: preflight.data.id,
         durationMs: Date.now() - startedAt,
         ...toErrorLog(error),
       },
       "admin dog update failed",
     );
 
-    return {
-      status: 500,
-      body: {
-        ok: false,
-        error: "Failed to update dog.",
-        code: "INTERNAL_ERROR",
-      },
-    };
+    return updateInternalErrorResponse();
   }
 }


### PR DESCRIPTION
## Summary

- Refactors admin dog manage server use-cases into orchestration-first entrypoints by extracting validation, parent guard, registration, and response logic into feature-local `internal/*` modules.
- Keeps public server exports and request/response contracts unchanged while reducing use-case file size and improving readability.
- Aligns touched admin dog `db` and `server` files with alias import rules (`@db/*`, `@server/*`) to remove lint warnings in the refactor scope.

## Changes

- Split `createAdminDog` and `updateAdminDog` non-entry logic into private helpers under `packages/server/admin/dogs/manage/internal/*`.
- Kept `packages/server/admin/dogs/manage/normalization.ts` stable for existing cross-feature usage.
- Updated admin dog lookups/manage imports in `packages/db` and `packages/server` from deep relative paths to configured aliases.

## Files

- `packages/db/admin/dogs/lookups/list-breeder-options.ts`
- `packages/db/admin/dogs/lookups/list-owner-options.ts`
- `packages/db/admin/dogs/lookups/list-parent-options.ts`
- `packages/db/admin/dogs/manage/create-dog.ts`
- `packages/db/admin/dogs/manage/find-dog-by-id.ts`
- `packages/db/admin/dogs/manage/find-dog-by-registration.ts`
- `packages/db/admin/dogs/manage/list-dogs.ts`
- `packages/server/admin/dogs/lookups/list-breeder-options.ts`
- `packages/server/admin/dogs/lookups/list-owner-options.ts`
- `packages/server/admin/dogs/lookups/list-parent-options.ts`
- `packages/server/admin/dogs/manage/create-dog.ts`
- `packages/server/admin/dogs/manage/delete-dog.ts`
- `packages/server/admin/dogs/manage/internal/create-input-validation.ts`
- `packages/server/admin/dogs/manage/internal/create-parent-validation.ts`
- `packages/server/admin/dogs/manage/internal/manage-responses.ts`
- `packages/server/admin/dogs/manage/internal/registration-validation.ts`
- `packages/server/admin/dogs/manage/internal/update-input-validation.ts`
- `packages/server/admin/dogs/manage/internal/update-parent-validation.ts`
- `packages/server/admin/dogs/manage/list-dogs.ts`
- `packages/server/admin/dogs/manage/update-dog.ts`

## Testing

- `pnpm --filter @beagle/server test -- packages/server/admin/dogs/manage/__tests__/create-dog.test.ts`
- `pnpm --filter @beagle/server test -- packages/server/admin/dogs/manage/__tests__/update-dog.test.ts`
- `pnpm --filter @beagle/server test -- packages/server/admin/dogs/manage/__tests__/list-dogs.test.ts packages/server/admin/dogs/manage/__tests__/delete-dog.test.ts`
- `pnpm --filter @beagle/server typecheck`
- `pnpm --filter @beagle/db exec eslint admin/dogs/lookups admin/dogs/manage`
- `pnpm --filter @beagle/server exec eslint admin/dogs/lookups admin/dogs/manage`

## Checklist

- [ ] This PR includes user-visible changes.
- [ ] If user-visible, I updated `CHANGELOG.md` under a versioned block (e.g., `## [x.y.z] - YYYY-MM-DD`).
- [x] If changelog update is not needed, this PR is internal-only (`refactor` / `test` / `chore`) and I explained why in the PR description.

Ref BEJ-72
