### PR TITLE
Fix/gh versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
             /^## \[/ {
               if (in_block == 1) exit
             }
-            if (in_block == 0 && index($0, prefix) == 1) {
+            in_block == 0 && index($0, prefix) == 1 {
               date = substr($0, length(prefix) + 1)
               if (date ~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/) {
                 in_block=1


### PR DESCRIPTION
- replace top-level `if` with a condition-action pattern in release notes extraction
- prevent GitHub Actions awk syntax errors during release workflow runs


