### PR TITLE
fix(db): normalize alias imports and update CI action versions

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -11,9 +11,9 @@ jobs:
       BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
       BETTER_AUTH_URL: ${{ secrets.BETTER_AUTH_URL || vars.BETTER_AUTH_URL }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -41,9 +41,9 @@ jobs:
       BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
       BETTER_AUTH_URL: ${{ secrets.BETTER_AUTH_URL || vars.BETTER_AUTH_URL }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -9,6 +9,7 @@
       "@web/*": ["./*"],
       "@server/*": ["../../packages/server/*"],
       "@db/*": ["../../packages/db/*"],
+      "@contracts/*": ["../../packages/contracts/*"],
       "@api-client/*": ["../../packages/api-client/*"],
       "@beagle/api-client": ["../../packages/api-client/index.ts"],
       "@beagle/contracts": ["../../packages/contracts/index.ts"],

--- a/packages/contracts/dogs/profile/beagle-profile.ts
+++ b/packages/contracts/dogs/profile/beagle-profile.ts
@@ -1,4 +1,4 @@
-import type { BeagleShowStructuredResultDto } from "../../shows/beagle-shows";
+import type { BeagleShowStructuredResultDto } from "@contracts/shows/beagle-shows";
 
 export type BeagleDogProfileSex = "U" | "N" | "-";
 

--- a/packages/db/admin/users/manage/delete-user.ts
+++ b/packages/db/admin/users/manage/delete-user.ts
@@ -1,8 +1,8 @@
-import { prisma } from "../../../core/prisma";
+import { prisma } from "@db/core/prisma";
 import {
   runInAuditContextDb,
   type AuditContextDb,
-} from "../../../core/audit-context";
+} from "@db/core/audit-context";
 import type { Prisma, PrismaClient } from "@prisma/client";
 
 type AdminUserDbClient = PrismaClient | Prisma.TransactionClient;

--- a/packages/db/admin/users/manage/list-users.ts
+++ b/packages/db/admin/users/manage/list-users.ts
@@ -1,4 +1,4 @@
-import { prisma } from "../../../core/prisma";
+import { prisma } from "@db/core/prisma";
 
 export type AdminUserRowDb = {
   id: string;

--- a/packages/db/dogs/core/dog-row-loader.ts
+++ b/packages/db/dogs/core/dog-row-loader.ts
@@ -1,5 +1,5 @@
 import { DogSex, type Prisma } from "@prisma/client";
-import { prisma } from "../../core/prisma";
+import { prisma } from "@db/core/prisma";
 import {
   getFirstInsertedRegistrationNo,
   sortRegistrationsByInsertedAsc,

--- a/packages/db/dogs/profile/internal/offspring-litters.ts
+++ b/packages/db/dogs/profile/internal/offspring-litters.ts
@@ -1,5 +1,5 @@
 // Groups dog profile offspring into litters using birth date and co-parent identity.
-import { toBusinessDateOnly } from "../../../core/date-only";
+import { toBusinessDateOnly } from "@db/core/date-only";
 import {
   getPrimaryRegistrationNo,
   mapParent,

--- a/packages/db/dogs/profile/internal/profile-base-query.ts
+++ b/packages/db/dogs/profile/internal/profile-base-query.ts
@@ -1,6 +1,6 @@
 // Fetches the base dog profile row shape (dog + pedigree + offspring relations)
 // used by the profile DB orchestrator.
-import { prisma } from "../../../core/prisma";
+import { prisma } from "@db/core/prisma";
 
 export async function getDogProfileBaseRow(dogId: string) {
   return prisma.dog.findUnique({

--- a/packages/db/dogs/profile/internal/profile-mappers.ts
+++ b/packages/db/dogs/profile/internal/profile-mappers.ts
@@ -1,6 +1,6 @@
 // Shared dog profile DB mappers for registration, parent, and pedigree shaping.
 import { DogSex } from "@prisma/client";
-import { getFirstInsertedRegistrationNo } from "../../core/registration";
+import { getFirstInsertedRegistrationNo } from "@db/dogs/core/registration";
 import type {
   BeagleDogProfileParentDb,
   BeagleDogProfilePedigreeCardDb,

--- a/packages/db/dogs/profile/internal/profile-siblings-query.ts
+++ b/packages/db/dogs/profile/internal/profile-siblings-query.ts
@@ -1,6 +1,6 @@
 // Encapsulates sibling candidate query shape so the profile DB use-case remains
 // focused on orchestration instead of Prisma include/where details.
-import { prisma } from "../../../core/prisma";
+import { prisma } from "@db/core/prisma";
 import {
   buildSiblingWhere,
   type SiblingProfileContext,

--- a/packages/db/dogs/profile/internal/profile-siblings.ts
+++ b/packages/db/dogs/profile/internal/profile-siblings.ts
@@ -3,7 +3,7 @@
 import {
   getBusinessDateUtcRange,
   toBusinessDateOnly,
-} from "../../../core/date-only";
+} from "@db/core/date-only";
 import { getPrimaryRegistrationNo, toSexCode } from "./profile-mappers";
 import type {
   BeagleDogProfileSiblingRowDb,


### PR DESCRIPTION
- replace deep relative imports with `@db/*` and `@contracts/*` in the flagged db/contracts modules
- add `@contracts/*` path mapping in web tsconfig and bump GitHub Actions to v5 for Node 24 readiness


