### PR TITLE
feat(db): add legacy import phase1.5 for dog titles (BEJ-67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Beagle App v2
 
-Monorepo for a public Beagle database app with auth, admin-ready routing, and a single Next.js server runtime.
+Monorepo for a public Beagle database app supporting breeders, managed by Suomen Beaglejarjesto (Finska Beagleklubben).
+
+## Project snapshot
+
+Beagle App v2 is a production-style monorepo for a public Beagle database supporting breeders and managed by Suomen Beaglejarjesto (Finska Beagleklubben).
+
+- Next.js + React + TypeScript full-stack application
+- Monorepo architecture with separate web/server/db/contracts/api-client packages
+- PostgreSQL + Prisma for schema, migrations, and data access
+- Authentication and admin-ready routing for association-managed operations
+- Documented operational workflows for environment safety, imports, and deployment
 
 ## Quick links
 

--- a/docs/features/schema/schema.md
+++ b/docs/features/schema/schema.md
@@ -10,7 +10,7 @@ For show-domain deep details, see:
 
 - `Role`: `USER`, `ADMIN`
 - `DogSex`: `MALE`, `FEMALE`, `UNKNOWN`
-- `ImportKind`: `LEGACY_PHASE1`, `LEGACY_PHASE2`, `LEGACY_PHASE3`
+- `ImportKind`: `LEGACY_PHASE1`, `LEGACY_PHASE1_5`, `LEGACY_PHASE2`, `LEGACY_PHASE3`
 - `ImportStatus`: `PENDING`, `RUNNING`, `SUCCEEDED`, `FAILED`
 - `ImportIssueSeverity`: `INFO`, `WARNING`, `ERROR`
 - `ShowSourceTag`: source tagging for legacy/workbook/manual show data

--- a/docs/legacy-import/README.md
+++ b/docs/legacy-import/README.md
@@ -3,6 +3,7 @@
 Phase-specific documentation for legacy import runs:
 
 - [Phase 1](/Users/akikuivas/personal-projects/beagle/beagle-app-v2/docs/legacy-import/phase1.md)
+- [Phase 1.5](/Users/akikuivas/personal-projects/beagle/beagle-app-v2/docs/legacy-import/phase1.5.md)
 - [Phase 2](/Users/akikuivas/personal-projects/beagle/beagle-app-v2/docs/legacy-import/phase2.md)
 - [Phase 3](/Users/akikuivas/personal-projects/beagle/beagle-app-v2/docs/legacy-import/phase3.md)
 

--- a/docs/legacy-import/import-flow.md
+++ b/docs/legacy-import/import-flow.md
@@ -1,4 +1,4 @@
-# Legacy Import Flow (Phases 1-3)
+# Legacy Import Flow (Phases 1, 1.5, 2, 3)
 
 This document describes the current initial legacy-to-canonical migration flow after split-phase cutover.
 
@@ -10,21 +10,24 @@ This document describes the current initial legacy-to-canonical migration flow a
 Phase-specific docs:
 
 - `docs/legacy-import/phase1.md`
+- `docs/legacy-import/phase1.5.md`
 - `docs/legacy-import/phase2.md`
 - `docs/legacy-import/phase3.md`
 
 ## Commands
 
 - Phase 1 (foundation only): `pnpm import:phase1`
+- Phase 1.5 (dog titles): `pnpm import:phase1.5`
 - Phase 2 (trials): `pnpm import:phase2`
 - Phase 3 (shows): `pnpm import:phase3`
 - Show result definition seed (canonical awards, one-shot flow): `pnpm --filter @beagle/db seed:show-result-definitions`
 - Show workbook import schema seed (Kennelliitto workbook metadata, one-shot flow): `pnpm --filter @beagle/db seed:show-workbook-import-schema`
-- Optional full bootstrap (`auth:bootstrap-admin` -> `seed:show-result-definitions` -> `seed:show-workbook-import-schema` -> `phase1` -> `phase2` -> `phase3`): `pnpm import:bootstrap`
+- Optional full bootstrap (`auth:bootstrap-admin` -> `seed:show-result-definitions` -> `seed:show-workbook-import-schema` -> `phase1` -> `phase1.5` -> `phase2` -> `phase3`): `pnpm import:bootstrap`
 
 Optional actor id for phase commands:
 
 - `pnpm import:phase1 <USER_ID>`
+- `pnpm import:phase1.5 <USER_ID>`
 - `pnpm import:phase2 <USER_ID>`
 - `pnpm import:phase3 <USER_ID>`
 
@@ -72,18 +75,22 @@ Issue tooling:
 - relations (sire/dam links)
 - owners and ownerships
 
-2. `phase2` imports trial rows using current trial schema.
+2. `phase1.5` imports dog title rows (`DogTitle`) from `bea_apu.VALIO`,
+   grouped by dog via canonical registration resolution.
+   Same-value aliases are deduplicated; conflicting alias values create import issues.
 
-3. `phase3` imports show rows into canonical show tables (`ShowEvent`, `ShowEntry`,
+3. `phase2` imports trial rows using current trial schema.
+
+4. `phase3` imports show rows into canonical show tables (`ShowEvent`, `ShowEntry`,
    `ShowResultItem`) using merged legacy sources (`nay9599`, `beanay`, optional
    `nay9599_rd_ud`) plus `beanay_text` critique join.
    The phase3 runtime path does not write legacy `ShowResult`.
 
-4. `seed:show-result-definitions` bootstraps canonical `ShowResultDefinition` rows used by both
+5. `seed:show-result-definitions` bootstraps canonical `ShowResultDefinition` rows used by both
    legacy and Kennelliitto workbook mappings (for example `ROP`, `VSP`, `SERT`, `varaSERT`,
    `CACIB`, `varaCACIB`, `PUPN`, `SIJOITUS`, `JUN-ROP`, `JUN-VSP`, `VET-ROP`, `VET-VSP`, `SA`, `KP`).
 
-5. `seed:show-workbook-import-schema` bootstraps `ShowWorkbookColumnRule` metadata used by the
+6. `seed:show-workbook-import-schema` bootstraps `ShowWorkbookColumnRule` metadata used by the
    Kennelliitto workbook validator to resolve headers into imported, ignored, or blocked columns.
    This seed is the bootstrap baseline only; future admin-managed workbook
    schema edits should update the metadata directly instead of reseeding.
@@ -91,7 +98,7 @@ Issue tooling:
 Lifecycle note:
 
 - The entire legacy import flow is one-shot: `seed:show-result-definitions`,
-  `seed:show-workbook-import-schema`, `phase1`, `phase2`, `phase3`, and
+  `seed:show-workbook-import-schema`, `phase1`, `phase1.5`, `phase2`, `phase3`, and
   `import:bootstrap` all belong to the same initial canonical
   bootstrap/migration.
 - None of these commands are documented as upgrade, replay, or reconciliation steps for an
@@ -117,14 +124,16 @@ Bootstrap invariants:
 2. `seed:show-result-definitions`
 3. `seed:show-workbook-import-schema`
 4. `phase1`
-5. `phase2`
-6. `phase3`
+5. `phase1.5`
+6. `phase2`
+7. `phase3`
 
 ## ImportRun and issues model
 
 Each phase creates its own `ImportRun` with its own `runId`.
 
 - `phase1` -> `kind=LEGACY_PHASE1`
+- `phase1.5` -> `kind=LEGACY_PHASE1_5`
 - `phase2` -> `kind=LEGACY_PHASE2`
 - `phase3` -> `kind=LEGACY_PHASE3`
 
@@ -141,13 +150,14 @@ CSV export is per run id. Export separate CSV sets for each phase run id.
 Issue code details are maintained in phase docs:
 
 - `docs/legacy-import/phase1.md`
+- `docs/legacy-import/phase1.5.md`
 - `docs/legacy-import/phase2.md`
 - `docs/legacy-import/phase3.md`
 
 ## Execution model
 
 This import flow is intended for initial migration, run in order
-(`seed:show-result-definitions` -> `seed:show-workbook-import-schema` -> `phase1` -> `phase2` -> `phase3`).
+(`seed:show-result-definitions` -> `seed:show-workbook-import-schema` -> `phase1` -> `phase1.5` -> `phase2` -> `phase3`).
 Treat it as a one-time bootstrap/migration flow, not as an ongoing sync,
 replay, or upgrade pipeline.
 

--- a/docs/legacy-import/phase1.5.md
+++ b/docs/legacy-import/phase1.5.md
@@ -1,0 +1,79 @@
+# Legacy Import Phase 1.5
+
+## Purpose
+
+This is the detailed implementation reference for phase1.5.
+For overall flow and ordering, see `docs/legacy-import/import-flow.md`.
+
+Phase 1.5 imports legacy dog title rows from `bea_apu.VALIO` into `DogTitle`.
+
+## Command
+
+`pnpm import:phase1.5 [USER_ID]`
+
+## Primary source table
+
+- `bea_apu`
+
+## Source row mapping (high level)
+
+- `REKNO` -> registration key used to resolve dog via `DogRegistration`
+- `VALIO` -> `DogTitle.titleCode` (raw value; no title-definition mapping)
+
+Written title fields:
+
+- `titleCode`: legacy `VALIO` value (trimmed)
+- `titleName`: `null`
+- `awardedOn`: `null`
+- `sortOrder`: `0`
+
+## Main writes
+
+- `DogTitle`
+
+One raw title row is imported per dog for this phase.
+
+## Deduplication and conflict rules
+
+- Blank `VALIO` values are skipped.
+- Rows are grouped by resolved dog.
+- Value comparison for dedupe/conflict uses normalized `VALIO`:
+  - trim
+  - collapse repeated whitespace to a single space
+  - uppercase
+- If all non-empty normalized values for a dog are equal, rows deduplicate to one imported title row.
+- If two or more distinct normalized values exist for the same dog, phase1.5 records `TITLE_ALIAS_VALUE_CONFLICT`.
+
+Conflict winner selection:
+
+- Prefer a value from source rows whose `REKNO` matches the dog's canonical registration
+  (the oldest registration row for that dog).
+- If no source row uses the canonical registration, choose deterministic fallback:
+  lexicographically smallest normalized value.
+- Phase still imports one row for that dog and records the conflict issue.
+
+## Issue codes
+
+- `TITLE_REGISTRATION_MISSING`
+- `TITLE_REGISTRATION_INVALID_FORMAT`
+- `TITLE_DOG_NOT_FOUND`
+- `TITLE_ALIAS_VALUE_CONFLICT`
+- run-level fallback: `UNEXPECTED_EXCEPTION`
+
+Issue rows are written to `ImportRunIssue` with `kind=LEGACY_PHASE1_5`.
+
+## Error handling detail
+
+- Row-level validation/linking issues are recorded and import continues.
+- Run finishes `SUCCEEDED` with warnings when issues exist.
+- Unexpected exceptions mark run as `FAILED` with `UNEXPECTED_EXCEPTION`.
+
+## Implementation references
+
+- Phase use-case: `packages/server/imports/phase1_5/run-legacy-phase1_5.ts`
+- Source loader: `packages/db/imports/phase1_5/source.ts`
+
+## Operational notes
+
+- Phase 1.5 should run after phase1 and before phase2.
+- Phase 1.5 belongs to the same one-shot bootstrap/migration flow as phase1/2/3.

--- a/docs/legacy-import/phase1.md
+++ b/docs/legacy-import/phase1.md
@@ -89,5 +89,5 @@ Issue rows are written to `ImportRunIssue` with `kind=LEGACY_PHASE1`.
 
 ## Operational notes
 
-- Phase 1 should be run before phase2 and phase3.
+- Phase 1 should be run before phase1.5, phase2, and phase3.
 - Phase 1 belongs to the initial migration flow and is included in `import:bootstrap`.

--- a/docs/legacy-import/phase3.md
+++ b/docs/legacy-import/phase3.md
@@ -64,7 +64,7 @@ Run seed first:
 - `pnpm --filter @beagle/db seed:show-result-definitions`
 - `pnpm --filter @beagle/db seed:show-workbook-import-schema`
 
-The seed step above is part of the same one-shot legacy import flow as phase1-3.
+The seed step above is part of the same one-shot legacy import flow as phase1, phase1.5, phase2, and phase3.
 This flow is documented as initial bootstrap/migration only, not as replay or
 upgrade of an already bootstrapped environment.
 

--- a/docs/ops-env-safety.md
+++ b/docs/ops-env-safety.md
@@ -125,6 +125,14 @@ pass-cli run --env-file .env.staging -- pnpm import:phase1
 CONFIRM_PROD=YES pass-cli run --env-file .env.prod -- pnpm import:phase1
 ```
 
+Phase-1.5 import:
+
+```bash
+pass-cli run --env-file .env.local -- pnpm import:phase1.5
+pass-cli run --env-file .env.staging -- pnpm import:phase1.5
+CONFIRM_PROD=YES pass-cli run --env-file .env.prod -- pnpm import:phase1.5
+```
+
 Legacy dump restore into MariaDB:
 
 ```bash
@@ -177,7 +185,7 @@ This seed is the bootstrap baseline for `ShowWorkbookColumnRule` /
 `ShowWorkbookColumnValueMap` metadata. It is not intended as the long-term
 editing path once admin-managed workbook schema settings exist.
 
-Bootstrap import (`auth:bootstrap-admin` -> `seed:show-result-definitions` -> `seed:show-workbook-import-schema` -> `phase1` -> `phase2` -> `phase3`):
+Bootstrap import (`auth:bootstrap-admin` -> `seed:show-result-definitions` -> `seed:show-workbook-import-schema` -> `phase1` -> `phase1.5` -> `phase2` -> `phase3`):
 
 ```bash
 pass-cli run --env-file .env.local -- pnpm import:bootstrap

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "auth:set-password": "pnpm --filter @beagle/server exec tsx scripts/set-user-password.ts",
     "db:push": "pnpm --filter @beagle/db exec prisma db push",
     "import:phase1": "pnpm --filter @beagle/server import:phase1 --",
+    "import:phase1.5": "pnpm --filter @beagle/server import:phase1.5 --",
     "import:phase2": "pnpm --filter @beagle/server import:phase2 --",
     "import:phase3": "pnpm --filter @beagle/server import:phase3 --",
     "import:bootstrap": "pnpm --filter @beagle/server import:bootstrap --",

--- a/packages/db/imports/phase1_5/__tests__/source.test.ts
+++ b/packages/db/imports/phase1_5/__tests__/source.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchLegacyPhase1_5Rows } from "../source";
+
+const { connectLegacyDatabaseMock } = vi.hoisted(() => ({
+  connectLegacyDatabaseMock: vi.fn(),
+}));
+
+vi.mock("../../internal", () => ({
+  connectLegacyDatabase: connectLegacyDatabaseMock,
+}));
+
+describe("fetchLegacyPhase1_5Rows", () => {
+  beforeEach(() => {
+    connectLegacyDatabaseMock.mockReset();
+  });
+
+  it("loads REKNO + VALIO rows from bea_apu", async () => {
+    const connection = {
+      query: vi.fn().mockResolvedValue([
+        { registrationNo: "FI-1/20", titleCodeRaw: "FI JVA" },
+        { registrationNo: "FI-2/20", titleCodeRaw: null },
+      ]),
+      end: vi.fn().mockResolvedValue(undefined),
+    };
+    connectLegacyDatabaseMock.mockResolvedValue(connection);
+
+    const result = await fetchLegacyPhase1_5Rows();
+
+    expect(connection.query).toHaveBeenCalledWith(
+      expect.stringContaining("FROM bea_apu"),
+    );
+    expect(result).toEqual([
+      { registrationNo: "FI-1/20", titleCodeRaw: "FI JVA" },
+      { registrationNo: "FI-2/20", titleCodeRaw: null },
+    ]);
+    expect(connection.end).toHaveBeenCalled();
+  });
+});

--- a/packages/db/imports/phase1_5/index.ts
+++ b/packages/db/imports/phase1_5/index.ts
@@ -1,0 +1,1 @@
+export { fetchLegacyPhase1_5Rows } from "./source";

--- a/packages/db/imports/phase1_5/source.ts
+++ b/packages/db/imports/phase1_5/source.ts
@@ -1,0 +1,35 @@
+import { connectLegacyDatabase } from "../internal";
+import type { LegacyDogTitleRow } from "../types";
+
+// Loads legacy dog title rows for phase1.5 import.
+export async function fetchLegacyPhase1_5Rows(options?: {
+  log?: (message: string) => void;
+}): Promise<LegacyDogTitleRow[]> {
+  const log = options?.log ?? (() => {});
+  const startedAt = Date.now();
+  log("Connecting to legacy database...");
+  const connection = await connectLegacyDatabase();
+  try {
+    log("Connected to legacy database");
+
+    const titleRowsStartedAt = Date.now();
+    const titleRows = (await connection.query(
+      `SELECT REKNO as registrationNo,
+              VALIO as titleCodeRaw
+       FROM bea_apu`,
+    )) as LegacyDogTitleRow[];
+    log(
+      `Fetched title rows: count=${titleRows.length}, elapsed=${Math.round((Date.now() - titleRowsStartedAt) / 1000)}s`,
+    );
+
+    log(
+      `Legacy title source fetch completed in ${Math.round((Date.now() - startedAt) / 1000)}s`,
+    );
+
+    return titleRows;
+  } finally {
+    log("Closing legacy database connection...");
+    await connection.end();
+    log("Legacy database connection closed");
+  }
+}

--- a/packages/db/imports/types.ts
+++ b/packages/db/imports/types.ts
@@ -22,6 +22,11 @@ export type LegacyEkRow = {
   ekNo: number | null;
 };
 
+export type LegacyDogTitleRow = {
+  registrationNo: string | null;
+  titleCodeRaw: string | null;
+};
+
 export type LegacyOwnerRow = {
   registrationNo: string;
   ownerName: string | null;

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -26,11 +26,13 @@ export {
 export { fetchLegacyTrialRows } from "./imports/phase2";
 export { fetchLegacyShowRows } from "./imports/phase3";
 export { fetchLegacyPhase1Rows } from "./imports/phase1";
+export { fetchLegacyPhase1_5Rows } from "./imports/phase1_5";
 
 export {
   type LegacyBreederRow,
   type LegacyDogRow,
   type LegacyEkRow,
+  type LegacyDogTitleRow,
   type LegacyOwnerRow,
   type LegacyTrialResultRow,
   type LegacyShowResultRow,

--- a/packages/server/imports/phase1_5/__tests__/run-legacy-phase1_5.test.ts
+++ b/packages/server/imports/phase1_5/__tests__/run-legacy-phase1_5.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runLegacyPhase1_5 } from "../run-legacy-phase1_5";
+
+const {
+  createImportRunMock,
+  markImportRunRunningMock,
+  markImportRunFinishedMock,
+  createImportRunIssueMock,
+  createImportRunIssuesBulkMock,
+  fetchLegacyPhase1_5RowsMock,
+  dogRegistrationFindManyMock,
+  dogTitleCreateManyMock,
+} = vi.hoisted(() => ({
+  createImportRunMock: vi.fn(),
+  markImportRunRunningMock: vi.fn(),
+  markImportRunFinishedMock: vi.fn(),
+  createImportRunIssueMock: vi.fn(),
+  createImportRunIssuesBulkMock: vi.fn(),
+  fetchLegacyPhase1_5RowsMock: vi.fn(),
+  dogRegistrationFindManyMock: vi.fn(),
+  dogTitleCreateManyMock: vi.fn(),
+}));
+
+vi.mock("@beagle/db", () => ({
+  ImportKind: {
+    LEGACY_PHASE1_5: "LEGACY_PHASE1_5",
+  },
+  createImportRun: createImportRunMock,
+  markImportRunRunning: markImportRunRunningMock,
+  markImportRunFinished: markImportRunFinishedMock,
+  createImportRunIssue: createImportRunIssueMock,
+  createImportRunIssuesBulk: createImportRunIssuesBulkMock,
+  fetchLegacyPhase1_5Rows: fetchLegacyPhase1_5RowsMock,
+  prisma: {
+    dogRegistration: { findMany: dogRegistrationFindManyMock },
+    dogTitle: { createMany: dogTitleCreateManyMock },
+  },
+}));
+
+describe("runLegacyPhase1_5", () => {
+  beforeEach(() => {
+    createImportRunMock.mockReset();
+    markImportRunRunningMock.mockReset();
+    markImportRunFinishedMock.mockReset();
+    createImportRunIssueMock.mockReset();
+    createImportRunIssuesBulkMock.mockReset();
+    fetchLegacyPhase1_5RowsMock.mockReset();
+    dogRegistrationFindManyMock.mockReset();
+    dogTitleCreateManyMock.mockReset();
+
+    createImportRunMock.mockResolvedValue({ id: "run-15" });
+    markImportRunRunningMock.mockResolvedValue(undefined);
+    markImportRunFinishedMock.mockResolvedValue({
+      id: "run-15",
+      kind: "LEGACY_PHASE1_5",
+      status: "SUCCEEDED",
+      dogsUpserted: 0,
+      ownersUpserted: 0,
+      ownershipsUpserted: 0,
+      trialResultsUpserted: 0,
+      showResultsUpserted: 0,
+      errorsCount: 0,
+      startedAt: new Date("2024-01-01T00:00:00.000Z"),
+      finishedAt: new Date("2024-01-01T00:00:01.000Z"),
+      errorSummary: null,
+      createdByUserId: "user-1",
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2024-01-01T00:00:01.000Z"),
+      issuesCount: 1,
+    });
+    dogTitleCreateManyMock.mockResolvedValue({ count: 0 });
+  });
+
+  it("imports titles, skips blanks, deduplicates same-value aliases, and records conflicts", async () => {
+    fetchLegacyPhase1_5RowsMock.mockResolvedValue([
+      { registrationNo: "FI-1/20", titleCodeRaw: "SE JCH" },
+      { registrationNo: "FI-1A/20", titleCodeRaw: "fi jch" },
+      { registrationNo: "FI-1B/20", titleCodeRaw: "FI JVA" },
+      { registrationNo: "FI-1/20", titleCodeRaw: "   " },
+      { registrationNo: null, titleCodeRaw: "FI JVA" },
+      { registrationNo: "BAD REG", titleCodeRaw: "FI JVA" },
+      { registrationNo: "FI-404/20", titleCodeRaw: "FI JVA" },
+    ]);
+    dogRegistrationFindManyMock.mockResolvedValue([
+      { registrationNo: "FI-1/20", dogId: "dog-1" },
+      { registrationNo: "FI-1A/20", dogId: "dog-1" },
+      { registrationNo: "FI-1B/20", dogId: "dog-1" },
+    ]);
+
+    const result = await runLegacyPhase1_5("user-1");
+
+    expect(result.status).toBe(202);
+    expect(dogTitleCreateManyMock).toHaveBeenCalledWith({
+      data: [
+        {
+          dogId: "dog-1",
+          titleCode: "SE JCH",
+          titleName: null,
+          awardedOn: null,
+          sortOrder: 0,
+        },
+      ],
+    });
+    expect(createImportRunIssuesBulkMock).toHaveBeenCalledWith(
+      "run-15",
+      expect.arrayContaining([
+        expect.objectContaining({ code: "TITLE_REGISTRATION_MISSING" }),
+        expect.objectContaining({ code: "TITLE_REGISTRATION_INVALID_FORMAT" }),
+        expect.objectContaining({ code: "TITLE_DOG_NOT_FOUND" }),
+        expect.objectContaining({ code: "TITLE_ALIAS_VALUE_CONFLICT" }),
+      ]),
+      expect.any(Object),
+    );
+    expect(markImportRunFinishedMock).toHaveBeenCalledWith(
+      "run-15",
+      expect.objectContaining({
+        status: "SUCCEEDED",
+        errorsCount: 4,
+        errorSummary: "Import completed with warnings.",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("uses deterministic fallback value when no canonical registration row exists in source rows", async () => {
+    fetchLegacyPhase1_5RowsMock.mockResolvedValue([
+      { registrationNo: "FI-ALIAS-1/20", titleCodeRaw: "SE JCH" },
+      { registrationNo: "FI-ALIAS-2/20", titleCodeRaw: "fi jva" },
+    ]);
+    dogRegistrationFindManyMock.mockResolvedValue([
+      { registrationNo: "FI-BASE/20", dogId: "dog-2" },
+      { registrationNo: "FI-ALIAS-1/20", dogId: "dog-2" },
+      { registrationNo: "FI-ALIAS-2/20", dogId: "dog-2" },
+    ]);
+
+    await runLegacyPhase1_5("user-1");
+
+    expect(dogTitleCreateManyMock).toHaveBeenCalledWith({
+      data: [
+        {
+          dogId: "dog-2",
+          titleCode: "fi jva",
+          titleName: null,
+          awardedOn: null,
+          sortOrder: 0,
+        },
+      ],
+    });
+    expect(createImportRunIssuesBulkMock).toHaveBeenCalledWith(
+      "run-15",
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "TITLE_ALIAS_VALUE_CONFLICT",
+        }),
+      ]),
+      expect.any(Object),
+    );
+  });
+});

--- a/packages/server/imports/phase1_5/index.ts
+++ b/packages/server/imports/phase1_5/index.ts
@@ -1,0 +1,1 @@
+export { runLegacyPhase1_5 } from "./run-legacy-phase1_5";

--- a/packages/server/imports/phase1_5/run-legacy-phase1_5.ts
+++ b/packages/server/imports/phase1_5/run-legacy-phase1_5.ts
@@ -1,0 +1,428 @@
+import {
+  type AuditContextDb,
+  type ImportIssueSeverity,
+  ImportKind,
+  createImportRun,
+  createImportRunIssue,
+  createImportRunIssuesBulk,
+  fetchLegacyPhase1_5Rows,
+  markImportRunFinished,
+  markImportRunRunning,
+  prisma,
+} from "@beagle/db";
+import type { ImportRunResponse } from "@beagle/contracts";
+import type { ServiceResult } from "../../core/result";
+import {
+  isValidRegistrationNo,
+  normalizeNullable,
+  normalizeRegistrationNo,
+} from "../core";
+import { toImportRunResponse } from "../runs/transform";
+
+type TitleCandidate = {
+  registrationNo: string;
+  rawTitleCode: string;
+  normalizedTitleCode: string;
+};
+
+function normalizeTitleCodeForComparison(value: string): string {
+  return value.replace(/\s+/g, " ").toUpperCase();
+}
+
+function sortUnique(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function pickTitleCode(
+  candidates: TitleCandidate[],
+  canonicalRegistrationNo: string | null,
+): string {
+  const canonicalCandidates =
+    canonicalRegistrationNo == null
+      ? []
+      : candidates.filter(
+          (candidate) => candidate.registrationNo === canonicalRegistrationNo,
+        );
+  const scoped =
+    canonicalCandidates.length > 0 ? canonicalCandidates : candidates;
+  const sorted = [...scoped].sort((left, right) => {
+    const rawCompare = left.rawTitleCode.localeCompare(right.rawTitleCode);
+    if (rawCompare !== 0) return rawCompare;
+    return left.registrationNo.localeCompare(right.registrationNo);
+  });
+  return sorted[0]?.rawTitleCode ?? candidates[0]?.rawTitleCode ?? "";
+}
+
+// Imports raw legacy title rows as one DogTitle per dog, with alias conflict issues.
+export async function runLegacyPhase1_5(
+  createdByUserId?: string,
+  options?: {
+    log?: (message: string) => void;
+    auditSource?: AuditContextDb["source"];
+  },
+): Promise<ServiceResult<ImportRunResponse>> {
+  const log = options?.log ?? (() => {});
+  const auditContext: AuditContextDb = {
+    actorUserId: createdByUserId ?? null,
+    source: options?.auditSource ?? "SYSTEM",
+  };
+  const stageStartedAt = new Map<string, number>();
+  const startStage = (name: string) => {
+    stageStartedAt.set(name, Date.now());
+    log(`[stage:${name}] start`);
+  };
+  const finishStage = (name: string, summary?: string) => {
+    const startedAt = stageStartedAt.get(name) ?? Date.now();
+    const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+    log(
+      `[stage:${name}] done in ${elapsedSeconds}s${summary ? ` ${summary}` : ""}`,
+    );
+  };
+  const logProgress = (name: string, processed: number, total: number) => {
+    const percent =
+      total > 0 ? Math.min(100, Math.round((processed / total) * 100)) : 100;
+    log(`[stage:${name}] progress ${processed}/${total} (${percent}%)`);
+  };
+
+  let runId: string | null = null;
+  let errorsCount = 0;
+  const issueBuffer: Array<{
+    stage: string;
+    severity?: ImportIssueSeverity;
+    code: string;
+    message: string;
+    registrationNo?: string | null;
+    sourceTable?: string | null;
+    payloadJson?: string | null;
+  }> = [];
+  const ISSUE_BUFFER_SIZE = 250;
+  const flushIssueBuffer = async () => {
+    if (!runId || issueBuffer.length === 0) return;
+    const next = issueBuffer.splice(0, issueBuffer.length);
+    await createImportRunIssuesBulk(runId, next, auditContext);
+  };
+  const recordIssue = async (issue: {
+    stage: string;
+    severity?: ImportIssueSeverity;
+    code: string;
+    message: string;
+    registrationNo?: string | null;
+    sourceTable?: string | null;
+    payloadJson?: string | null;
+  }) => {
+    issueBuffer.push({ ...issue, severity: issue.severity ?? "WARNING" });
+    if (issueBuffer.length >= ISSUE_BUFFER_SIZE) {
+      await flushIssueBuffer();
+    }
+  };
+
+  try {
+    const run = await createImportRun({
+      kind: ImportKind.LEGACY_PHASE1_5,
+      createdByUserId,
+      auditContext,
+    });
+    runId = run.id;
+    log(`Created import run ${run.id}`);
+    await markImportRunRunning(run.id, auditContext);
+    log("Marked run as RUNNING");
+
+    startStage("load");
+    const titleRows = await fetchLegacyPhase1_5Rows({
+      log: (message) => log(`[stage:load] ${message}`),
+    });
+    log(`Loaded legacy title rows: rows=${titleRows.length}`);
+    finishStage("load");
+
+    startStage("index");
+    const registrationRows = await prisma.dogRegistration.findMany({
+      select: {
+        registrationNo: true,
+        dogId: true,
+      },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    });
+    const dogIdByRegistration = new Map<string, string>();
+    const canonicalRegistrationByDogId = new Map<string, string>();
+    for (const row of registrationRows) {
+      dogIdByRegistration.set(row.registrationNo, row.dogId);
+      if (!canonicalRegistrationByDogId.has(row.dogId)) {
+        canonicalRegistrationByDogId.set(row.dogId, row.registrationNo);
+      }
+    }
+    log(
+      `Indexed registrations=${dogIdByRegistration.size}, dogs=${canonicalRegistrationByDogId.size}`,
+    );
+    finishStage("index");
+
+    startStage("titles");
+    let processed = 0;
+    let skippedBlank = 0;
+    const candidatesByDogId = new Map<string, TitleCandidate[]>();
+    for (const row of titleRows) {
+      processed += 1;
+
+      const rawTitleCode = normalizeNullable(row.titleCodeRaw);
+      if (!rawTitleCode) {
+        skippedBlank += 1;
+        if (processed % 1000 === 0) {
+          logProgress("titles", processed, titleRows.length);
+        }
+        continue;
+      }
+
+      const registrationNo = normalizeRegistrationNo(row.registrationNo);
+      if (!registrationNo) {
+        errorsCount += 1;
+        await recordIssue({
+          stage: "titles",
+          code: "TITLE_REGISTRATION_MISSING",
+          message:
+            "Title row is missing registration number; row skipped before dog resolution.",
+          sourceTable: "bea_apu",
+          payloadJson: JSON.stringify(row),
+        });
+        if (processed % 1000 === 0) {
+          logProgress("titles", processed, titleRows.length);
+        }
+        continue;
+      }
+
+      if (!isValidRegistrationNo(registrationNo)) {
+        errorsCount += 1;
+        await recordIssue({
+          stage: "titles",
+          code: "TITLE_REGISTRATION_INVALID_FORMAT",
+          message: "Title row has invalid registration format.",
+          registrationNo,
+          sourceTable: "bea_apu",
+          payloadJson: JSON.stringify(row),
+        });
+        if (processed % 1000 === 0) {
+          logProgress("titles", processed, titleRows.length);
+        }
+        continue;
+      }
+
+      const dogId = dogIdByRegistration.get(registrationNo);
+      if (!dogId) {
+        errorsCount += 1;
+        await recordIssue({
+          stage: "titles",
+          code: "TITLE_DOG_NOT_FOUND",
+          message:
+            "Title row registration did not resolve to a dog in canonical registrations.",
+          registrationNo,
+          sourceTable: "bea_apu",
+          payloadJson: JSON.stringify(row),
+        });
+        if (processed % 1000 === 0) {
+          logProgress("titles", processed, titleRows.length);
+        }
+        continue;
+      }
+
+      const candidates = candidatesByDogId.get(dogId) ?? [];
+      candidates.push({
+        registrationNo,
+        rawTitleCode,
+        normalizedTitleCode: normalizeTitleCodeForComparison(rawTitleCode),
+      });
+      candidatesByDogId.set(dogId, candidates);
+
+      if (processed % 1000 === 0) {
+        logProgress("titles", processed, titleRows.length);
+      }
+    }
+    logProgress("titles", processed, titleRows.length);
+
+    const titlesToCreate: Array<{
+      dogId: string;
+      titleCode: string;
+    }> = [];
+    let conflicts = 0;
+
+    for (const [dogId, candidates] of candidatesByDogId.entries()) {
+      if (candidates.length === 0) continue;
+      const canonicalRegistrationNo =
+        canonicalRegistrationByDogId.get(dogId) ?? null;
+      const candidatesByNormalizedCode = new Map<string, TitleCandidate[]>();
+      for (const candidate of candidates) {
+        const values =
+          candidatesByNormalizedCode.get(candidate.normalizedTitleCode) ?? [];
+        values.push(candidate);
+        candidatesByNormalizedCode.set(candidate.normalizedTitleCode, values);
+      }
+
+      const distinctValues = sortUnique(candidatesByNormalizedCode.keys());
+      const canonicalDistinctValues = canonicalRegistrationNo
+        ? sortUnique(
+            candidates
+              .filter(
+                (candidate) =>
+                  candidate.registrationNo === canonicalRegistrationNo,
+              )
+              .map((candidate) => candidate.normalizedTitleCode),
+          )
+        : [];
+
+      if (distinctValues.length > 1) {
+        conflicts += 1;
+        errorsCount += 1;
+        await recordIssue({
+          stage: "titles",
+          code: "TITLE_ALIAS_VALUE_CONFLICT",
+          message:
+            "Conflicting alias title values detected: the same dog resolved from multiple registrations with distinct non-empty normalized VALIO values.",
+          registrationNo: canonicalRegistrationNo,
+          sourceTable: "bea_apu",
+          payloadJson: JSON.stringify({
+            dogId,
+            canonicalRegistrationNo,
+            distinctNormalizedValues: distinctValues,
+            sourceRegistrations: sortUnique(
+              candidates.map((candidate) => candidate.registrationNo),
+            ),
+            canonicalNormalizedValues: canonicalDistinctValues,
+            sourceRows: [...candidates]
+              .map((candidate) => ({
+                registrationNo: candidate.registrationNo,
+                titleCodeRaw: candidate.rawTitleCode,
+                normalizedTitleCode: candidate.normalizedTitleCode,
+                isCanonicalRegistration:
+                  candidate.registrationNo === canonicalRegistrationNo,
+              }))
+              .sort((left, right) => {
+                const leftKey = `${left.registrationNo}|${left.normalizedTitleCode}|${left.titleCodeRaw}`;
+                const rightKey = `${right.registrationNo}|${right.normalizedTitleCode}|${right.titleCodeRaw}`;
+                return leftKey.localeCompare(rightKey);
+              }),
+          }),
+        });
+      }
+
+      const preferredNormalizedValue =
+        canonicalDistinctValues[0] ?? distinctValues[0];
+      if (!preferredNormalizedValue) {
+        continue;
+      }
+      const valueCandidates =
+        candidatesByNormalizedCode.get(preferredNormalizedValue) ?? [];
+      if (valueCandidates.length === 0) {
+        continue;
+      }
+
+      const titleCode = pickTitleCode(valueCandidates, canonicalRegistrationNo);
+      titlesToCreate.push({
+        dogId,
+        titleCode,
+      });
+    }
+
+    titlesToCreate.sort((left, right) => left.dogId.localeCompare(right.dogId));
+    const CREATE_MANY_CHUNK_SIZE = 1000;
+    let titlesInserted = 0;
+    for (
+      let start = 0;
+      start < titlesToCreate.length;
+      start += CREATE_MANY_CHUNK_SIZE
+    ) {
+      const chunk = titlesToCreate.slice(start, start + CREATE_MANY_CHUNK_SIZE);
+      if (chunk.length === 0) continue;
+      // Phase1.5 is part of the one-shot legacy bootstrap flow where DogTitle
+      // rows are expected to be empty before import. No replay/reconciliation
+      // behavior is required in this migration step.
+      await prisma.dogTitle.createMany({
+        data: chunk.map((title) => ({
+          dogId: title.dogId,
+          titleCode: title.titleCode,
+          titleName: null,
+          awardedOn: null,
+          sortOrder: 0,
+        })),
+      });
+      titlesInserted += chunk.length;
+    }
+
+    finishStage(
+      "titles",
+      `rows=${titleRows.length}, dogsWithImportedTitle=${titlesInserted}, skippedBlank=${skippedBlank}, conflicts=${conflicts}`,
+    );
+
+    await flushIssueBuffer();
+
+    const finished = await markImportRunFinished(
+      run.id,
+      {
+        status: "SUCCEEDED",
+        dogsUpserted: 0,
+        ownersUpserted: 0,
+        ownershipsUpserted: 0,
+        trialResultsUpserted: 0,
+        showResultsUpserted: 0,
+        errorsCount,
+        errorSummary:
+          errorsCount > 0 ? "Import completed with warnings." : null,
+      },
+      auditContext,
+    );
+
+    return {
+      status: 202,
+      body: { ok: true, data: toImportRunResponse(finished) },
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message.trim()
+        ? error.message.trim()
+        : "Import failed.";
+    log(`Import failed: ${message}`);
+    if (!runId) {
+      return {
+        status: 500,
+        body: {
+          ok: false,
+          code: "IMPORT_FAILED",
+          error: `Import run failed before initialization: ${message}`,
+        },
+      };
+    }
+
+    await createImportRunIssue(
+      runId,
+      {
+        stage: "run",
+        severity: "ERROR",
+        code: "UNEXPECTED_EXCEPTION",
+        message,
+      },
+      auditContext,
+    );
+    await flushIssueBuffer();
+    const finished = await markImportRunFinished(
+      runId,
+      {
+        status: "FAILED",
+        dogsUpserted: 0,
+        ownersUpserted: 0,
+        ownershipsUpserted: 0,
+        trialResultsUpserted: 0,
+        showResultsUpserted: 0,
+        errorsCount: errorsCount + 1,
+        errorSummary: message,
+      },
+      auditContext,
+    );
+
+    return {
+      status: 500,
+      body: {
+        ok: false,
+        code: "IMPORT_FAILED",
+        error: `Import run failed (runId=${finished.id}): ${message}`,
+      },
+    };
+  } finally {
+    log("Import run finished");
+  }
+}

--- a/packages/server/imports/runs/__tests__/service.test.ts
+++ b/packages/server/imports/runs/__tests__/service.test.ts
@@ -3,6 +3,7 @@ import { createImportsService } from "../service";
 
 const {
   runLegacyPhase1Mock,
+  runLegacyPhase1_5Mock,
   runLegacyPhase2Mock,
   runLegacyPhase3Mock,
   getImportRunByIdMock,
@@ -10,6 +11,7 @@ const {
   isInvalidImportRunIssuesCursorErrorMock,
 } = vi.hoisted(() => ({
   runLegacyPhase1Mock: vi.fn(),
+  runLegacyPhase1_5Mock: vi.fn(),
   runLegacyPhase2Mock: vi.fn(),
   runLegacyPhase3Mock: vi.fn(),
   getImportRunByIdMock: vi.fn(),
@@ -25,6 +27,10 @@ vi.mock("../../phase2", () => ({
   runLegacyPhase2: runLegacyPhase2Mock,
 }));
 
+vi.mock("../../phase1_5", () => ({
+  runLegacyPhase1_5: runLegacyPhase1_5Mock,
+}));
+
 vi.mock("../../phase3", () => ({
   runLegacyPhase3: runLegacyPhase3Mock,
 }));
@@ -38,6 +44,7 @@ vi.mock("@beagle/db", () => ({
 describe("imports runs service", () => {
   beforeEach(() => {
     runLegacyPhase1Mock.mockReset();
+    runLegacyPhase1_5Mock.mockReset();
     runLegacyPhase2Mock.mockReset();
     runLegacyPhase3Mock.mockReset();
     getImportRunByIdMock.mockReset();
@@ -78,6 +85,20 @@ describe("imports runs service", () => {
     const result = await service.runLegacyPhase2("user-2");
 
     expect(runLegacyPhase2Mock).toHaveBeenCalledWith("user-2", undefined);
+    expect(result).toEqual(expected);
+  });
+
+  it("delegates runLegacyPhase1_5 to phase1_5 runner", async () => {
+    const expected = {
+      status: 202,
+      body: { ok: true, data: { id: "run-15", kind: "LEGACY_PHASE1_5" } },
+    };
+    runLegacyPhase1_5Mock.mockResolvedValue(expected);
+
+    const service = createImportsService();
+    const result = await service.runLegacyPhase1_5("user-15");
+
+    expect(runLegacyPhase1_5Mock).toHaveBeenCalledWith("user-15", undefined);
     expect(result).toEqual(expected);
   });
 

--- a/packages/server/imports/runs/service.ts
+++ b/packages/server/imports/runs/service.ts
@@ -11,6 +11,7 @@ import type {
 } from "@beagle/contracts";
 import type { ServiceResult } from "../../core/result";
 import { runLegacyPhase1 } from "../phase1";
+import { runLegacyPhase1_5 } from "../phase1_5";
 import { runLegacyPhase2 } from "../phase2";
 import { runLegacyPhase3 } from "../phase3";
 import { toImportRunIssueResponse, toImportRunResponse } from "./transform";
@@ -25,6 +26,16 @@ export function createImportsService() {
       },
     ): Promise<ServiceResult<ImportRunResponse>> {
       return runLegacyPhase1(createdByUserId, options);
+    },
+
+    async runLegacyPhase1_5(
+      createdByUserId?: string,
+      options?: {
+        log?: (message: string) => void;
+        auditSource?: AuditContextDb["source"];
+      },
+    ): Promise<ServiceResult<ImportRunResponse>> {
+      return runLegacyPhase1_5(createdByUserId, options);
     },
 
     async runLegacyPhase2(

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,7 @@
     "test:unit": "node ../../node_modules/vitest/vitest.mjs run",
     "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --coverage",
     "import:phase1": "node --import tsx/esm scripts/imports/phase1/run.ts",
+    "import:phase1.5": "node --import tsx/esm scripts/imports/phase1_5/run.ts",
     "import:phase2": "node --import tsx/esm scripts/imports/phase2/run.ts",
     "import:phase3": "node --import tsx/esm scripts/imports/phase3/run.ts",
     "import:bootstrap": "node --import tsx/esm scripts/imports/bootstrap/run.ts",

--- a/packages/server/scripts/imports/bootstrap/run.ts
+++ b/packages/server/scripts/imports/bootstrap/run.ts
@@ -50,7 +50,7 @@ function runScript(scriptFile: string, label: string) {
 async function main() {
   const args = process.argv.slice(2).filter((arg) => arg !== "--");
   console.log(
-    "[import:bootstrap] Starting bootstrap-admin -> seed-show-result-definitions -> seed-show-workbook-import-schema -> phase1 -> phase2 -> phase3",
+    "[import:bootstrap] Starting bootstrap-admin -> seed-show-result-definitions -> seed-show-workbook-import-schema -> phase1 -> phase1.5 -> phase2 -> phase3",
   );
 
   runScript("../../bootstrap-admin.ts", "auth:bootstrap-admin");
@@ -63,6 +63,7 @@ async function main() {
     "seed:show-workbook-import-schema",
   );
   runPhase("../phase1/run.ts", "import:phase1", args);
+  runPhase("../phase1_5/run.ts", "import:phase1.5", args);
   runPhase("../phase2/run.ts", "import:phase2", args);
   runPhase("../phase3/run.ts", "import:phase3", args);
 

--- a/packages/server/scripts/imports/internal/run-import-phase.ts
+++ b/packages/server/scripts/imports/internal/run-import-phase.ts
@@ -12,7 +12,7 @@ type ExecutePhase = (
 ) => Promise<RunResult>;
 
 export async function runImportPhase(
-  phaseLabel: "phase1" | "phase2" | "phase3",
+  phaseLabel: "phase1" | "phase1.5" | "phase2" | "phase3",
   executePhase: ExecutePhase,
 ) {
   const args = process.argv.slice(2).filter((arg) => arg !== "--");

--- a/packages/server/scripts/imports/phase1_5/run.ts
+++ b/packages/server/scripts/imports/phase1_5/run.ts
@@ -1,0 +1,23 @@
+import { importsService } from "../../../imports";
+import { disconnectImportScriptPrisma, runImportPhase } from "../internal";
+
+async function main() {
+  await runImportPhase("phase1.5", async (createdByUserId, log) => {
+    const result = await importsService.runLegacyPhase1_5(createdByUserId, {
+      log,
+      auditSource: "SCRIPT",
+    });
+    return {
+      ok: result.body.ok,
+      status: result.status,
+      body: result.body,
+    };
+  });
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(disconnectImportScriptPrisma);


### PR DESCRIPTION
## Summary

- Deliver BEJ-67 dog titles support by adding legacy import phase `phase1.5` for dog titles.
- Import one raw title row per dog from `bea_apu.VALIO` with blank-skip, alias dedupe, and conflict issue handling.
- Keep legacy import sequence/docs aligned for one-shot bootstrap flow.

## Changes

- Added phase1.5 source loader (`bea_apu.REKNO`, `bea_apu.VALIO`).
- Added phase1.5 runner and import-kind wiring (`LEGACY_PHASE1_5`) in imports service and scripts.
- Added targeted tests for source loading, import behavior (blank skip, dedupe, conflict), and service delegation.
- Updated legacy import and ops docs for `phase1.5` and bootstrap order.

## Testing

- `pnpm --filter @beagle/server exec vitest run imports/phase1_5/__tests__/run-legacy-phase1_5.test.ts imports/runs/__tests__/service.test.ts`
- `pnpm --filter @beagle/db exec vitest run imports/phase1_5/__tests__/source.test.ts`
- `pnpm --filter @beagle/server typecheck`
- `pnpm --filter @beagle/db typecheck`
- `pnpm --filter @beagle/server lint`
- `pnpm --filter @beagle/db lint`

Refs: BEJ-67
