### PR TITLE
fix(config-typescript): add contracts alias in package tsconfigs

### DIFF
--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../config-typescript/base.json",
   "compilerOptions": {
     "paths": {
-      "@api-client/*": ["./*"]
+      "@api-client/*": ["./*"],
+      "@contracts/*": ["../contracts/*"]
     }
   },
   "include": ["**/*.ts"]

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "paths": {
       "@server/*": ["./*"],
-      "@db/*": ["../db/*"]
+      "@db/*": ["../db/*"],
+      "@contracts/*": ["../contracts/*"]
     }
   },
   "include": ["**/*.ts"]


### PR DESCRIPTION
- add `@contracts/*` path mapping to api-client and server tsconfig paths
- fix cross-package TypeScript resolution errors when contracts use alias imports


