### PR TITLE
Refactor legacy import reporting

### DIFF
--- a/docs/legacy-import/import-flow.md
+++ b/docs/legacy-import/import-flow.md
@@ -139,8 +139,8 @@ Each phase creates its own `ImportRun` with its own `runId`.
 
 Issue rows are written to shared `ImportRunIssue` storage per run.
 
-- Successful run with no issues: `status=SUCCEEDED`, `errorsCount=0`, `errorSummary=null`
-- Successful run with issues: `status=SUCCEEDED`, `errorSummary="Import completed with warnings."`
+- Successful run: `status=SUCCEEDED`, `errorSummary` stores a phase-specific summary
+  of the imported counters for that phase
 - Failed run: `status=FAILED`, run-level `UNEXPECTED_EXCEPTION` issue recorded
 
 CSV export is per run id. Export separate CSV sets for each phase run id.

--- a/docs/legacy-import/phase1.md
+++ b/docs/legacy-import/phase1.md
@@ -31,6 +31,7 @@ Phase 1 imports foundation entities and link structures. It does not import tria
 - `bea_apu` -> `Dog.ekNo` by registration lookup.
 - `beaom` -> `Owner` + `DogOwnership` rows by registration lookup.
 - `samakoira` -> alias registrations (`REK_2`, `REK_3`) attached to canonical `REK_1`.
+- `samakoira.VARA` -> appended into `Dog.note` for the canonical dog when non-empty.
 
 ## Main writes
 
@@ -66,6 +67,7 @@ Phase 1 imports foundation entities and link structures. It does not import tria
   - existing alias on different dog: `REGISTRATION_ALIAS_CONFLICT`
   - empty `REK_2` slots are recorded as warnings
   - empty `REK_3` slots are expected and skipped silently
+- `samakoira.VARA` values are merged into `Dog.note` using a `|` separator and duplicate text is not re-added.
 - Ownership rows are duplicate-safe via unique key + `skipDuplicates`.
 
 ## Issue profile

--- a/docs/legacy-import/phase1.md
+++ b/docs/legacy-import/phase1.md
@@ -64,6 +64,8 @@ Phase 1 imports foundation entities and link structures. It does not import tria
 - Alias registration inserts from `samakoira` avoid duplicates/conflicts:
   - existing alias on same dog: kept
   - existing alias on different dog: `REGISTRATION_ALIAS_CONFLICT`
+  - empty `REK_2` slots are recorded as warnings
+  - empty `REK_3` slots are expected and skipped silently
 - Ownership rows are duplicate-safe via unique key + `skipDuplicates`.
 
 ## Issue profile

--- a/docs/legacy-import/phase1.md
+++ b/docs/legacy-import/phase1.md
@@ -53,6 +53,9 @@ Phase 1 imports foundation entities and link structures. It does not import tria
 - Owner links:
   - owner row requires a resolved dog by registration
   - ownership uses `ownershipDateKey` and `createMany(skipDuplicates=true)`
+- EK rows:
+  - `bea_apu` rows with a non-empty `EKNO` update `Dog.ekNo`
+  - rows without `EKNO` are treated as non-EK rows and skipped without recording an issue
 
 ## Idempotency and rerun behavior
 

--- a/docs/legacy-import/phase1.md
+++ b/docs/legacy-import/phase1.md
@@ -51,6 +51,7 @@ Phase 1 imports foundation entities and link structures. It does not import tria
 - Parent links (`sireId`, `damId`):
   - resolved after dog/registration indexing
   - missing/invalid/placeholder parent refs are reported as issues
+  - when the dog itself never imported, `RELATION_DOG_NOT_FOUND` now clarifies whether the row was skipped earlier because `KNIMI` was blank or whether the dog was absent from the imported dogs index in the new database
 - Owner links:
   - owner row requires a resolved dog by registration
   - ownership uses `ownershipDateKey` and `createMany(skipDuplicates=true)`

--- a/docs/legacy-import/phase1.md
+++ b/docs/legacy-import/phase1.md
@@ -55,7 +55,8 @@ Phase 1 imports foundation entities and link structures. It does not import tria
   - ownership uses `ownershipDateKey` and `createMany(skipDuplicates=true)`
 - EK rows:
   - `bea_apu` rows with a non-empty `EKNO` update `Dog.ekNo`
-  - rows without `EKNO` are treated as non-EK rows and skipped without recording an issue
+  - rows without `EKNO` do not update `Dog.ekNo`
+  - malformed `registrationNo` values are still recorded as issues before the `EKNO` check
 
 ## Idempotency and rerun behavior
 

--- a/docs/legacy-import/phase1.md
+++ b/docs/legacy-import/phase1.md
@@ -59,6 +59,7 @@ Phase 1 imports foundation entities and link structures. It does not import tria
   - `bea_apu` rows with a non-empty `EKNO` update `Dog.ekNo`
   - rows without `EKNO` do not update `Dog.ekNo`
   - malformed `registrationNo` values are still recorded as issues before the `EKNO` check
+  - the phase log reports both the raw `bea_apu` row count and the subset that has a non-empty `EKNO`
 
 ## Idempotency and rerun behavior
 

