### PR TITLE
fix(db): prefer scoped vercel database URLs over generic DATABASE_URL

### DIFF
--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -19,6 +19,12 @@ This repository supports two valid Vercel project configurations.
 - `RUN_DB_MIGRATIONS=true` (default): run `pnpm db:migrate:deploy` after successful build.
 - `RUN_DB_MIGRATIONS=false`: skip migration deploy in that environment.
 
+## Database URL precedence on Vercel
+
+- Runtime DB client resolution prefers scoped Vercel variables first (`beagle_db_<scope>_...`), then falls back to `DATABASE_URL`.
+- Migration resolution (`prisma migrate deploy`) prefers non-pooled scoped values first (`beagle_db_<scope>_DATABASE_URL_UNPOOLED` or `beagle_db_<scope>_POSTGRES_URL_NON_POOLING`), then falls back to `DATABASE_URL`.
+- For production deploys, set `beagle_db_production_POSTGRES_URL_NON_POOLING` (or `beagle_db_production_DATABASE_URL_UNPOOLED`) to ensure migrations run against a direct connection.
+
 ## Common failure: `Command "vercel:build" not found`
 
 If Vercel logs show:

--- a/packages/db/core/__tests__/resolve-database-url.test.ts
+++ b/packages/db/core/__tests__/resolve-database-url.test.ts
@@ -46,4 +46,26 @@ describe("resolveDatabaseUrl", () => {
 
     expect(url).toBe("postgresql://develop-nonpooling");
   });
+
+  it("prefers scoped runtime URL over generic DATABASE_URL", () => {
+    const url = resolveDatabaseUrl({
+      DATABASE_URL: "postgresql://generic-runtime",
+      beagle_db_develop_POSTGRES_PRISMA_URL: "postgresql://scoped-runtime",
+    });
+
+    expect(url).toBe("postgresql://scoped-runtime");
+  });
+
+  it("prefers scoped migration URL over generic DATABASE_URL", () => {
+    const url = resolveDatabaseUrl(
+      {
+        DATABASE_URL: "postgresql://generic-migration",
+        beagle_db_develop_POSTGRES_URL_NON_POOLING:
+          "postgresql://scoped-migration",
+      },
+      "migration",
+    );
+
+    expect(url).toBe("postgresql://scoped-migration");
+  });
 });

--- a/packages/db/core/resolve-database-url.ts
+++ b/packages/db/core/resolve-database-url.ts
@@ -70,12 +70,13 @@ export function resolveDatabaseUrl(
 ): string {
   const scope = getScopeFromEnv(env);
 
-  const resolvedUrl =
-    env.DATABASE_URL ??
-    (target === "runtime"
+  const scopedResolvedUrl =
+    target === "runtime"
       ? pickRuntimeUrl(env, scope)
-      : pickMigrationUrl(env, scope)) ??
-    LOCAL_DATABASE_URL;
+      : pickMigrationUrl(env, scope);
+
+  const resolvedUrl =
+    scopedResolvedUrl ?? env.DATABASE_URL ?? LOCAL_DATABASE_URL;
 
   return resolvedUrl;
 }


### PR DESCRIPTION
- resolve runtime and migration URLs from scoped `beagle_db_<scope>_*` vars before falling back to `DATABASE_URL`
- add regression tests and deployment docs for Vercel URL precedence and non-pooled migration configuration