--- a/packages/db/imports/phase1/__tests__/source.test.ts
+++ b/packages/db/imports/phase1/__tests__/source.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchLegacyPhase1_5Rows } from "../source";
+import { fetchLegacyPhase1Rows } from "../source";
 
 const { connectLegacyDatabaseMock } = vi.hoisted(() => ({
   connectLegacyDatabaseMock: vi.fn(),
@@ -9,33 +9,30 @@ vi.mock("../../internal", () => ({
   connectLegacyDatabase: connectLegacyDatabaseMock,
 }));
 
-describe("fetchLegacyPhase1_5Rows", () => {
+describe("fetchLegacyPhase1Rows", () => {
   beforeEach(() => {
     connectLegacyDatabaseMock.mockReset();
   });
 
-  it("loads REKNO + VALIO rows from bea_apu", async () => {
+  it("logs raw bea_apu rows and the subset with EKNO", async () => {
     const log = vi.fn();
     const connection = {
       query: vi.fn().mockResolvedValue([
-        { registrationNo: "FI-1/20", titleCodeRaw: "FI JVA" },
-        { registrationNo: "FI-2/20", titleCodeRaw: null },
+        { registrationNo: "FI-1/20", ekNo: 123 },
+        { registrationNo: "FI-2/20", ekNo: null },
       ]),
       end: vi.fn().mockResolvedValue(undefined),
     };
     connectLegacyDatabaseMock.mockResolvedValue(connection);
 
-    const result = await fetchLegacyPhase1_5Rows({ log });
+    const result = await fetchLegacyPhase1Rows({ log });
 
-    expect(connection.query).toHaveBeenCalledWith(
-      expect.stringContaining("FROM bea_apu"),
-    );
-    expect(result).toEqual([
-      { registrationNo: "FI-1/20", titleCodeRaw: "FI JVA" },
-      { registrationNo: "FI-2/20", titleCodeRaw: null },
+    expect(result.eks).toEqual([
+      { registrationNo: "FI-1/20", ekNo: 123 },
+      { registrationNo: "FI-2/20", ekNo: null },
     ]);
     expect(log).toHaveBeenCalledWith(
-      "Fetched bea_apu title source rows: total=2, elapsed=0s",
+      "Fetched bea_apu source rows: total=2, withEkNo=1, elapsed=0s",
     );
     expect(connection.end).toHaveBeenCalled();
   });

--- a/packages/db/imports/phase1/source.ts
+++ b/packages/db/imports/phase1/source.ts
@@ -54,8 +54,9 @@ export async function fetchLegacyPhase1Rows(options?: {
               EKNO as ekNo
        FROM bea_apu`,
     )) as LegacyEkRow[];
+    const eksWithEkNo = eks.filter((row) => row.ekNo != null).length;
     log(
-      `Fetched EK rows: count=${eks.length}, elapsed=${Math.round((Date.now() - eksStartedAt) / 1000)}s`,
+      `Fetched bea_apu source rows: total=${eks.length}, withEkNo=${eksWithEkNo}, elapsed=${Math.round((Date.now() - eksStartedAt) / 1000)}s`,
     );
 
     const ownersStartedAt = Date.now();

--- a/packages/db/imports/phase1_5/source.ts
+++ b/packages/db/imports/phase1_5/source.ts
@@ -19,7 +19,7 @@ export async function fetchLegacyPhase1_5Rows(options?: {
        FROM bea_apu`,
     )) as LegacyDogTitleRow[];
     log(
-      `Fetched title rows: count=${titleRows.length}, elapsed=${Math.round((Date.now() - titleRowsStartedAt) / 1000)}s`,
+      `Fetched bea_apu title source rows: total=${titleRows.length}, elapsed=${Math.round((Date.now() - titleRowsStartedAt) / 1000)}s`,
     );
 
     log(

--- a/packages/db/imports/phase2/__tests__/source.test.ts
+++ b/packages/db/imports/phase2/__tests__/source.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchLegacyTrialRows } from "../source";
+
+const { connectLegacyDatabaseMock } = vi.hoisted(() => ({
+  connectLegacyDatabaseMock: vi.fn(),
+}));
+
+vi.mock("../../internal", () => ({
+  connectLegacyDatabase: connectLegacyDatabaseMock,
+}));
+
+describe("fetchLegacyTrialRows", () => {
+  beforeEach(() => {
+    connectLegacyDatabaseMock.mockReset();
+  });
+
+  it("logs akoeall source rows as raw input rows", async () => {
+    const log = vi.fn();
+    const connection = {
+      query: vi
+        .fn()
+        .mockResolvedValue([
+          { registrationNo: "FI-1/20" },
+          { registrationNo: "FI-2/20" },
+        ]),
+      end: vi.fn().mockResolvedValue(undefined),
+    };
+    connectLegacyDatabaseMock.mockResolvedValue(connection);
+
+    const result = await fetchLegacyTrialRows({ log });
+
+    expect(result).toEqual([
+      { registrationNo: "FI-1/20" },
+      { registrationNo: "FI-2/20" },
+    ]);
+    expect(log).toHaveBeenCalledWith(
+      "Fetched akoeall source rows: total=2, elapsed=0s",
+    );
+    expect(connection.end).toHaveBeenCalled();
+  });
+});

--- a/packages/db/imports/phase2/source.ts
+++ b/packages/db/imports/phase2/source.ts
@@ -36,7 +36,7 @@ export async function fetchLegacyTrialRows(options?: {
        FROM akoeall`,
     )) as LegacyTrialResultRow[];
     log(
-      `Fetched trial rows: count=${trialResults.length}, elapsed=${Math.round((Date.now() - trialResultsStartedAt) / 1000)}s`,
+      `Fetched akoeall source rows: total=${trialResults.length}, elapsed=${Math.round((Date.now() - trialResultsStartedAt) / 1000)}s`,
     );
 
     log(

--- a/packages/db/imports/phase3/__tests__/source.test.ts
+++ b/packages/db/imports/phase3/__tests__/source.test.ts
@@ -39,6 +39,7 @@ describe("fetchLegacyShowRows", () => {
   });
 
   it("resolves equal-priority collisions deterministically", async () => {
+    const log = vi.fn();
     const zetaFirst: RawLegacyRow = {
       registrationNo: "FI-123/20",
       eventDateRaw: "20240101",
@@ -59,12 +60,15 @@ describe("fetchLegacyShowRows", () => {
       .mockResolvedValueOnce(createConnection([zetaFirst, alphaSecond]))
       .mockResolvedValueOnce(createConnection([alphaSecond, zetaFirst]));
 
-    const first = await fetchLegacyShowRows();
-    const second = await fetchLegacyShowRows();
+    const first = await fetchLegacyShowRows({ log });
+    const second = await fetchLegacyShowRows({ log });
 
     expect(first).toHaveLength(1);
     expect(second).toHaveLength(1);
     expect(first[0]?.judge).toBe("Alpha Judge");
     expect(second[0]?.judge).toBe("Alpha Judge");
+    expect(log).toHaveBeenCalledWith(
+      "Fetched legacy show source rows: total=1, mergedKeys=1, passthroughRowsWithoutMergeKey=0, elapsed=0s",
+    );
   });
 });

--- a/packages/db/imports/phase3/source.ts
+++ b/packages/db/imports/phase3/source.ts
@@ -196,7 +196,7 @@ export async function fetchLegacyShowRows(options?: {
     }
 
     log(
-      `Fetched and merged show rows: count=${showResults.length}, mergedKeys=${mergedByKey.size}, passthroughRowsWithoutMergeKey=${rowsWithoutMergeKey.length}, elapsed=${Math.round((Date.now() - showResultsStartedAt) / 1000)}s`,
+      `Fetched legacy show source rows: total=${showResults.length}, mergedKeys=${mergedByKey.size}, passthroughRowsWithoutMergeKey=${rowsWithoutMergeKey.length}, elapsed=${Math.round((Date.now() - showResultsStartedAt) / 1000)}s`,
     );
 
     log(

--- a/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
+++ b/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runLegacyPhase1 } from "../run-legacy-phase1";
+
+const {
+  createImportRunMock,
+  markImportRunRunningMock,
+  markImportRunFinishedMock,
+  createImportRunIssueMock,
+  createImportRunIssuesBulkMock,
+  fetchLegacyPhase1RowsMock,
+  breederFindManyMock,
+  dogRegistrationFindUniqueMock,
+  dogRegistrationFindManyMock,
+  dogRegistrationUpdateMock,
+  dogCreateMock,
+  dogUpdateMock,
+  ownerFindFirstMock,
+  ownerCreateMock,
+  dogOwnershipCreateManyMock,
+} = vi.hoisted(() => ({
+  createImportRunMock: vi.fn(),
+  markImportRunRunningMock: vi.fn(),
+  markImportRunFinishedMock: vi.fn(),
+  createImportRunIssueMock: vi.fn(),
+  createImportRunIssuesBulkMock: vi.fn(),
+  fetchLegacyPhase1RowsMock: vi.fn(),
+  breederFindManyMock: vi.fn(),
+  dogRegistrationFindUniqueMock: vi.fn(),
+  dogRegistrationFindManyMock: vi.fn(),
+  dogRegistrationUpdateMock: vi.fn(),
+  dogCreateMock: vi.fn(),
+  dogUpdateMock: vi.fn(),
+  ownerFindFirstMock: vi.fn(),
+  ownerCreateMock: vi.fn(),
+  dogOwnershipCreateManyMock: vi.fn(),
+}));
+
+vi.mock("@beagle/db", () => ({
+  DogSex: {
+    MALE: "MALE",
+    FEMALE: "FEMALE",
+    UNKNOWN: "UNKNOWN",
+  },
+  ImportKind: {
+    LEGACY_PHASE1: "LEGACY_PHASE1",
+  },
+  createImportRun: createImportRunMock,
+  markImportRunRunning: markImportRunRunningMock,
+  markImportRunFinished: markImportRunFinishedMock,
+  createImportRunIssue: createImportRunIssueMock,
+  createImportRunIssuesBulk: createImportRunIssuesBulkMock,
+  fetchLegacyPhase1Rows: fetchLegacyPhase1RowsMock,
+  prisma: {
+    breeder: { findMany: breederFindManyMock },
+    dogRegistration: {
+      findUnique: dogRegistrationFindUniqueMock,
+      findMany: dogRegistrationFindManyMock,
+      update: dogRegistrationUpdateMock,
+      create: vi.fn(),
+      findFirst: vi.fn(),
+    },
+    dog: {
+      create: dogCreateMock,
+      update: dogUpdateMock,
+      findUnique: vi.fn(),
+    },
+    owner: {
+      findFirst: ownerFindFirstMock,
+      create: ownerCreateMock,
+    },
+    dogOwnership: {
+      createMany: dogOwnershipCreateManyMock,
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+describe("runLegacyPhase1", () => {
+  beforeEach(() => {
+    createImportRunMock.mockReset();
+    markImportRunRunningMock.mockReset();
+    markImportRunFinishedMock.mockReset();
+    createImportRunIssueMock.mockReset();
+    createImportRunIssuesBulkMock.mockReset();
+    fetchLegacyPhase1RowsMock.mockReset();
+    breederFindManyMock.mockReset();
+    dogRegistrationFindUniqueMock.mockReset();
+    dogRegistrationFindManyMock.mockReset();
+    dogRegistrationUpdateMock.mockReset();
+    dogCreateMock.mockReset();
+    dogUpdateMock.mockReset();
+    ownerFindFirstMock.mockReset();
+    ownerCreateMock.mockReset();
+    dogOwnershipCreateManyMock.mockReset();
+
+    createImportRunMock.mockResolvedValue({ id: "run-1" });
+    markImportRunRunningMock.mockResolvedValue(undefined);
+    markImportRunFinishedMock.mockResolvedValue({
+      id: "run-1",
+      kind: "LEGACY_PHASE1",
+      status: "SUCCEEDED",
+      dogsUpserted: 1,
+      ownersUpserted: 0,
+      ownershipsUpserted: 0,
+      trialResultsUpserted: 0,
+      showResultsUpserted: 0,
+      errorsCount: 0,
+      startedAt: new Date("2024-01-01T00:00:00.000Z"),
+      finishedAt: new Date("2024-01-01T00:00:01.000Z"),
+      errorSummary: null,
+      createdByUserId: "user-1",
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2024-01-01T00:00:01.000Z"),
+      issuesCount: 0,
+    });
+
+    fetchLegacyPhase1RowsMock.mockResolvedValue({
+      dogs: [
+        {
+          registrationNo: "FI12345/21",
+          name: "Aino",
+          sex: "U",
+          birthDateRaw: "20240101",
+          sireRegistrationNo: null,
+          damRegistrationNo: null,
+          breederName: null,
+        },
+      ],
+      breeders: [],
+      eks: [
+        { registrationNo: "FI12345/21", ekNo: 5588 },
+        { registrationNo: "FI12345/21", ekNo: null },
+      ],
+      owners: [],
+      samakoira: [],
+    });
+
+    breederFindManyMock.mockResolvedValue([]);
+    dogRegistrationFindUniqueMock.mockImplementation(({ select }) => {
+      if (select?.source) {
+        return Promise.resolve(null);
+      }
+      return Promise.resolve({ dogId: "dog-1" });
+    });
+    dogRegistrationFindManyMock.mockResolvedValue([
+      { registrationNo: "FI12345/21", dogId: "dog-1" },
+    ]);
+    dogRegistrationUpdateMock.mockResolvedValue(undefined);
+    dogCreateMock.mockResolvedValue({ id: "dog-1" });
+    dogUpdateMock.mockResolvedValue(undefined);
+    ownerFindFirstMock.mockResolvedValue(null);
+    ownerCreateMock.mockResolvedValue({ id: "owner-1" });
+    dogOwnershipCreateManyMock.mockResolvedValue({ count: 0 });
+  });
+
+  it("updates EK values for valid rows and ignores null EK rows without recording issues", async () => {
+    const result = await runLegacyPhase1("user-1");
+
+    expect(result.status).toBe(202);
+    expect(dogUpdateMock).toHaveBeenCalledWith({
+      where: { id: "dog-1" },
+      data: { ekNo: 5588 },
+    });
+    expect(createImportRunIssuesBulkMock).not.toHaveBeenCalled();
+    expect(createImportRunIssueMock).not.toHaveBeenCalled();
+    expect(markImportRunFinishedMock).toHaveBeenCalledWith(
+      "run-1",
+      expect.objectContaining({
+        status: "SUCCEEDED",
+        errorsCount: 0,
+        errorSummary: null,
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
+++ b/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
@@ -209,7 +209,9 @@ describe("runLegacyPhase1", () => {
       owners: [],
       samakoira: [],
     });
-    dogRegistrationFindManyMock.mockResolvedValue([]);
+    dogRegistrationFindManyMock.mockResolvedValue([
+      { registrationNo: "FI12345/21", dogId: "dog-1" },
+    ]);
 
     const result = await runLegacyPhase1("user-1");
 
@@ -234,6 +236,58 @@ describe("runLegacyPhase1", () => {
           sourceTable: "bearek_id",
         }),
       ]),
+      expect.any(Object),
+    );
+  });
+
+  it("describes placeholder parent registrations as unknown and excluded from the new database", async () => {
+    fetchLegacyPhase1RowsMock.mockResolvedValue({
+      dogs: [
+        {
+          registrationNo: "FI12345/21",
+          name: "Aino",
+          sex: "U",
+          birthDateRaw: "20240101",
+          sireRegistrationNo: null,
+          damRegistrationNo: "U000000",
+          breederName: null,
+        },
+      ],
+      breeders: [],
+      eks: [],
+      owners: [],
+      samakoira: [],
+    });
+    dogRegistrationFindManyMock.mockResolvedValue([
+      { registrationNo: "FI12345/21", dogId: "dog-1" },
+    ]);
+
+    const result = await runLegacyPhase1("user-1");
+
+    expect(result.status).toBe(202);
+    expect(createImportRunIssuesBulkMock).toHaveBeenCalledWith(
+      "run-1",
+      expect.arrayContaining([
+        expect.objectContaining({
+          stage: "relations",
+          severity: "INFO",
+          code: "RELATION_DAM_PLACEHOLDER",
+          message:
+            "Dam registration is a placeholder and was treated as unknown, so the placeholder reference was not written to the new database.",
+          registrationNo: "FI12345/21",
+          sourceTable: "bearek_id",
+        }),
+      ]),
+      expect.any(Object),
+    );
+    expect(createImportRunIssueMock).not.toHaveBeenCalled();
+    expect(markImportRunFinishedMock).toHaveBeenCalledWith(
+      "run-1",
+      expect.objectContaining({
+        status: "SUCCEEDED",
+        errorsCount: 0,
+        errorSummary: null,
+      }),
       expect.any(Object),
     );
   });

--- a/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
+++ b/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
@@ -191,6 +191,53 @@ describe("runLegacyPhase1", () => {
     );
   });
 
+  it("explains that missing KNIMI prevented the dog from being imported and linked", async () => {
+    fetchLegacyPhase1RowsMock.mockResolvedValue({
+      dogs: [
+        {
+          registrationNo: "S87477",
+          name: null,
+          sex: "N",
+          birthDateRaw: null,
+          sireRegistrationNo: null,
+          damRegistrationNo: null,
+          breederName: null,
+        },
+      ],
+      breeders: [],
+      eks: [],
+      owners: [],
+      samakoira: [],
+    });
+    dogRegistrationFindManyMock.mockResolvedValue([]);
+
+    const result = await runLegacyPhase1("user-1");
+
+    expect(result.status).toBe(202);
+    expect(dogCreateMock).not.toHaveBeenCalled();
+    expect(createImportRunIssuesBulkMock).toHaveBeenCalledWith(
+      "run-1",
+      expect.arrayContaining([
+        expect.objectContaining({
+          stage: "dogs",
+          code: "DOG_MISSING_REQUIRED_FIELDS",
+          message: "Dog row missing registration number or name.",
+          registrationNo: "S87477",
+          sourceTable: "bearek_id",
+        }),
+        expect.objectContaining({
+          stage: "relations",
+          code: "RELATION_DOG_NOT_FOUND",
+          message:
+            "Dog was not found in the imported dogs index because the source row was skipped earlier due to blank KNIMI, so sire/dam relations were not created.",
+          registrationNo: "S87477",
+          sourceTable: "bearek_id",
+        }),
+      ]),
+      expect.any(Object),
+    );
+  });
+
   it("skips a null EK row without writing an EK value", async () => {
     fetchLegacyPhase1RowsMock.mockResolvedValue({
       dogs: [

--- a/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
+++ b/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
@@ -185,7 +185,7 @@ describe("runLegacyPhase1", () => {
       expect.objectContaining({
         status: "SUCCEEDED",
         errorsCount: 0,
-        errorSummary: null,
+        errorSummary: expect.stringContaining("Phase 1:"),
       }),
       expect.any(Object),
     );
@@ -286,7 +286,7 @@ describe("runLegacyPhase1", () => {
       expect.objectContaining({
         status: "SUCCEEDED",
         errorsCount: 0,
-        errorSummary: null,
+        errorSummary: expect.stringContaining("Phase 1:"),
       }),
       expect.any(Object),
     );
@@ -324,7 +324,7 @@ describe("runLegacyPhase1", () => {
       expect.objectContaining({
         status: "SUCCEEDED",
         errorsCount: 0,
-        errorSummary: null,
+        errorSummary: expect.stringContaining("Phase 1:"),
       }),
       expect.any(Object),
     );
@@ -381,7 +381,7 @@ describe("runLegacyPhase1", () => {
       expect.objectContaining({
         status: "SUCCEEDED",
         errorsCount: 0,
-        errorSummary: null,
+        errorSummary: expect.stringContaining("Phase 1:"),
       }),
       expect.any(Object),
     );
@@ -443,7 +443,7 @@ describe("runLegacyPhase1", () => {
       expect.objectContaining({
         status: "SUCCEEDED",
         errorsCount: 0,
-        errorSummary: null,
+        errorSummary: expect.stringContaining("Phase 1:"),
       }),
       expect.any(Object),
     );

--- a/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
+++ b/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
@@ -11,6 +11,7 @@ const {
   breederFindManyMock,
   dogRegistrationFindUniqueMock,
   dogRegistrationFindManyMock,
+  dogRegistrationCreateMock,
   dogRegistrationUpdateMock,
   dogCreateMock,
   dogUpdateMock,
@@ -27,6 +28,7 @@ const {
   breederFindManyMock: vi.fn(),
   dogRegistrationFindUniqueMock: vi.fn(),
   dogRegistrationFindManyMock: vi.fn(),
+  dogRegistrationCreateMock: vi.fn(),
   dogRegistrationUpdateMock: vi.fn(),
   dogCreateMock: vi.fn(),
   dogUpdateMock: vi.fn(),
@@ -55,8 +57,8 @@ vi.mock("@beagle/db", () => ({
     dogRegistration: {
       findUnique: dogRegistrationFindUniqueMock,
       findMany: dogRegistrationFindManyMock,
+      create: dogRegistrationCreateMock,
       update: dogRegistrationUpdateMock,
-      create: vi.fn(),
       findFirst: vi.fn(),
     },
     dog: {
@@ -86,6 +88,7 @@ describe("runLegacyPhase1", () => {
     breederFindManyMock.mockReset();
     dogRegistrationFindUniqueMock.mockReset();
     dogRegistrationFindManyMock.mockReset();
+    dogRegistrationCreateMock.mockReset();
     dogRegistrationUpdateMock.mockReset();
     dogCreateMock.mockReset();
     dogUpdateMock.mockReset();
@@ -145,6 +148,9 @@ describe("runLegacyPhase1", () => {
     dogRegistrationFindManyMock.mockResolvedValue([
       { registrationNo: "FI12345/21", dogId: "dog-1" },
     ]);
+    dogRegistrationCreateMock.mockResolvedValue({
+      id: "registration-1",
+    });
     dogRegistrationUpdateMock.mockResolvedValue(undefined);
     dogCreateMock.mockResolvedValue({ id: "dog-1" });
     dogUpdateMock.mockResolvedValue(undefined);
@@ -211,6 +217,125 @@ describe("runLegacyPhase1", () => {
       dogUpdateMock.mock.calls.filter(([call]) => "ekNo" in call.data),
     ).toHaveLength(0);
     expect(createImportRunIssuesBulkMock).not.toHaveBeenCalled();
+    expect(createImportRunIssueMock).not.toHaveBeenCalled();
+    expect(markImportRunFinishedMock).toHaveBeenCalledWith(
+      "run-1",
+      expect.objectContaining({
+        status: "SUCCEEDED",
+        errorsCount: 0,
+        errorSummary: null,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("does not record an issue for an empty REK_3 alias slot", async () => {
+    fetchLegacyPhase1RowsMock.mockResolvedValue({
+      dogs: [
+        {
+          registrationNo: "FI12345/21",
+          name: "Aino",
+          sex: "U",
+          birthDateRaw: "20240101",
+          sireRegistrationNo: null,
+          damRegistrationNo: null,
+          breederName: null,
+        },
+      ],
+      breeders: [],
+      eks: [],
+      owners: [],
+      samakoira: [
+        {
+          rek1: "FI12345/21",
+          rek2: "FI99999/21",
+          rek3: null,
+        },
+      ],
+    });
+    dogRegistrationFindUniqueMock.mockImplementation(({ where, select }) => {
+      if (select?.source) {
+        return Promise.resolve(null);
+      }
+      if (where?.registrationNo === "FI99999/21") {
+        return Promise.resolve(null);
+      }
+      return Promise.resolve({ dogId: "dog-1" });
+    });
+
+    const result = await runLegacyPhase1("user-1");
+
+    expect(result.status).toBe(202);
+    expect(dogRegistrationCreateMock).toHaveBeenCalledWith({
+      data: {
+        dogId: "dog-1",
+        registrationNo: "FI99999/21",
+        source: "LEGACY_SAMAKOIRA",
+      },
+    });
+    expect(createImportRunIssuesBulkMock).not.toHaveBeenCalled();
+    expect(createImportRunIssueMock).not.toHaveBeenCalled();
+    expect(markImportRunFinishedMock).toHaveBeenCalledWith(
+      "run-1",
+      expect.objectContaining({
+        status: "SUCCEEDED",
+        errorsCount: 0,
+        errorSummary: null,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("records an empty REK_2 alias slot as a warning", async () => {
+    fetchLegacyPhase1RowsMock.mockResolvedValue({
+      dogs: [
+        {
+          registrationNo: "FI12345/21",
+          name: "Aino",
+          sex: "U",
+          birthDateRaw: "20240101",
+          sireRegistrationNo: null,
+          damRegistrationNo: null,
+          breederName: null,
+        },
+      ],
+      breeders: [],
+      eks: [],
+      owners: [],
+      samakoira: [
+        {
+          rek1: "FI12345/21",
+          rek2: null,
+          rek3: null,
+        },
+      ],
+    });
+    dogRegistrationFindUniqueMock.mockImplementation(({ where, select }) => {
+      if (select?.source) {
+        return Promise.resolve(null);
+      }
+      if (where?.registrationNo === "FI12345/21") {
+        return Promise.resolve({ dogId: "dog-1" });
+      }
+      return Promise.resolve(null);
+    });
+
+    const result = await runLegacyPhase1("user-1");
+
+    expect(result.status).toBe(202);
+    expect(createImportRunIssuesBulkMock).toHaveBeenCalledWith(
+      "run-1",
+      expect.arrayContaining([
+        expect.objectContaining({
+          stage: "samakoira",
+          severity: "WARNING",
+          code: "SAMAKOIRA_ALIAS_EMPTY",
+          registrationNo: "FI12345/21",
+          sourceTable: "samakoira",
+        }),
+      ]),
+      expect.any(Object),
+    );
     expect(createImportRunIssueMock).not.toHaveBeenCalled();
     expect(markImportRunFinishedMock).toHaveBeenCalledWith(
       "run-1",

--- a/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
+++ b/packages/server/imports/phase1/__tests__/run-legacy-phase1.test.ts
@@ -157,10 +157,59 @@ describe("runLegacyPhase1", () => {
     const result = await runLegacyPhase1("user-1");
 
     expect(result.status).toBe(202);
-    expect(dogUpdateMock).toHaveBeenCalledWith({
-      where: { id: "dog-1" },
-      data: { ekNo: 5588 },
+    expect(dogUpdateMock.mock.calls).toEqual(
+      expect.arrayContaining([
+        [
+          {
+            where: { id: "dog-1" },
+            data: { ekNo: 5588 },
+          },
+        ],
+      ]),
+    );
+    expect(
+      dogUpdateMock.mock.calls.some(
+        ([call]) => "ekNo" in call.data && call.data.ekNo === 0,
+      ),
+    ).toBe(false);
+    expect(createImportRunIssuesBulkMock).not.toHaveBeenCalled();
+    expect(createImportRunIssueMock).not.toHaveBeenCalled();
+    expect(markImportRunFinishedMock).toHaveBeenCalledWith(
+      "run-1",
+      expect.objectContaining({
+        status: "SUCCEEDED",
+        errorsCount: 0,
+        errorSummary: null,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("skips a null EK row without writing an EK value", async () => {
+    fetchLegacyPhase1RowsMock.mockResolvedValue({
+      dogs: [
+        {
+          registrationNo: "FI12345/21",
+          name: "Aino",
+          sex: "U",
+          birthDateRaw: "20240101",
+          sireRegistrationNo: null,
+          damRegistrationNo: null,
+          breederName: null,
+        },
+      ],
+      breeders: [],
+      eks: [{ registrationNo: "FI12345/21", ekNo: null }],
+      owners: [],
+      samakoira: [],
     });
+
+    const result = await runLegacyPhase1("user-1");
+
+    expect(result.status).toBe(202);
+    expect(
+      dogUpdateMock.mock.calls.filter(([call]) => "ekNo" in call.data),
+    ).toHaveLength(0);
     expect(createImportRunIssuesBulkMock).not.toHaveBeenCalled();
     expect(createImportRunIssueMock).not.toHaveBeenCalled();
     expect(markImportRunFinishedMock).toHaveBeenCalledWith(

--- a/packages/server/imports/phase1/run-legacy-phase1.ts
+++ b/packages/server/imports/phase1/run-legacy-phase1.ts
@@ -71,6 +71,10 @@ function parseRegistrationNo(value: string | null | undefined): {
   };
 }
 
+function formatPlaceholderRelationMessage(role: "Sire" | "Dam"): string {
+  return `${role} registration is a placeholder and was treated as unknown, so the placeholder reference was not written to the new database.`;
+}
+
 async function loadDogIdByRegistration(): Promise<Map<string, string>> {
   const registrations = await prisma.dogRegistration.findMany({
     select: { registrationNo: true, dogId: true },
@@ -996,8 +1000,7 @@ export async function runLegacyPhase1(
           stage: "relations",
           severity: "INFO",
           code: "RELATION_SIRE_PLACEHOLDER",
-          message:
-            "Sire registration is a placeholder and was treated as unknown.",
+          message: formatPlaceholderRelationMessage("Sire"),
           registrationNo: registration.registrationNo,
           sourceTable: "bearek_id",
           payloadJson: JSON.stringify({
@@ -1012,8 +1015,7 @@ export async function runLegacyPhase1(
           stage: "relations",
           severity: "INFO",
           code: "RELATION_DAM_PLACEHOLDER",
-          message:
-            "Dam registration is a placeholder and was treated as unknown.",
+          message: formatPlaceholderRelationMessage("Dam"),
           registrationNo: registration.registrationNo,
           sourceTable: "bearek_id",
           payloadJson: JSON.stringify({

--- a/packages/server/imports/phase1/run-legacy-phase1.ts
+++ b/packages/server/imports/phase1/run-legacy-phase1.ts
@@ -958,15 +958,18 @@ export async function runLegacyPhase1(
       if (!dogId) {
         relationsSkippedDogNotFound += 1;
         errorsCount += 1;
+        const missingDogName = !normalizeNullable(row.name);
         await recordIssue({
           stage: "relations",
           code: "RELATION_DOG_NOT_FOUND",
-          message:
-            "Relations row references a dog that was not found among imported dogs.",
+          message: missingDogName
+            ? "Dog was not found in the imported dogs index because the source row was skipped earlier due to blank KNIMI, so sire/dam relations were not created."
+            : "Dog was not found in the imported dogs index from the new database, so sire/dam relations were not created.",
           registrationNo: registration.registrationNo,
           sourceTable: "bearek_id",
           payloadJson: JSON.stringify({
             registrationNo: row.registrationNo,
+            dogName: row.name,
             sireRegistrationNo: row.sireRegistrationNo,
             damRegistrationNo: row.damRegistrationNo,
           }),

--- a/packages/server/imports/phase1/run-legacy-phase1.ts
+++ b/packages/server/imports/phase1/run-legacy-phase1.ts
@@ -592,6 +592,14 @@ export async function runLegacyPhase1(
         continue;
       }
 
+      if (row.ekNo == null) {
+        eksSkipped += 1;
+        if (eksProcessed % 1000 === 0) {
+          logProgress("ek", eksProcessed, totalEks);
+        }
+        continue;
+      }
+
       const registration = await prisma.dogRegistration.findUnique({
         where: { registrationNo },
         select: { dogId: true },

--- a/packages/server/imports/phase1/run-legacy-phase1.ts
+++ b/packages/server/imports/phase1/run-legacy-phase1.ts
@@ -572,26 +572,6 @@ export async function runLegacyPhase1(
         continue;
       }
 
-      if (row.ekNo == null) {
-        eksSkipped += 1;
-        await recordIssue({
-          stage: "ek",
-          severity: "INFO",
-          code: "EK_MISSING_EKNO",
-          message: "EK row missing EK number.",
-          registrationNo,
-          sourceTable: "bea_apu",
-          payloadJson: JSON.stringify({
-            registrationNo: row.registrationNo,
-            ekNo: row.ekNo,
-          }),
-        });
-        if (eksProcessed % 1000 === 0) {
-          logProgress("ek", eksProcessed, totalEks);
-        }
-        continue;
-      }
-
       if (isInvalid) {
         eksSkipped += 1;
         errorsCount += 1;

--- a/packages/server/imports/phase1/run-legacy-phase1.ts
+++ b/packages/server/imports/phase1/run-legacy-phase1.ts
@@ -711,18 +711,21 @@ export async function runLegacyPhase1(
       for (const alias of aliases) {
         const parsedAlias = parseRegistrationNo(alias.value);
         if (!parsedAlias.registrationNo) {
-          await recordIssue({
-            stage: "samakoira",
-            severity: "INFO",
-            code: "SAMAKOIRA_ALIAS_EMPTY",
-            message: `Samakoira alias ${alias.key} is empty.`,
-            registrationNo: canonical.registrationNo,
-            sourceTable: "samakoira",
-            payloadJson: JSON.stringify({
-              rek1: canonical.registrationNo,
-              [alias.key]: alias.value,
-            }),
-          });
+          if (alias.key === "REK_2") {
+            await recordIssue({
+              stage: "samakoira",
+              severity: "WARNING",
+              code: "SAMAKOIRA_ALIAS_EMPTY",
+              message: `Samakoira alias ${alias.key} is empty.`,
+              registrationNo: canonical.registrationNo,
+              sourceTable: "samakoira",
+              payloadJson: JSON.stringify({
+                rek1: canonical.registrationNo,
+                [alias.key]: alias.value,
+              }),
+            });
+          }
+          // Missing alias slots are expected in legacy samakoira rows.
           continue;
         }
         if (parsedAlias.isInvalid) {

--- a/packages/server/imports/phase1/run-legacy-phase1.ts
+++ b/packages/server/imports/phase1/run-legacy-phase1.ts
@@ -290,7 +290,7 @@ export async function runLegacyPhase1(
       (row) => row.ekNo != null,
     ).length;
     log(
-      `Loaded legacy rows: dogs=${legacy.dogs.length}, breeders=${legacy.breeders.length}, bea_apuRows=${beaApuRows}, bea_apuRowsWithEkNo=${beaApuRowsWithEkNo}, owners=${legacy.owners.length}, samakoira=${legacy.samakoira.length}`,
+      `Loaded legacy source rows: dogs=${legacy.dogs.length}, breeders=${legacy.breeders.length}, bea_apuRows=${beaApuRows}, bea_apuRowsWithEkNo=${beaApuRowsWithEkNo}, owners=${legacy.owners.length}, samakoira=${legacy.samakoira.length}`,
     );
     finishStage("load");
 

--- a/packages/server/imports/phase1/run-legacy-phase1.ts
+++ b/packages/server/imports/phase1/run-legacy-phase1.ts
@@ -23,6 +23,7 @@ import {
 } from "../core";
 import { toOwnershipDateKey, upsertOwner } from "../internal";
 import { toImportRunResponse } from "../runs/transform";
+import { formatLegacyImportSummary } from "../runs/phase-summary";
 
 const FINNISH_REGISTRATION_PREFIXES = new Set(["FI", "SF"]);
 
@@ -1229,8 +1230,13 @@ export async function runLegacyPhase1(
         trialResultsUpserted,
         showResultsUpserted,
         errorsCount,
-        errorSummary:
-          errorsCount > 0 ? "Import completed with warnings." : null,
+        errorSummary: formatLegacyImportSummary({
+          kind: "LEGACY_PHASE1",
+          dogsUpserted,
+          ownersUpserted,
+          ownershipsUpserted,
+          errorsCount,
+        }),
       },
       auditContext,
     );

--- a/packages/server/imports/phase1/run-legacy-phase1.ts
+++ b/packages/server/imports/phase1/run-legacy-phase1.ts
@@ -285,8 +285,12 @@ export async function runLegacyPhase1(
     const legacy = await fetchLegacyPhase1Rows({
       log: (message) => log(`[stage:load] ${message}`),
     });
+    const beaApuRows = legacy.eks.length;
+    const beaApuRowsWithEkNo = legacy.eks.filter(
+      (row) => row.ekNo != null,
+    ).length;
     log(
-      `Loaded legacy rows: dogs=${legacy.dogs.length}, breeders=${legacy.breeders.length}, eks=${legacy.eks.length}, owners=${legacy.owners.length}, samakoira=${legacy.samakoira.length}`,
+      `Loaded legacy rows: dogs=${legacy.dogs.length}, breeders=${legacy.breeders.length}, bea_apuRows=${beaApuRows}, bea_apuRowsWithEkNo=${beaApuRowsWithEkNo}, owners=${legacy.owners.length}, samakoira=${legacy.samakoira.length}`,
     );
     finishStage("load");
 

--- a/packages/server/imports/phase1_5/__tests__/run-legacy-phase1_5.test.ts
+++ b/packages/server/imports/phase1_5/__tests__/run-legacy-phase1_5.test.ts
@@ -116,7 +116,8 @@ describe("runLegacyPhase1_5", () => {
       expect.objectContaining({
         status: "SUCCEEDED",
         errorsCount: 4,
-        errorSummary: "Import completed with warnings.",
+        errorSummary:
+          "Phase 1.5: titles=1, skippedBlank=1, conflicts=1, errors=4.",
       }),
       expect.any(Object),
     );

--- a/packages/server/imports/phase1_5/run-legacy-phase1_5.ts
+++ b/packages/server/imports/phase1_5/run-legacy-phase1_5.ts
@@ -18,6 +18,7 @@ import {
   normalizeRegistrationNo,
 } from "../core";
 import { toImportRunResponse } from "../runs/transform";
+import { formatLegacyImportSummary } from "../runs/phase-summary";
 
 type TitleCandidate = {
   registrationNo: string;
@@ -361,8 +362,13 @@ export async function runLegacyPhase1_5(
         trialResultsUpserted: 0,
         showResultsUpserted: 0,
         errorsCount,
-        errorSummary:
-          errorsCount > 0 ? "Import completed with warnings." : null,
+        errorSummary: formatLegacyImportSummary({
+          kind: "LEGACY_PHASE1_5",
+          titlesInserted,
+          skippedBlank,
+          conflicts,
+          errorsCount,
+        }),
       },
       auditContext,
     );

--- a/packages/server/imports/phase1_5/run-legacy-phase1_5.ts
+++ b/packages/server/imports/phase1_5/run-legacy-phase1_5.ts
@@ -132,7 +132,7 @@ export async function runLegacyPhase1_5(
     const titleRows = await fetchLegacyPhase1_5Rows({
       log: (message) => log(`[stage:load] ${message}`),
     });
-    log(`Loaded legacy title rows: rows=${titleRows.length}`);
+    log(`Loaded legacy title source rows: total=${titleRows.length}`);
     finishStage("load");
 
     startStage("index");

--- a/packages/server/imports/phase2/run-legacy-phase2.ts
+++ b/packages/server/imports/phase2/run-legacy-phase2.ts
@@ -94,7 +94,7 @@ export async function runLegacyPhase2(
     const trialRows = await fetchLegacyTrialRows({
       log: (message) => log(`[stage:load] ${message}`),
     });
-    log(`Loaded legacy trial rows: trialResults=${trialRows.length}`);
+    log(`Loaded legacy trial source rows: total=${trialRows.length}`);
     finishStage("load");
 
     startStage("index");

--- a/packages/server/imports/phase2/run-legacy-phase2.ts
+++ b/packages/server/imports/phase2/run-legacy-phase2.ts
@@ -13,6 +13,7 @@ import {
 import type { ImportRunResponse } from "@beagle/contracts";
 import type { ServiceResult } from "../../core/result";
 import { upsertTrialRows } from "../internal";
+import { formatLegacyImportSummary } from "../runs/phase-summary";
 import { toImportRunResponse } from "../runs/transform";
 
 // Runs the legacy phase2 trials-only import using current trial schema.
@@ -142,8 +143,11 @@ export async function runLegacyPhase2(
         trialResultsUpserted,
         showResultsUpserted: 0,
         errorsCount,
-        errorSummary:
-          errorsCount > 0 ? "Import completed with warnings." : null,
+        errorSummary: formatLegacyImportSummary({
+          kind: "LEGACY_PHASE2",
+          trialResultsUpserted,
+          errorsCount,
+        }),
       },
       auditContext,
     );

--- a/packages/server/imports/phase3/run-legacy-phase3.ts
+++ b/packages/server/imports/phase3/run-legacy-phase3.ts
@@ -13,6 +13,7 @@ import {
 import type { ImportRunResponse } from "@beagle/contracts";
 import type { ServiceResult } from "../../core/result";
 import { upsertShowRows } from "../internal";
+import { formatLegacyImportSummary } from "../runs/phase-summary";
 import { toImportRunResponse } from "../runs/transform";
 
 // Runs one-shot legacy phase3 initial load into canonical show tables.
@@ -202,8 +203,11 @@ export async function runLegacyPhase3(
         trialResultsUpserted: 0,
         showResultsUpserted,
         errorsCount,
-        errorSummary:
-          errorsCount > 0 ? "Import completed with warnings." : null,
+        errorSummary: formatLegacyImportSummary({
+          kind: "LEGACY_PHASE3",
+          showResultsUpserted,
+          errorsCount,
+        }),
       },
       auditContext,
     );

--- a/packages/server/imports/phase3/run-legacy-phase3.ts
+++ b/packages/server/imports/phase3/run-legacy-phase3.ts
@@ -147,7 +147,7 @@ export async function runLegacyPhase3(
     const showRows = await fetchLegacyShowRows({
       log: (message) => log(`[stage:load] ${message}`),
     });
-    log(`Loaded legacy show rows: showResults=${showRows.length}`);
+    log(`Loaded legacy show source rows: total=${showRows.length}`);
     finishStage("load");
 
     startStage("index");

--- a/packages/server/imports/runs/__tests__/phase-summary.test.ts
+++ b/packages/server/imports/runs/__tests__/phase-summary.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { formatLegacyImportSummary } from "../phase-summary";
+
+describe("formatLegacyImportSummary", () => {
+  it("formats phase1 with the relevant counters only", () => {
+    const summary = formatLegacyImportSummary({
+      kind: "LEGACY_PHASE1",
+      dogsUpserted: 12,
+      ownersUpserted: 3,
+      ownershipsUpserted: 4,
+      errorsCount: 1,
+    });
+
+    expect(summary).toBe("Phase 1: dogs=12, owners=3, ownerships=4, errors=1.");
+    expect(summary).not.toContain("trialResults=");
+    expect(summary).not.toContain("showResults=");
+    expect(summary).not.toContain("titles=");
+  });
+
+  it("formats phase1.5 with title-specific counters", () => {
+    const summary = formatLegacyImportSummary({
+      kind: "LEGACY_PHASE1_5",
+      titlesInserted: 7,
+      skippedBlank: 2,
+      conflicts: 1,
+      errorsCount: 4,
+    });
+
+    expect(summary).toBe(
+      "Phase 1.5: titles=7, skippedBlank=2, conflicts=1, errors=4.",
+    );
+    expect(summary).not.toContain("dogs=");
+    expect(summary).not.toContain("owners=");
+    expect(summary).not.toContain("trialResults=");
+    expect(summary).not.toContain("showResults=");
+  });
+
+  it("formats phase2 with trial counters only", () => {
+    const summary = formatLegacyImportSummary({
+      kind: "LEGACY_PHASE2",
+      trialResultsUpserted: 9,
+      errorsCount: 0,
+    });
+
+    expect(summary).toBe("Phase 2: trialResults=9, errors=0.");
+    expect(summary).not.toContain("dogs=");
+    expect(summary).not.toContain("owners=");
+    expect(summary).not.toContain("titles=");
+    expect(summary).not.toContain("showResults=");
+  });
+
+  it("formats phase3 with show counters only", () => {
+    const summary = formatLegacyImportSummary({
+      kind: "LEGACY_PHASE3",
+      showResultsUpserted: 11,
+      errorsCount: 6,
+    });
+
+    expect(summary).toBe("Phase 3: showResults=11, errors=6.");
+    expect(summary).not.toContain("dogs=");
+    expect(summary).not.toContain("owners=");
+    expect(summary).not.toContain("titles=");
+    expect(summary).not.toContain("trialResults=");
+  });
+});

--- a/packages/server/imports/runs/index.ts
+++ b/packages/server/imports/runs/index.ts
@@ -1,2 +1,3 @@
 export { createImportsService, importsService } from "./service";
 export { toImportRunIssueResponse, toImportRunResponse } from "./transform";
+export { formatLegacyImportSummary } from "./phase-summary";

--- a/packages/server/imports/runs/phase-summary.ts
+++ b/packages/server/imports/runs/phase-summary.ts
@@ -1,0 +1,68 @@
+import { ImportKind } from "@beagle/db";
+
+type LegacyImportKind =
+  | "LEGACY_PHASE1"
+  | "LEGACY_PHASE1_5"
+  | "LEGACY_PHASE2"
+  | "LEGACY_PHASE3";
+
+type LegacyImportSummaryInput =
+  | {
+      kind: "LEGACY_PHASE1";
+      dogsUpserted: number;
+      ownersUpserted: number;
+      ownershipsUpserted: number;
+      errorsCount: number;
+    }
+  | {
+      kind: "LEGACY_PHASE1_5";
+      titlesInserted: number;
+      skippedBlank: number;
+      conflicts: number;
+      errorsCount: number;
+    }
+  | {
+      kind: "LEGACY_PHASE2";
+      trialResultsUpserted: number;
+      errorsCount: number;
+    }
+  | {
+      kind: "LEGACY_PHASE3";
+      showResultsUpserted: number;
+      errorsCount: number;
+    };
+
+function formatMetric(label: string, value: number): string {
+  return `${label}=${value}`;
+}
+
+function toPhaseLabel(kind: LegacyImportKind): string {
+  switch (kind) {
+    case ImportKind.LEGACY_PHASE1:
+      return "Phase 1";
+    case ImportKind.LEGACY_PHASE1_5:
+      return "Phase 1.5";
+    case ImportKind.LEGACY_PHASE2:
+      return "Phase 2";
+    case ImportKind.LEGACY_PHASE3:
+      return "Phase 3";
+  }
+}
+
+// Formats the final, human-facing summary stored on each legacy import run.
+export function formatLegacyImportSummary(
+  input: LegacyImportSummaryInput,
+): string {
+  const phaseLabel = toPhaseLabel(input.kind);
+
+  switch (input.kind) {
+    case ImportKind.LEGACY_PHASE1:
+      return `${phaseLabel}: ${formatMetric("dogs", input.dogsUpserted)}, ${formatMetric("owners", input.ownersUpserted)}, ${formatMetric("ownerships", input.ownershipsUpserted)}, ${formatMetric("errors", input.errorsCount)}.`;
+    case ImportKind.LEGACY_PHASE1_5:
+      return `${phaseLabel}: ${formatMetric("titles", input.titlesInserted)}, ${formatMetric("skippedBlank", input.skippedBlank)}, ${formatMetric("conflicts", input.conflicts)}, ${formatMetric("errors", input.errorsCount)}.`;
+    case ImportKind.LEGACY_PHASE2:
+      return `${phaseLabel}: ${formatMetric("trialResults", input.trialResultsUpserted)}, ${formatMetric("errors", input.errorsCount)}.`;
+    case ImportKind.LEGACY_PHASE3:
+      return `${phaseLabel}: ${formatMetric("showResults", input.showResultsUpserted)}, ${formatMetric("errors", input.errorsCount)}.`;
+  }
+}

--- a/packages/server/scripts/imports/internal/__tests__/issue-summary.test.ts
+++ b/packages/server/scripts/imports/internal/__tests__/issue-summary.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  createImportIssueSummaryCollector,
+  formatImportIssueSummary,
+} from "../issue-summary";
+
+describe("issue summary formatter", () => {
+  it("collects run totals, top codes, and samples incrementally", () => {
+    const collector = createImportIssueSummaryCollector();
+    collector.add({
+      stage: "dogs",
+      severity: "WARNING",
+      code: "DOG_MISSING_REQUIRED_FIELDS",
+      message: "dog issue",
+      registrationNo: "FI-1/20",
+      sourceTable: "bearek_id",
+      payloadJson: null,
+    });
+    collector.add({
+      stage: "run",
+      severity: "ERROR",
+      code: "UNEXPECTED_EXCEPTION",
+      message: "run failed",
+      registrationNo: null,
+      sourceTable: null,
+      payloadJson: null,
+    });
+    collector.add({
+      stage: "owners",
+      severity: "WARNING",
+      code: "OWNER_MISSING_REQUIRED_FIELDS",
+      message: "owner issue",
+      registrationNo: "FI-2/20",
+      sourceTable: "beaom",
+      payloadJson: null,
+    });
+
+    const summary = collector.build();
+
+    expect(summary.total).toBe(3);
+    expect(summary.topCodes).toEqual([
+      { code: "DOG_MISSING_REQUIRED_FIELDS", count: 1 },
+      { code: "OWNER_MISSING_REQUIRED_FIELDS", count: 1 },
+      { code: "UNEXPECTED_EXCEPTION", count: 1 },
+    ]);
+    expect(summary.samples).toHaveLength(3);
+  });
+
+  it("formats run-level issue summary lines", () => {
+    const collector = createImportIssueSummaryCollector();
+    collector.add({
+      stage: "trials",
+      severity: "WARNING",
+      code: "TRIAL_REGISTRATION_INVALID_FORMAT",
+      message: "trial issue",
+      registrationNo: "bad",
+      sourceTable: "akoeall",
+      payloadJson: null,
+    });
+
+    const lines = formatImportIssueSummary(collector.build());
+
+    expect(lines).toEqual([
+      "Issue summary: total=1",
+      "Top issue codes:",
+      "  TRIAL_REGISTRATION_INVALID_FORMAT = 1",
+      "Sample issues:",
+      "  [trials/WARNING/TRIAL_REGISTRATION_INVALID_FORMAT] reg=bad table=akoeall msg=trial issue",
+    ]);
+  });
+});

--- a/packages/server/scripts/imports/internal/issue-summary.ts
+++ b/packages/server/scripts/imports/internal/issue-summary.ts
@@ -1,0 +1,93 @@
+type ImportIssueRow = {
+  stage: string;
+  severity: string;
+  code: string;
+  message: string;
+  registrationNo: string | null;
+  sourceTable: string | null;
+  payloadJson: string | null;
+};
+
+export type ImportIssueSummary = {
+  total: number;
+  topCodes: Array<{ code: string; count: number }>;
+  samples: ImportIssueRow[];
+};
+
+type ImportIssueSummaryCollector = {
+  add(issue: ImportIssueRow): void;
+  build(): ImportIssueSummary;
+};
+
+function sortedTopCodes(codeCounts: Map<string, number>): Array<{
+  code: string;
+  count: number;
+}> {
+  return [...codeCounts.entries()]
+    .map(([code, count]) => ({ code, count }))
+    .sort((left, right) => {
+      if (right.count !== left.count) return right.count - left.count;
+      return left.code.localeCompare(right.code);
+    })
+    .slice(0, 3);
+}
+
+// Collects a run-level issue summary while the script streams through pages.
+export function createImportIssueSummaryCollector(): ImportIssueSummaryCollector {
+  const codeCounts = new Map<string, number>();
+  const samples: ImportIssueRow[] = [];
+  let total = 0;
+
+  return {
+    add(issue) {
+      total += 1;
+      codeCounts.set(issue.code, (codeCounts.get(issue.code) ?? 0) + 1);
+      if (samples.length < 10) {
+        samples.push(issue);
+      }
+    },
+    build() {
+      return {
+        total,
+        topCodes: sortedTopCodes(codeCounts),
+        samples: [...samples],
+      };
+    },
+  };
+}
+
+export function formatImportIssueSummary(
+  summary: ImportIssueSummary,
+): string[] {
+  const lines: string[] = [];
+  if (summary.total === 0) {
+    return lines;
+  }
+
+  lines.push(`Issue summary: total=${summary.total}`);
+
+  if (summary.topCodes.length > 0) {
+    lines.push(`Top issue codes:`);
+    for (const topCode of summary.topCodes) {
+      lines.push(`  ${topCode.code} = ${topCode.count}`);
+    }
+  }
+
+  if (summary.samples.length > 0) {
+    lines.push(`Sample issues:`);
+    for (const sample of summary.samples) {
+      lines.push(
+        `  [${sample.stage}/${sample.severity}/${sample.code}] reg=${sample.registrationNo ?? "-"} table=${sample.sourceTable ?? "-"} msg=${sample.message}`,
+      );
+      if (sample.payloadJson) {
+        const trimmed =
+          sample.payloadJson.length > 500
+            ? `${sample.payloadJson.slice(0, 500)}...`
+            : sample.payloadJson;
+        lines.push(`    payload=${trimmed}`);
+      }
+    }
+  }
+
+  return lines;
+}

--- a/packages/server/scripts/imports/internal/run-import-phase.ts
+++ b/packages/server/scripts/imports/internal/run-import-phase.ts
@@ -1,4 +1,8 @@
-import { listImportRunIssues, prisma } from "@beagle/db";
+import { getImportRunById, listImportRunIssues, prisma } from "@beagle/db";
+import {
+  createImportIssueSummaryCollector,
+  formatImportIssueSummary,
+} from "./issue-summary";
 
 type RunResult = {
   ok: boolean;
@@ -31,7 +35,6 @@ export async function runImportPhase(
   console.log(
     `[import:${phaseLabel}] Completed in ${Math.round((Date.now() - start) / 1000)}s`,
   );
-  console.log(JSON.stringify(output, null, 2));
 
   const runIdFromError =
     !output.ok &&
@@ -55,30 +58,27 @@ export async function runImportPhase(
       : runIdFromError;
 
   if (runId) {
-    const grouped = new Map<string, number>();
-    const samples: Array<{
-      stage: string;
-      severity: string;
-      code: string;
-      message: string;
-      registrationNo: string | null;
-      sourceTable: string | null;
-      payloadJson: string | null;
-    }> = [];
-    let cursor: string | undefined;
-    let total = 0;
+    try {
+      const run = await getImportRunById(runId);
+      if (run) {
+        console.log(
+          `[import:${phaseLabel}] Summary: ${run.errorSummary ?? "No final summary available."}`,
+        );
+        console.log(
+          `[import:${phaseLabel}] Run stats: status=${run.status} errors=${run.errorsCount} issues=${run.issuesCount}`,
+        );
+      }
 
-    do {
-      const page = await listImportRunIssues(runId, {
-        limit: 500,
-        cursor,
-      });
-      for (const issue of page.items) {
-        total += 1;
-        const key = `${issue.stage}:${issue.severity}:${issue.code}`;
-        grouped.set(key, (grouped.get(key) ?? 0) + 1);
-        if (samples.length < 10) {
-          samples.push({
+      const collector = createImportIssueSummaryCollector();
+      let cursor: string | undefined;
+
+      do {
+        const page = await listImportRunIssues(runId, {
+          limit: 500,
+          cursor,
+        });
+        for (const issue of page.items) {
+          collector.add({
             stage: issue.stage,
             severity: issue.severity,
             code: issue.code,
@@ -88,31 +88,20 @@ export async function runImportPhase(
             payloadJson: issue.payloadJson,
           });
         }
-      }
-      cursor = page.nextCursor ?? undefined;
-    } while (cursor);
+        cursor = page.nextCursor ?? undefined;
+      } while (cursor);
 
-    if (total > 0) {
-      console.log(`[import:${phaseLabel}] Issue rows stored: ${total}`);
-      console.log(`[import:${phaseLabel}] Issue groups:`);
-      for (const [key, count] of [...grouped.entries()].sort(
-        (a, b) => b[1] - a[1],
-      )) {
-        console.log(`[import:${phaseLabel}]   ${key} = ${count}`);
-      }
-      console.log(`[import:${phaseLabel}] Issue samples:`);
-      for (const sample of samples) {
-        console.log(
-          `[import:${phaseLabel}]   [${sample.stage}/${sample.severity}/${sample.code}] reg=${sample.registrationNo ?? "-"} table=${sample.sourceTable ?? "-"} msg=${sample.message}`,
-        );
-        if (sample.payloadJson) {
-          const trimmed =
-            sample.payloadJson.length > 500
-              ? `${sample.payloadJson.slice(0, 500)}...`
-              : sample.payloadJson;
-          console.log(`[import:${phaseLabel}]     payload=${trimmed}`);
+      const summary = collector.build();
+      if (summary.total > 0) {
+        for (const line of formatImportIssueSummary(summary)) {
+          console.log(`[import:${phaseLabel}] ${line}`);
         }
       }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      console.log(
+        `[import:${phaseLabel}] Skipped post-run summary due to error: ${message}`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- Add phase-aware final summaries for legacy import runs across phases 1, 1.5, 2, and 3.
- Improve import issue reporting by collecting run-level issue totals, top codes, and sample issue rows in script output.
- Update legacy import docs to reflect the current phase flow and issue tooling behavior.

## Checklist

- [ ] This PR includes user-visible changes.
- [x] If changelog update is not needed, this PR is internal-only (`refactor` / `test` / `chore`) and I explained why in the PR description.


ref BEJ-65
