### PR TITLE
Lock AJOK flow-gate contract baseline for BEJ-78

### DIFF
--- a/apps/web/components/admin/trials/__tests__/admin-trial-details-page-client.test.tsx
+++ b/apps/web/components/admin/trials/__tests__/admin-trial-details-page-client.test.tsx
@@ -117,7 +117,7 @@ describe("AdminTrialDetailsPageClient", () => {
           eventDate: "2026-04-14",
           eventName: "Kevätkoe",
           eventPlace: "Helsinki",
-          kennelDistrict: "Etelä",
+          kennelDistrict: null,
           kennelDistrictNo: "01",
           ke: "KE",
           lk: "A",
@@ -157,6 +157,11 @@ describe("AdminTrialDetailsPageClient", () => {
     expect(html).toContain("admin.trials.detail.sections.scoreBreakdown");
     expect(html).toContain("admin.trials.detail.sections.metadata");
     expect(html).toContain("admin.trials.detail.sections.raw");
+    expect(html).toContain("admin.trials.validation.title");
+    expect(html).toContain("admin.trials.validation.sections.missing");
+    expect(html).toContain("admin.trials.validation.sections.incomplete");
+    expect(html).toContain("sklKoeId");
+    expect(html).toContain("kennelpiiri");
     expect(html).toContain("Rex");
     expect(html).toContain("source-1");
     expect(html).toContain("admin.trials.detail.raw.unavailable");

--- a/apps/web/components/admin/trials/__tests__/admin-trials-page-client.test.tsx
+++ b/apps/web/components/admin/trials/__tests__/admin-trials-page-client.test.tsx
@@ -96,6 +96,10 @@ describe("AdminTrialsPageClient", () => {
     expect(html).toContain("admin.trials.manage.columns.judge");
     expect(html).toContain("admin.trials.manage.results.openDetailHint");
     expect(html).toContain("admin.trials.manage.results.openDetailAriaPrefix");
+    expect(html).toContain("admin.trials.validation.title");
+    expect(html).toContain("admin.trials.validation.sections.missing");
+    expect(html).toContain("admin.trials.validation.incomplete.notEvaluated");
+    expect(html).toContain("sklKoeId");
     expect(html).toContain("Rex");
     expect(html).toContain("FI123");
     expect(html).toContain("src-1");

--- a/apps/web/components/admin/trials/admin-trial-details-page-client.tsx
+++ b/apps/web/components/admin/trials/admin-trial-details-page-client.tsx
@@ -9,6 +9,7 @@ import {
   isAdminTrialQueryError,
   useAdminTrialQuery,
 } from "@/queries/admin/trials";
+import { AdminTrialValidationPanel } from "./admin-trial-validation-panel";
 
 function showDash(value: string | number | null | undefined): string {
   if (value === null || value === undefined) {
@@ -97,217 +98,224 @@ export function AdminTrialDetailsPageClient({
         title={t("admin.trials.detail.section.title")}
         subtitle={t("admin.trials.detail.section.subtitle")}
       >
-        {!normalizedTrialId ? (
-          <Card>
-            <CardContent className="p-5 text-sm text-destructive">
-              {t("admin.trials.detail.state.invalid")}
-            </CardContent>
-          </Card>
-        ) : trialQuery.isLoading ? (
-          <Card>
-            <CardContent className="p-5 text-sm text-muted-foreground">
-              {t("admin.trials.detail.state.loading")}
-            </CardContent>
-          </Card>
-        ) : trialQuery.isError && isNotFoundError ? (
-          <Card>
-            <CardContent className="p-5 text-sm text-muted-foreground">
-              {t("admin.trials.detail.state.notFound")}
-            </CardContent>
-          </Card>
-        ) : trialQuery.isError ? (
-          <Card>
-            <CardContent className="p-5 text-sm text-destructive">
-              {detailErrorMessage}
-            </CardContent>
-          </Card>
-        ) : !trial ? (
-          <Card>
-            <CardContent className="p-5 text-sm text-muted-foreground">
-              {t("admin.trials.detail.state.notFound")}
-            </CardContent>
-          </Card>
-        ) : (
-          <Card>
-            <CardContent className="space-y-4 pt-5">
-              <div className="space-y-2">
-                <SectionTitle>
-                  {t("admin.trials.detail.sections.trialInfo")}
-                </SectionTitle>
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.eventDate")}
-                    value={formatDateForFinland(trial.eventDate)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.eventPlace")}
-                    value={showDash(trial.eventPlace)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.eventName")}
-                    value={showDash(trial.eventName)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.kennelDistrict")}
-                    value={showDash(trial.kennelDistrict)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.kennelDistrictNo")}
-                    value={showDash(trial.kennelDistrictNo)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.judge")}
-                    value={showDash(trial.judge)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.ke")}
-                    value={showDash(trial.ke)}
-                  />
-                </div>
-              </div>
-
-              <Separator />
-
-              <div className="space-y-2">
-                <SectionTitle>
-                  {t("admin.trials.detail.sections.dogInfo")}
-                </SectionTitle>
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.dogName")}
-                    value={showDash(trial.dogName)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.registrationNo")}
-                    value={showDash(trial.registrationNo)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.dogId")}
-                    value={showDash(trial.dogId)}
-                  />
-                </div>
-              </div>
-
-              <Separator />
-
-              <div className="space-y-2">
-                <SectionTitle>
-                  {t("admin.trials.detail.sections.resultSummary")}
-                </SectionTitle>
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.lk")}
-                    value={showDash(trial.lk)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.pa")}
-                    value={showDash(trial.pa)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.sija")}
-                    value={showDash(trial.sija)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.piste")}
-                    value={formatNumber(trial.piste)}
-                  />
-                </div>
-              </div>
-
-              <Separator />
-
-              <div className="space-y-2">
-                <SectionTitle>
-                  {t("admin.trials.detail.sections.scoreBreakdown")}
-                </SectionTitle>
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.haku")}
-                    value={formatNumber(trial.haku)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.hauk")}
-                    value={formatNumber(trial.hauk)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.yva")}
-                    value={formatNumber(trial.yva)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.hlo")}
-                    value={formatNumber(trial.hlo)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.alo")}
-                    value={formatNumber(trial.alo)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.tja")}
-                    value={formatNumber(trial.tja)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.pin")}
-                    value={formatNumber(trial.pin)}
-                  />
-                </div>
-              </div>
-
-              <Separator />
-
-              <div className="space-y-2">
-                <SectionTitle>
-                  {t("admin.trials.detail.sections.metadata")}
-                </SectionTitle>
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.trialId")}
-                    value={showDash(trial.trialId)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.sourceKey")}
-                    value={showDash(trial.sourceKey)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.legacyFlag")}
-                    value={showDash(trial.legacyFlag)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.createdAt")}
-                    value={formatTimestamp(trial.createdAt)}
-                  />
-                  <FieldRow
-                    label={t("admin.trials.detail.fields.updatedAt")}
-                    value={formatTimestamp(trial.updatedAt)}
-                  />
-                </div>
-              </div>
-
-              <Separator />
-
-              <div className="space-y-2">
-                <SectionTitle>
-                  {t("admin.trials.detail.sections.raw")}
-                </SectionTitle>
-                <details>
-                  <summary className="cursor-pointer text-sm underline-offset-2 hover:underline">
-                    {t("admin.trials.detail.raw.toggle")}
-                  </summary>
-                  <div className="mt-3">
-                    {trial.rawPayloadAvailable && trial.rawPayloadJson ? (
-                      <pre className="overflow-x-auto rounded-md bg-muted p-3 text-xs">
-                        {trial.rawPayloadJson}
-                      </pre>
-                    ) : (
-                      <p className="text-sm text-muted-foreground">
-                        {t("admin.trials.detail.raw.unavailable")}
-                      </p>
-                    )}
+        <div className="space-y-4">
+          {!normalizedTrialId ? (
+            <Card>
+              <CardContent className="p-5 text-sm text-destructive">
+                {t("admin.trials.detail.state.invalid")}
+              </CardContent>
+            </Card>
+          ) : trialQuery.isLoading ? (
+            <Card>
+              <CardContent className="p-5 text-sm text-muted-foreground">
+                {t("admin.trials.detail.state.loading")}
+              </CardContent>
+            </Card>
+          ) : trialQuery.isError && isNotFoundError ? (
+            <Card>
+              <CardContent className="p-5 text-sm text-muted-foreground">
+                {t("admin.trials.detail.state.notFound")}
+              </CardContent>
+            </Card>
+          ) : trialQuery.isError ? (
+            <Card>
+              <CardContent className="p-5 text-sm text-destructive">
+                {detailErrorMessage}
+              </CardContent>
+            </Card>
+          ) : !trial ? (
+            <Card>
+              <CardContent className="p-5 text-sm text-muted-foreground">
+                {t("admin.trials.detail.state.notFound")}
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="space-y-4 pt-5">
+                <div className="space-y-2">
+                  <SectionTitle>
+                    {t("admin.trials.detail.sections.trialInfo")}
+                  </SectionTitle>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.eventDate")}
+                      value={formatDateForFinland(trial.eventDate)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.eventPlace")}
+                      value={showDash(trial.eventPlace)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.eventName")}
+                      value={showDash(trial.eventName)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.kennelDistrict")}
+                      value={showDash(trial.kennelDistrict)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.kennelDistrictNo")}
+                      value={showDash(trial.kennelDistrictNo)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.judge")}
+                      value={showDash(trial.judge)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.ke")}
+                      value={showDash(trial.ke)}
+                    />
                   </div>
-                </details>
-              </div>
-            </CardContent>
-          </Card>
-        )}
+                </div>
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <SectionTitle>
+                    {t("admin.trials.detail.sections.dogInfo")}
+                  </SectionTitle>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.dogName")}
+                      value={showDash(trial.dogName)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.registrationNo")}
+                      value={showDash(trial.registrationNo)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.dogId")}
+                      value={showDash(trial.dogId)}
+                    />
+                  </div>
+                </div>
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <SectionTitle>
+                    {t("admin.trials.detail.sections.resultSummary")}
+                  </SectionTitle>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.lk")}
+                      value={showDash(trial.lk)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.pa")}
+                      value={showDash(trial.pa)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.sija")}
+                      value={showDash(trial.sija)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.piste")}
+                      value={formatNumber(trial.piste)}
+                    />
+                  </div>
+                </div>
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <SectionTitle>
+                    {t("admin.trials.detail.sections.scoreBreakdown")}
+                  </SectionTitle>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.haku")}
+                      value={formatNumber(trial.haku)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.hauk")}
+                      value={formatNumber(trial.hauk)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.yva")}
+                      value={formatNumber(trial.yva)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.hlo")}
+                      value={formatNumber(trial.hlo)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.alo")}
+                      value={formatNumber(trial.alo)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.tja")}
+                      value={formatNumber(trial.tja)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.pin")}
+                      value={formatNumber(trial.pin)}
+                    />
+                  </div>
+                </div>
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <SectionTitle>
+                    {t("admin.trials.detail.sections.metadata")}
+                  </SectionTitle>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.trialId")}
+                      value={showDash(trial.trialId)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.sourceKey")}
+                      value={showDash(trial.sourceKey)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.legacyFlag")}
+                      value={showDash(trial.legacyFlag)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.createdAt")}
+                      value={formatTimestamp(trial.createdAt)}
+                    />
+                    <FieldRow
+                      label={t("admin.trials.detail.fields.updatedAt")}
+                      value={formatTimestamp(trial.updatedAt)}
+                    />
+                  </div>
+                </div>
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <SectionTitle>
+                    {t("admin.trials.detail.sections.raw")}
+                  </SectionTitle>
+                  <details>
+                    <summary className="cursor-pointer text-sm underline-offset-2 hover:underline">
+                      {t("admin.trials.detail.raw.toggle")}
+                    </summary>
+                    <div className="mt-3">
+                      {trial.rawPayloadAvailable && trial.rawPayloadJson ? (
+                        <pre className="overflow-x-auto rounded-md bg-muted p-3 text-xs">
+                          {trial.rawPayloadJson}
+                        </pre>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">
+                          {t("admin.trials.detail.raw.unavailable")}
+                        </p>
+                      )}
+                    </div>
+                  </details>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          <AdminTrialValidationPanel
+            context="detail"
+            trial={!trialQuery.isError && !trialQuery.isLoading ? trial : null}
+          />
+        </div>
       </ListingSectionShell>
     </div>
   );

--- a/apps/web/components/admin/trials/admin-trial-validation-panel.tsx
+++ b/apps/web/components/admin/trials/admin-trial-validation-panel.tsx
@@ -8,25 +8,20 @@ import {
   type TrialValidationGapItem,
 } from "@/lib/admin/trials/manage";
 
-function groupLabelKey(group: TrialValidationGapItem["group"]): string {
-  switch (group) {
-    case "event":
-      return "admin.trials.validation.groups.event";
-    case "dog":
-      return "admin.trials.validation.groups.dog";
-    case "result":
-      return "admin.trials.validation.groups.result";
-    case "conditions":
-      return "admin.trials.validation.groups.conditions";
-    case "status":
-      return "admin.trials.validation.groups.status";
-    case "additional":
-      return "admin.trials.validation.groups.additional";
-    case "judges":
-      return "admin.trials.validation.groups.judges";
-    default:
-      return "admin.trials.validation.groups.result";
-  }
+const GROUP_LABEL_KEYS = {
+  event: "admin.trials.validation.groups.event",
+  dog: "admin.trials.validation.groups.dog",
+  result: "admin.trials.validation.groups.result",
+  conditions: "admin.trials.validation.groups.conditions",
+  status: "admin.trials.validation.groups.status",
+  additional: "admin.trials.validation.groups.additional",
+  judges: "admin.trials.validation.groups.judges",
+} as const;
+
+function groupLabelKey(
+  group: TrialValidationGapItem["group"],
+): (typeof GROUP_LABEL_KEYS)[TrialValidationGapItem["group"]] {
+  return GROUP_LABEL_KEYS[group];
 }
 
 function GapList({ items }: { items: TrialValidationGapItem[] }) {

--- a/apps/web/components/admin/trials/admin-trial-validation-panel.tsx
+++ b/apps/web/components/admin/trials/admin-trial-validation-panel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import type { AdminTrialDetails } from "@beagle/contracts";
+import { Card, CardContent } from "@/components/ui/card";
+import { useI18n } from "@/hooks/i18n";
+import {
+  evaluateTrialValidationGaps,
+  type TrialValidationGapItem,
+} from "@/lib/admin/trials/manage";
+
+function groupLabelKey(group: TrialValidationGapItem["group"]): string {
+  switch (group) {
+    case "event":
+      return "admin.trials.validation.groups.event";
+    case "dog":
+      return "admin.trials.validation.groups.dog";
+    case "result":
+      return "admin.trials.validation.groups.result";
+    case "conditions":
+      return "admin.trials.validation.groups.conditions";
+    case "status":
+      return "admin.trials.validation.groups.status";
+    case "additional":
+      return "admin.trials.validation.groups.additional";
+    case "judges":
+      return "admin.trials.validation.groups.judges";
+    default:
+      return "admin.trials.validation.groups.result";
+  }
+}
+
+function GapList({ items }: { items: TrialValidationGapItem[] }) {
+  const { t } = useI18n();
+
+  return (
+    <ul className="space-y-1 text-sm">
+      {items.map((item) => (
+        <li key={`${item.status}-${item.targetField}`}>
+          <span className="text-muted-foreground">
+            {t(groupLabelKey(item.group))}:
+          </span>{" "}
+          <code>{item.targetField}</code>
+          {item.sourceField ? (
+            <span className="text-muted-foreground"> ({item.sourceField})</span>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+type AdminTrialValidationPanelProps = {
+  trial?: AdminTrialDetails | null;
+  context: "detail" | "search";
+};
+
+export function AdminTrialValidationPanel({
+  trial,
+  context,
+}: AdminTrialValidationPanelProps) {
+  const { t } = useI18n();
+  const evaluation = evaluateTrialValidationGaps(trial);
+  const isDetailContext = context === "detail";
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 p-5">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold">
+            {t("admin.trials.validation.title")}
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            {isDetailContext
+              ? t("admin.trials.validation.description.detail")
+              : t("admin.trials.validation.description.search")}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {t("admin.trials.validation.summary.totalPrefix")}{" "}
+            {evaluation.totalFieldCount} •{" "}
+            {t("admin.trials.validation.summary.availablePrefix")}{" "}
+            {evaluation.availableCount} •{" "}
+            {t("admin.trials.validation.summary.missingPrefix")}{" "}
+            {evaluation.missingFromModel.length}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <h4 className="text-sm font-medium">
+            {t("admin.trials.validation.sections.missing")}
+          </h4>
+          {evaluation.missingFromModel.length > 0 ? (
+            <GapList items={evaluation.missingFromModel} />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {t("admin.trials.validation.empty.missing")}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <h4 className="text-sm font-medium">
+            {t("admin.trials.validation.sections.incomplete")}
+          </h4>
+          {!isDetailContext ? (
+            <p className="text-sm text-muted-foreground">
+              {t("admin.trials.validation.incomplete.notEvaluated")}
+            </p>
+          ) : evaluation.availableButIncomplete.length > 0 ? (
+            <GapList items={evaluation.availableButIncomplete} />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {t("admin.trials.validation.empty.incomplete")}
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/admin/trials/admin-trials-page-client.tsx
+++ b/apps/web/components/admin/trials/admin-trials-page-client.tsx
@@ -13,6 +13,7 @@ import { useI18n } from "@/hooks/i18n";
 import { formatDateForFinland } from "@/lib/admin/core/date";
 import { useAdminTrialsQuery } from "@/queries/admin/trials";
 import { cn } from "@/lib/utils";
+import { AdminTrialValidationPanel } from "./admin-trial-validation-panel";
 
 function showDash(value: string | number | null | undefined): string {
   if (value === null || value === undefined) {
@@ -113,6 +114,8 @@ export function AdminTrialsPageClient() {
           {!trialsQuery.isLoading && !trialsQuery.isError ? (
             <TrialResults trials={trials} />
           ) : null}
+
+          <AdminTrialValidationPanel context="search" />
         </div>
       </ListingSectionShell>
     </div>

--- a/apps/web/components/admin/trials/index.ts
+++ b/apps/web/components/admin/trials/index.ts
@@ -1,2 +1,3 @@
 export { AdminTrialDetailsPageClient } from "./admin-trial-details-page-client";
 export { AdminTrialsPageClient } from "./admin-trials-page-client";
+export { AdminTrialValidationPanel } from "./admin-trial-validation-panel";

--- a/apps/web/lib/admin/trials/manage/__tests__/trial-field-contract.test.ts
+++ b/apps/web/lib/admin/trials/manage/__tests__/trial-field-contract.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  AJOK_MINIMUM_PRE_SWITCH_FIELDS,
+  TRIAL_FIELD_CONTRACT_CATALOG,
+  countTrialFieldContractStatuses,
+} from "../trial-field-contract";
+
+describe("TRIAL_FIELD_CONTRACT_CATALOG", () => {
+  it("includes each AJOK target field exactly once", () => {
+    const keys = TRIAL_FIELD_CONTRACT_CATALOG.map((item) => item.targetField);
+    const unique = new Set(keys);
+
+    expect(unique.size).toBe(keys.length);
+  });
+
+  it("keeps source field mapping strict by status", () => {
+    for (const item of TRIAL_FIELD_CONTRACT_CATALOG) {
+      if (item.status === "typed-now") {
+        expect(item.sourceField).not.toBeNull();
+      } else {
+        expect(item.sourceField).toBeNull();
+      }
+    }
+  });
+
+  it("matches locked baseline status counts", () => {
+    expect(countTrialFieldContractStatuses()).toEqual({
+      "typed-now": 16,
+      "raw-only": 8,
+      missing: 26,
+    });
+  });
+
+  it("contains minimum pre-switch fields in the catalog", () => {
+    const targetFieldSet = new Set(
+      TRIAL_FIELD_CONTRACT_CATALOG.map((item) => item.targetField),
+    );
+
+    for (const targetField of AJOK_MINIMUM_PRE_SWITCH_FIELDS) {
+      expect(targetFieldSet.has(targetField)).toBe(true);
+    }
+  });
+});

--- a/apps/web/lib/admin/trials/manage/__tests__/trial-flow-gate.test.ts
+++ b/apps/web/lib/admin/trials/manage/__tests__/trial-flow-gate.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  AJOK_MINIMUM_PRE_SWITCH_FIELDS,
+  TRIAL_FIELD_CONTRACT_CATALOG,
+  type TrialFieldContractItem,
+} from "../trial-field-contract";
+import { evaluateTrialFlowGate } from "../trial-flow-gate";
+
+describe("evaluateTrialFlowGate", () => {
+  it("passes when all minimum required fields are typed-now", () => {
+    const evaluation = evaluateTrialFlowGate();
+
+    expect(evaluation.isReadyForReadSwitch).toBe(true);
+    expect(evaluation.blockingFields).toEqual([]);
+    expect(evaluation.minimumRequiredFields).toEqual(
+      AJOK_MINIMUM_PRE_SWITCH_FIELDS,
+    );
+  });
+
+  it("fails with deterministic blocking fields when a required field drifts", () => {
+    const driftedCatalog: TrialFieldContractItem[] =
+      TRIAL_FIELD_CONTRACT_CATALOG.map((item) => {
+        if (
+          item.targetField !== "koepaiva" &&
+          item.targetField !== "sijoitus"
+        ) {
+          return item;
+        }
+
+        return {
+          ...item,
+          status: "missing",
+          sourceField: null,
+          followUpTicket: "BEJ-79",
+        };
+      });
+
+    const evaluation = evaluateTrialFlowGate({
+      catalog: driftedCatalog,
+      minimumRequiredFields: ["sijoitus", "koepaiva"],
+    });
+
+    expect(evaluation.isReadyForReadSwitch).toBe(false);
+    expect(evaluation.blockingFields.map((item) => item.targetField)).toEqual([
+      "koepaiva",
+      "sijoitus",
+    ]);
+  });
+
+  it("updates status counts when statuses change in a fixture", () => {
+    const driftedCatalog: TrialFieldContractItem[] =
+      TRIAL_FIELD_CONTRACT_CATALOG.map((item) => {
+        if (item.targetField !== "jarjestaja") {
+          return item;
+        }
+
+        return {
+          ...item,
+          status: "missing",
+          sourceField: null,
+        };
+      });
+
+    const evaluation = evaluateTrialFlowGate({ catalog: driftedCatalog });
+
+    expect(evaluation.statusCounts).toEqual({
+      "typed-now": 16,
+      "raw-only": 7,
+      missing: 27,
+    });
+  });
+});

--- a/apps/web/lib/admin/trials/manage/__tests__/trial-validation-gaps.test.ts
+++ b/apps/web/lib/admin/trials/manage/__tests__/trial-validation-gaps.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { evaluateTrialValidationGaps } from "../trial-validation-gaps";
+
+describe("evaluateTrialValidationGaps", () => {
+  it("returns missing baseline gaps without row-level incompleteness when no trial is provided", () => {
+    const evaluation = evaluateTrialValidationGaps(null);
+
+    expect(evaluation.totalFieldCount).toBeGreaterThan(0);
+    expect(evaluation.missingFromModel.length).toBeGreaterThan(0);
+    expect(evaluation.availableButIncomplete).toEqual([]);
+    expect(
+      evaluation.missingFromModel.some(
+        (item) => item.targetField === "sklKoeId",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns row-level incomplete gaps for available fields with empty values", () => {
+    const evaluation = evaluateTrialValidationGaps({
+      trialId: "trial-1",
+      dogId: "dog-1",
+      dogName: "Rex",
+      registrationNo: null,
+      eventDate: "2026-04-14",
+      eventName: null,
+      eventPlace: "Helsinki",
+      kennelDistrict: null,
+      kennelDistrictNo: null,
+      ke: null,
+      lk: null,
+      pa: null,
+      piste: null,
+      sija: null,
+      haku: null,
+      hauk: null,
+      yva: null,
+      hlo: null,
+      alo: null,
+      tja: null,
+      pin: null,
+      judge: null,
+      legacyFlag: null,
+      sourceKey: "source-1",
+      rawPayloadJson: null,
+      rawPayloadAvailable: false,
+      createdAt: "2026-04-14T10:00:00.000Z",
+      updatedAt: "2026-04-14T10:00:00.000Z",
+    });
+
+    expect(
+      evaluation.availableButIncomplete.some(
+        (item) =>
+          item.targetField === "rekisterinumero" &&
+          item.status === "available_but_incomplete",
+      ),
+    ).toBe(true);
+    expect(
+      evaluation.availableButIncomplete.some(
+        (item) =>
+          item.targetField === "kennelpiiri" &&
+          item.status === "available_but_incomplete",
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/web/lib/admin/trials/manage/index.ts
+++ b/apps/web/lib/admin/trials/manage/index.ts
@@ -1,0 +1,1 @@
+export * from "./trial-validation-gaps";

--- a/apps/web/lib/admin/trials/manage/index.ts
+++ b/apps/web/lib/admin/trials/manage/index.ts
@@ -1,1 +1,3 @@
+export * from "./trial-field-contract";
+export * from "./trial-flow-gate";
 export * from "./trial-validation-gaps";

--- a/apps/web/lib/admin/trials/manage/trial-field-contract.ts
+++ b/apps/web/lib/admin/trials/manage/trial-field-contract.ts
@@ -1,0 +1,432 @@
+import type { AdminTrialDetails } from "@beagle/contracts";
+
+// Locks the AJOK future-poytakirja field contract for current TrialResult read-path planning.
+// This is the machine-readable source for status classification and gate-required field sets.
+export const AJOK_FIELD_CONTRACT_VERSION = "v2026-04-14";
+
+export type TrialFieldContractGroup =
+  | "event"
+  | "dog"
+  | "result"
+  | "conditions"
+  | "status"
+  | "additional"
+  | "judges";
+
+export type TrialFieldContractStatus = "typed-now" | "raw-only" | "missing";
+
+export type TrialFieldFollowUpTicket = "BEJ-79" | "BEJ-80" | "BEJ-82";
+
+type TrialFieldContractBase = {
+  group: TrialFieldContractGroup;
+  targetField: string;
+  followUpTicket: TrialFieldFollowUpTicket | null;
+};
+
+export type TrialFieldContractItem =
+  | (TrialFieldContractBase & {
+      status: "typed-now";
+      sourceField: keyof AdminTrialDetails;
+    })
+  | (TrialFieldContractBase & {
+      status: "raw-only" | "missing";
+      sourceField: null;
+    });
+
+export type TrialFieldContractStatusCounts = Record<
+  TrialFieldContractStatus,
+  number
+>;
+
+export const AJOK_MINIMUM_PRE_SWITCH_FIELDS: readonly string[] = [
+  "koepaiva",
+  "koekunta",
+  "koiranNimi",
+  "rekisterinumero",
+  "loppupisteet",
+  "palkinto",
+  "sijoitus",
+  "hakuKeskiarvo",
+  "haukkuKeskiarvo",
+  "hakuloysyysTappioYhteensa",
+  "ajoloysyysTappioYhteensa",
+  "keli",
+  "ryhmatuomariNimi",
+] as const;
+
+// Source of truth for the AJOK future-poytakirja field contract.
+export const TRIAL_FIELD_CONTRACT_CATALOG: readonly TrialFieldContractItem[] = [
+  {
+    group: "event",
+    targetField: "sklKoeId",
+    status: "raw-only",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "event",
+    targetField: "rotukoodi",
+    status: "raw-only",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "event",
+    targetField: "kennelpiiri",
+    status: "typed-now",
+    sourceField: "kennelDistrict",
+    followUpTicket: null,
+  },
+  {
+    group: "event",
+    targetField: "kennelpiirinro",
+    status: "typed-now",
+    sourceField: "kennelDistrictNo",
+    followUpTicket: null,
+  },
+  {
+    group: "event",
+    targetField: "koekunta",
+    status: "typed-now",
+    sourceField: "eventPlace",
+    followUpTicket: null,
+  },
+  {
+    group: "event",
+    targetField: "koepaiva",
+    status: "typed-now",
+    sourceField: "eventDate",
+    followUpTicket: null,
+  },
+  {
+    group: "event",
+    targetField: "jarjestaja",
+    status: "raw-only",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "event",
+    targetField: "koemuoto",
+    status: "raw-only",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "dog",
+    targetField: "koiranNimi",
+    status: "typed-now",
+    sourceField: "dogName",
+    followUpTicket: null,
+  },
+  {
+    group: "dog",
+    targetField: "rekisterinumero",
+    status: "typed-now",
+    sourceField: "registrationNo",
+    followUpTicket: null,
+  },
+  {
+    group: "dog",
+    targetField: "isanNimi",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "dog",
+    targetField: "isanRekisterinumero",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "dog",
+    targetField: "emanNimi",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "dog",
+    targetField: "emanRekisterinumero",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "dog",
+    targetField: "omistaja",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "dog",
+    targetField: "omistajanKotikunta",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "dog",
+    targetField: "sukupuoli",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "dog",
+    targetField: "rokotusOk",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-82",
+  },
+  {
+    group: "dog",
+    targetField: "tunnistusOk",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-82",
+  },
+  {
+    group: "result",
+    targetField: "era1Alkoi",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "result",
+    targetField: "era2Alkoi",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "result",
+    targetField: "hakuMin1",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "result",
+    targetField: "hakuMin2",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "result",
+    targetField: "ajoMin1",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "result",
+    targetField: "ajoMin2",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "result",
+    targetField: "hyvaksytytAjominuutit",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "result",
+    targetField: "ajoajanPisteet",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "result",
+    targetField: "hakuKeskiarvo",
+    status: "typed-now",
+    sourceField: "haku",
+    followUpTicket: null,
+  },
+  {
+    group: "result",
+    targetField: "haukkuKeskiarvo",
+    status: "typed-now",
+    sourceField: "hauk",
+    followUpTicket: null,
+  },
+  {
+    group: "result",
+    targetField: "ajotaitoKeskiarvo",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "result",
+    targetField: "ansiopisteetYhteensa",
+    status: "typed-now",
+    sourceField: "piste",
+    followUpTicket: null,
+  },
+  {
+    group: "result",
+    targetField: "hakuloysyysTappioYhteensa",
+    status: "typed-now",
+    sourceField: "hlo",
+    followUpTicket: null,
+  },
+  {
+    group: "result",
+    targetField: "ajoloysyysTappioYhteensa",
+    status: "typed-now",
+    sourceField: "alo",
+    followUpTicket: null,
+  },
+  {
+    group: "result",
+    targetField: "tappiopisteetYhteensa",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "result",
+    targetField: "loppupisteet",
+    status: "typed-now",
+    sourceField: "piste",
+    followUpTicket: null,
+  },
+  {
+    group: "result",
+    targetField: "palkinto",
+    status: "typed-now",
+    sourceField: "pa",
+    followUpTicket: null,
+  },
+  {
+    group: "result",
+    targetField: "sijoitus",
+    status: "typed-now",
+    sourceField: "sija",
+    followUpTicket: null,
+  },
+  {
+    group: "result",
+    targetField: "koiriaLuokassa",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "conditions",
+    targetField: "keli",
+    status: "typed-now",
+    sourceField: "ke",
+    followUpTicket: null,
+  },
+  {
+    group: "conditions",
+    targetField: "paljasMaa",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-82",
+  },
+  {
+    group: "conditions",
+    targetField: "lumikeli",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-82",
+  },
+  {
+    group: "status",
+    targetField: "luopui",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "status",
+    targetField: "suljettu",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "status",
+    targetField: "keskeytetty",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "status",
+    targetField: "huomautusTeksti",
+    status: "missing",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "additional",
+    targetField: "lisatiedotJson",
+    status: "raw-only",
+    sourceField: null,
+    followUpTicket: "BEJ-80",
+  },
+  {
+    group: "judges",
+    targetField: "ryhmatuomariNimi",
+    status: "typed-now",
+    sourceField: "judge",
+    followUpTicket: null,
+  },
+  {
+    group: "judges",
+    targetField: "palkintotuomariNimi",
+    status: "raw-only",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "judges",
+    targetField: "ylituomariNimi",
+    status: "raw-only",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+  {
+    group: "judges",
+    targetField: "ylituomariNumero",
+    status: "raw-only",
+    sourceField: null,
+    followUpTicket: "BEJ-79",
+  },
+] as const;
+
+export function countTrialFieldContractStatuses(
+  catalog: readonly TrialFieldContractItem[] = TRIAL_FIELD_CONTRACT_CATALOG,
+): TrialFieldContractStatusCounts {
+  const counts: TrialFieldContractStatusCounts = {
+    "typed-now": 0,
+    "raw-only": 0,
+    missing: 0,
+  };
+
+  for (const item of catalog) {
+    counts[item.status] += 1;
+  }
+
+  return counts;
+}
+
+export function findTrialFieldContractItem(
+  targetField: string,
+  catalog: readonly TrialFieldContractItem[] = TRIAL_FIELD_CONTRACT_CATALOG,
+): TrialFieldContractItem | undefined {
+  return catalog.find((item) => item.targetField === targetField);
+}

--- a/apps/web/lib/admin/trials/manage/trial-flow-gate.ts
+++ b/apps/web/lib/admin/trials/manage/trial-flow-gate.ts
@@ -1,0 +1,72 @@
+import {
+  AJOK_FIELD_CONTRACT_VERSION,
+  AJOK_MINIMUM_PRE_SWITCH_FIELDS,
+  countTrialFieldContractStatuses,
+  findTrialFieldContractItem,
+  TRIAL_FIELD_CONTRACT_CATALOG,
+  type TrialFieldContractItem,
+  type TrialFieldContractStatusCounts,
+} from "./trial-field-contract";
+
+// Evaluates whether the locked BEJ-78 minimum field contract is satisfied.
+// Used as a deterministic read-switch gate before moving to the new AJOK schema path.
+export type TrialFlowGateBlockingField = {
+  targetField: string;
+  group: TrialFieldContractItem["group"];
+  status: TrialFieldContractItem["status"];
+  followUpTicket: TrialFieldContractItem["followUpTicket"];
+};
+
+export type TrialFlowGateEvaluation = {
+  version: string;
+  minimumRequiredFields: readonly string[];
+  statusCounts: TrialFieldContractStatusCounts;
+  isReadyForReadSwitch: boolean;
+  blockingFields: TrialFlowGateBlockingField[];
+};
+
+function toBlockingField(
+  item: TrialFieldContractItem,
+): TrialFlowGateBlockingField {
+  return {
+    targetField: item.targetField,
+    group: item.group,
+    status: item.status,
+    followUpTicket: item.followUpTicket,
+  };
+}
+
+// Evaluates whether the minimum pre-switch AJOK contract is typed and safe for a UI read-path switch.
+export function evaluateTrialFlowGate(options?: {
+  catalog?: readonly TrialFieldContractItem[];
+  minimumRequiredFields?: readonly string[];
+}): TrialFlowGateEvaluation {
+  const catalog = options?.catalog ?? TRIAL_FIELD_CONTRACT_CATALOG;
+  const minimumRequiredFields =
+    options?.minimumRequiredFields ?? AJOK_MINIMUM_PRE_SWITCH_FIELDS;
+
+  const blockingFields: TrialFlowGateBlockingField[] = [];
+
+  for (const targetField of minimumRequiredFields) {
+    const item = findTrialFieldContractItem(targetField, catalog);
+    if (!item) {
+      throw new Error(
+        `Unknown trial field contract targetField in minimum gate set: ${targetField}`,
+      );
+    }
+
+    if (item.status !== "typed-now") {
+      blockingFields.push(toBlockingField(item));
+    }
+  }
+
+  blockingFields.sort((a, b) => a.targetField.localeCompare(b.targetField));
+
+  return {
+    version: AJOK_FIELD_CONTRACT_VERSION,
+    minimumRequiredFields,
+    statusCounts: countTrialFieldContractStatuses(catalog),
+    isReadyForReadSwitch: blockingFields.length === 0,
+    blockingFields,
+  };
+}

--- a/apps/web/lib/admin/trials/manage/trial-validation-gaps.ts
+++ b/apps/web/lib/admin/trials/manage/trial-validation-gaps.ts
@@ -1,0 +1,177 @@
+import type { AdminTrialDetails } from "@beagle/contracts";
+
+export type TrialValidationGapStatus =
+  | "missing_from_model"
+  | "available_but_incomplete";
+
+type TrialValidationGroup =
+  | "event"
+  | "dog"
+  | "result"
+  | "conditions"
+  | "status"
+  | "additional"
+  | "judges";
+
+type TrialValidationCatalogItem = {
+  group: TrialValidationGroup;
+  targetField: string;
+  sourceField?: keyof AdminTrialDetails;
+};
+
+export type TrialValidationGapItem = {
+  group: TrialValidationGroup;
+  targetField: string;
+  sourceField: keyof AdminTrialDetails | null;
+  status: TrialValidationGapStatus;
+};
+
+export type TrialValidationEvaluation = {
+  missingFromModel: TrialValidationGapItem[];
+  availableButIncomplete: TrialValidationGapItem[];
+  availableCount: number;
+  totalFieldCount: number;
+};
+
+const TRIAL_VALIDATION_FIELD_CATALOG: readonly TrialValidationCatalogItem[] = [
+  { group: "event", targetField: "sklKoeId" },
+  { group: "event", targetField: "rotukoodi" },
+  {
+    group: "event",
+    targetField: "kennelpiiri",
+    sourceField: "kennelDistrict",
+  },
+  {
+    group: "event",
+    targetField: "kennelpiirinro",
+    sourceField: "kennelDistrictNo",
+  },
+  { group: "event", targetField: "koekunta", sourceField: "eventPlace" },
+  { group: "event", targetField: "koepaiva", sourceField: "eventDate" },
+  { group: "event", targetField: "jarjestaja" },
+  { group: "event", targetField: "koemuoto" },
+  { group: "dog", targetField: "koiranNimi", sourceField: "dogName" },
+  {
+    group: "dog",
+    targetField: "rekisterinumero",
+    sourceField: "registrationNo",
+  },
+  { group: "dog", targetField: "isanNimi" },
+  { group: "dog", targetField: "isanRekisterinumero" },
+  { group: "dog", targetField: "emanNimi" },
+  { group: "dog", targetField: "emanRekisterinumero" },
+  { group: "dog", targetField: "omistaja" },
+  { group: "dog", targetField: "omistajanKotikunta" },
+  { group: "dog", targetField: "sukupuoli" },
+  { group: "dog", targetField: "rokotusOk" },
+  { group: "dog", targetField: "tunnistusOk" },
+  { group: "result", targetField: "era1Alkoi" },
+  { group: "result", targetField: "era2Alkoi" },
+  { group: "result", targetField: "hakuMin1" },
+  { group: "result", targetField: "hakuMin2" },
+  { group: "result", targetField: "ajoMin1" },
+  { group: "result", targetField: "ajoMin2" },
+  { group: "result", targetField: "hyvaksytytAjominuutit" },
+  { group: "result", targetField: "ajoajanPisteet" },
+  { group: "result", targetField: "hakuKeskiarvo", sourceField: "haku" },
+  { group: "result", targetField: "haukkuKeskiarvo", sourceField: "hauk" },
+  { group: "result", targetField: "ajotaitoKeskiarvo" },
+  {
+    group: "result",
+    targetField: "ansiopisteetYhteensa",
+    sourceField: "piste",
+  },
+  {
+    group: "result",
+    targetField: "hakuloysyysTappioYhteensa",
+    sourceField: "hlo",
+  },
+  {
+    group: "result",
+    targetField: "ajoloysyysTappioYhteensa",
+    sourceField: "alo",
+  },
+  { group: "result", targetField: "tappiopisteetYhteensa" },
+  { group: "result", targetField: "loppupisteet", sourceField: "piste" },
+  { group: "result", targetField: "palkinto", sourceField: "pa" },
+  { group: "result", targetField: "sijoitus", sourceField: "sija" },
+  { group: "result", targetField: "koiriaLuokassa" },
+  { group: "conditions", targetField: "keli", sourceField: "ke" },
+  { group: "conditions", targetField: "paljasMaa" },
+  { group: "conditions", targetField: "lumikeli" },
+  { group: "status", targetField: "luopui" },
+  { group: "status", targetField: "suljettu" },
+  { group: "status", targetField: "keskeytetty" },
+  { group: "status", targetField: "huomautusTeksti" },
+  { group: "additional", targetField: "lisatiedotJson" },
+  { group: "judges", targetField: "ryhmatuomariNimi", sourceField: "judge" },
+  { group: "judges", targetField: "palkintotuomariNimi" },
+  { group: "judges", targetField: "ylituomariNimi" },
+  { group: "judges", targetField: "ylituomariNumero" },
+] as const;
+
+function isValueComplete(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+
+  if (typeof value === "boolean") {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  return true;
+}
+
+// Evaluates AJOK pöytäkirja field availability against the current TrialResult read model.
+export function evaluateTrialValidationGaps(
+  trial: AdminTrialDetails | null | undefined,
+): TrialValidationEvaluation {
+  const missingFromModel: TrialValidationGapItem[] = [];
+  const availableButIncomplete: TrialValidationGapItem[] = [];
+  let availableCount = 0;
+
+  for (const item of TRIAL_VALIDATION_FIELD_CATALOG) {
+    if (!item.sourceField) {
+      missingFromModel.push({
+        group: item.group,
+        targetField: item.targetField,
+        sourceField: null,
+        status: "missing_from_model",
+      });
+      continue;
+    }
+
+    availableCount += 1;
+    if (!trial) {
+      continue;
+    }
+
+    if (!isValueComplete(trial[item.sourceField])) {
+      availableButIncomplete.push({
+        group: item.group,
+        targetField: item.targetField,
+        sourceField: item.sourceField,
+        status: "available_but_incomplete",
+      });
+    }
+  }
+
+  return {
+    missingFromModel,
+    availableButIncomplete,
+    availableCount,
+    totalFieldCount: TRIAL_VALIDATION_FIELD_CATALOG.length,
+  };
+}

--- a/apps/web/lib/admin/trials/manage/trial-validation-gaps.ts
+++ b/apps/web/lib/admin/trials/manage/trial-validation-gaps.ts
@@ -1,26 +1,12 @@
 import type { AdminTrialDetails } from "@beagle/contracts";
+import { TRIAL_FIELD_CONTRACT_CATALOG } from "./trial-field-contract";
 
 export type TrialValidationGapStatus =
   | "missing_from_model"
   | "available_but_incomplete";
 
-type TrialValidationGroup =
-  | "event"
-  | "dog"
-  | "result"
-  | "conditions"
-  | "status"
-  | "additional"
-  | "judges";
-
-type TrialValidationCatalogItem = {
-  group: TrialValidationGroup;
-  targetField: string;
-  sourceField?: keyof AdminTrialDetails;
-};
-
 export type TrialValidationGapItem = {
-  group: TrialValidationGroup;
+  group: (typeof TRIAL_FIELD_CONTRACT_CATALOG)[number]["group"];
   targetField: string;
   sourceField: keyof AdminTrialDetails | null;
   status: TrialValidationGapStatus;
@@ -32,83 +18,6 @@ export type TrialValidationEvaluation = {
   availableCount: number;
   totalFieldCount: number;
 };
-
-const TRIAL_VALIDATION_FIELD_CATALOG: readonly TrialValidationCatalogItem[] = [
-  { group: "event", targetField: "sklKoeId" },
-  { group: "event", targetField: "rotukoodi" },
-  {
-    group: "event",
-    targetField: "kennelpiiri",
-    sourceField: "kennelDistrict",
-  },
-  {
-    group: "event",
-    targetField: "kennelpiirinro",
-    sourceField: "kennelDistrictNo",
-  },
-  { group: "event", targetField: "koekunta", sourceField: "eventPlace" },
-  { group: "event", targetField: "koepaiva", sourceField: "eventDate" },
-  { group: "event", targetField: "jarjestaja" },
-  { group: "event", targetField: "koemuoto" },
-  { group: "dog", targetField: "koiranNimi", sourceField: "dogName" },
-  {
-    group: "dog",
-    targetField: "rekisterinumero",
-    sourceField: "registrationNo",
-  },
-  { group: "dog", targetField: "isanNimi" },
-  { group: "dog", targetField: "isanRekisterinumero" },
-  { group: "dog", targetField: "emanNimi" },
-  { group: "dog", targetField: "emanRekisterinumero" },
-  { group: "dog", targetField: "omistaja" },
-  { group: "dog", targetField: "omistajanKotikunta" },
-  { group: "dog", targetField: "sukupuoli" },
-  { group: "dog", targetField: "rokotusOk" },
-  { group: "dog", targetField: "tunnistusOk" },
-  { group: "result", targetField: "era1Alkoi" },
-  { group: "result", targetField: "era2Alkoi" },
-  { group: "result", targetField: "hakuMin1" },
-  { group: "result", targetField: "hakuMin2" },
-  { group: "result", targetField: "ajoMin1" },
-  { group: "result", targetField: "ajoMin2" },
-  { group: "result", targetField: "hyvaksytytAjominuutit" },
-  { group: "result", targetField: "ajoajanPisteet" },
-  { group: "result", targetField: "hakuKeskiarvo", sourceField: "haku" },
-  { group: "result", targetField: "haukkuKeskiarvo", sourceField: "hauk" },
-  { group: "result", targetField: "ajotaitoKeskiarvo" },
-  {
-    group: "result",
-    targetField: "ansiopisteetYhteensa",
-    sourceField: "piste",
-  },
-  {
-    group: "result",
-    targetField: "hakuloysyysTappioYhteensa",
-    sourceField: "hlo",
-  },
-  {
-    group: "result",
-    targetField: "ajoloysyysTappioYhteensa",
-    sourceField: "alo",
-  },
-  { group: "result", targetField: "tappiopisteetYhteensa" },
-  { group: "result", targetField: "loppupisteet", sourceField: "piste" },
-  { group: "result", targetField: "palkinto", sourceField: "pa" },
-  { group: "result", targetField: "sijoitus", sourceField: "sija" },
-  { group: "result", targetField: "koiriaLuokassa" },
-  { group: "conditions", targetField: "keli", sourceField: "ke" },
-  { group: "conditions", targetField: "paljasMaa" },
-  { group: "conditions", targetField: "lumikeli" },
-  { group: "status", targetField: "luopui" },
-  { group: "status", targetField: "suljettu" },
-  { group: "status", targetField: "keskeytetty" },
-  { group: "status", targetField: "huomautusTeksti" },
-  { group: "additional", targetField: "lisatiedotJson" },
-  { group: "judges", targetField: "ryhmatuomariNimi", sourceField: "judge" },
-  { group: "judges", targetField: "palkintotuomariNimi" },
-  { group: "judges", targetField: "ylituomariNimi" },
-  { group: "judges", targetField: "ylituomariNumero" },
-] as const;
 
 function isValueComplete(value: unknown): boolean {
   if (value === null || value === undefined) {
@@ -134,7 +43,7 @@ function isValueComplete(value: unknown): boolean {
   return true;
 }
 
-// Evaluates AJOK pöytäkirja field availability against the current TrialResult read model.
+// Evaluates AJOK poytakirja field availability against the current TrialResult read model.
 export function evaluateTrialValidationGaps(
   trial: AdminTrialDetails | null | undefined,
 ): TrialValidationEvaluation {
@@ -142,8 +51,8 @@ export function evaluateTrialValidationGaps(
   const availableButIncomplete: TrialValidationGapItem[] = [];
   let availableCount = 0;
 
-  for (const item of TRIAL_VALIDATION_FIELD_CATALOG) {
-    if (!item.sourceField) {
+  for (const item of TRIAL_FIELD_CONTRACT_CATALOG) {
+    if (item.status !== "typed-now") {
       missingFromModel.push({
         group: item.group,
         targetField: item.targetField,
@@ -172,6 +81,6 @@ export function evaluateTrialValidationGaps(
     missingFromModel,
     availableButIncomplete,
     availableCount,
-    totalFieldCount: TRIAL_VALIDATION_FIELD_CATALOG.length,
+    totalFieldCount: TRIAL_FIELD_CONTRACT_CATALOG.length,
   };
 }

--- a/apps/web/lib/i18n/messages/admin/trials.ts
+++ b/apps/web/lib/i18n/messages/admin/trials.ts
@@ -29,6 +29,33 @@ export const fiAdminTrialsMessages = {
   "admin.trials.manage.mobile.pa": "Pa",
   "admin.trials.manage.mobile.sija": "Sija",
   "admin.trials.manage.mobile.judge": "Tuomari",
+  "admin.trials.validation.title": "Pöytäkirja-gap validointi",
+  "admin.trials.validation.description.detail":
+    "Näyttää mitkä koirakohtaisen AJOK-pöytäkirjan kentät puuttuvat nykyisestä mallista tai ovat epätäydellisiä tällä rivillä.",
+  "admin.trials.validation.description.search":
+    "Näyttää event-haun perusnäkymässä mitkä koirakohtaisen AJOK-pöytäkirjan kentät puuttuvat nykyisestä mallista.",
+  "admin.trials.validation.summary.totalPrefix": "Pöytäkirjakenttiä yhteensä:",
+  "admin.trials.validation.summary.availablePrefix":
+    "Saatavilla nykyisessä mallissa:",
+  "admin.trials.validation.summary.missingPrefix":
+    "Puuttuu nykyisestä mallista:",
+  "admin.trials.validation.sections.missing":
+    "Puuttuvat kentät (missing_from_model)",
+  "admin.trials.validation.sections.incomplete":
+    "Epätäydelliset kentät (available_but_incomplete)",
+  "admin.trials.validation.empty.missing":
+    "Puuttuvia kenttiä ei tunnistettu nykyistä mallia vasten.",
+  "admin.trials.validation.empty.incomplete":
+    "Epätäydellisiä kenttiä ei löytynyt valitulta riviltä.",
+  "admin.trials.validation.incomplete.notEvaluated":
+    "Epätäydellisyys arvioidaan detail-näkymässä, koska listahaussa ei ladata kaikkia koirakohtaisia arvoja.",
+  "admin.trials.validation.groups.event": "Kokeen tiedot",
+  "admin.trials.validation.groups.dog": "Koiran tiedot",
+  "admin.trials.validation.groups.result": "Pisteet ja tulos",
+  "admin.trials.validation.groups.conditions": "Olosuhteet",
+  "admin.trials.validation.groups.status": "Tilat ja huomautukset",
+  "admin.trials.validation.groups.additional": "Lisätiedot",
+  "admin.trials.validation.groups.judges": "Tuomarit",
   "admin.trials.detail.title": "Koetuloksen detalji",
   "admin.trials.detail.header.placeholder": "Ladataan koetulosta...",
   "admin.trials.detail.section.title": "Koetuloksen tiedot",
@@ -106,6 +133,32 @@ export const svAdminTrialsMessages = {
   "admin.trials.manage.mobile.pa": "Pa",
   "admin.trials.manage.mobile.sija": "Placering",
   "admin.trials.manage.mobile.judge": "Domare",
+  "admin.trials.validation.title": "Protokoll-gap validering",
+  "admin.trials.validation.description.detail":
+    "Visar vilka fält i framtida hundspecifika AJOK-protokoll som saknas i nuvarande modell eller är ofullständiga i den valda raden.",
+  "admin.trials.validation.description.search":
+    "Visar i event-sökvyn vilka fält i framtida hundspecifika AJOK-protokoll som saknas i nuvarande modell.",
+  "admin.trials.validation.summary.totalPrefix": "Protokollfält totalt:",
+  "admin.trials.validation.summary.availablePrefix":
+    "Tillgängliga i nuvarande modell:",
+  "admin.trials.validation.summary.missingPrefix": "Saknas i nuvarande modell:",
+  "admin.trials.validation.sections.missing":
+    "Saknade fält (missing_from_model)",
+  "admin.trials.validation.sections.incomplete":
+    "Ofullständiga fält (available_but_incomplete)",
+  "admin.trials.validation.empty.missing":
+    "Inga saknade fält identifierades mot nuvarande modell.",
+  "admin.trials.validation.empty.incomplete":
+    "Inga ofullständiga fält hittades i den valda raden.",
+  "admin.trials.validation.incomplete.notEvaluated":
+    "Ofullständighet utvärderas i detaljvyn eftersom listsökningen inte laddar alla hundspecifika värden.",
+  "admin.trials.validation.groups.event": "Provets uppgifter",
+  "admin.trials.validation.groups.dog": "Hundens uppgifter",
+  "admin.trials.validation.groups.result": "Poäng och resultat",
+  "admin.trials.validation.groups.conditions": "Förhållanden",
+  "admin.trials.validation.groups.status": "Status och anmärkningar",
+  "admin.trials.validation.groups.additional": "Tilläggsuppgifter",
+  "admin.trials.validation.groups.judges": "Domare",
   "admin.trials.detail.title": "Provresultatdetalj",
   "admin.trials.detail.header.placeholder": "Laddar provresultat...",
   "admin.trials.detail.section.title": "Provresultatets uppgifter",

--- a/docs/features/admin-trial-management.md
+++ b/docs/features/admin-trial-management.md
@@ -1,12 +1,15 @@
 # Admin Trial Management
 
-Developer notes for the admin trial read-only list/detail flow (`BEJ-76`).
+Developer notes for the admin trial read-only list/detail flow (`BEJ-76`) and
+AJOK validation-gap panel baseline (`BEJ-77`).
 
 ## Primary purpose
 
 - The page is an admin-facing search and detail workflow for current `TrialResult` rows.
 - The main user task is to find one trial result row and inspect all typed fields without editing.
 - The detail page can also show raw/source payload when available in the current model.
+- The page also exposes a read-only validation panel that visualizes current AJOK
+  pöytäkirja gaps (missing vs incomplete) for schema planning.
 
 ## Main files
 
@@ -14,8 +17,10 @@ Developer notes for the admin trial read-only list/detail flow (`BEJ-76`).
 - `apps/web/app/(admin)/admin/trials/[trialId]/page.tsx`: route entrypoint for one trial result detail
 - `apps/web/components/admin/trials/admin-trials-page-client.tsx`: list filters + result rows/cards
 - `apps/web/components/admin/trials/admin-trial-details-page-client.tsx`: read-only detail sections
+- `apps/web/components/admin/trials/admin-trial-validation-panel.tsx`: shared read-only AJOK validation-gap panel for detail + search contexts
 - `apps/web/queries/admin/trials/manage/use-admin-trials-query.ts`: list query hook
 - `apps/web/queries/admin/trials/manage/use-admin-trial-query.ts`: detail query hook + mapped query errors
+- `apps/web/lib/admin/trials/manage/trial-validation-gaps.ts`: validation gap catalog + evaluator against current `AdminTrialDetails` model
 - `apps/web/app/api/admin/trials/route.ts`: list API route
 - `apps/web/app/api/admin/trials/[trialId]/route.ts`: detail API route
 - `packages/api-client/admin/trials/*`: admin trial API client methods
@@ -29,12 +34,17 @@ Developer notes for the admin trial read-only list/detail flow (`BEJ-76`).
 2. Row/card selection navigates to `/admin/trials/[trialId]`.
 3. Detail page fetches exactly one row through `useAdminTrialQuery`.
 4. Detail UI renders grouped read-only sections (kokeen tiedot, koiran tiedot, pisteet ja tulos, osa-arvostelu, metadata, raw/source).
+5. Validation panel compares current read model against AJOK target field set and shows:
+   - `missing_from_model`: field not represented in current read contract.
+   - `available_but_incomplete`: field exists in current model but selected row value is empty/null.
 
 ## Contract rules
 
 - List response: paginated summaries (`total`, `totalPages`, `page`, `items[]`).
 - Detail response: one row under `trial`.
 - `TRIAL_NOT_FOUND` is returned as an error code from API/service layers for missing IDs.
+- Validation target field source of truth for AJOK baseline is
+  `docs/features/trials/ajokoe-koirakohtainen-poytakirja.md`.
 
 ## Render rules
 
@@ -44,11 +54,16 @@ Developer notes for the admin trial read-only list/detail flow (`BEJ-76`).
 - Raw/source payload is shown in a collapsible read-only section.
 - If payload is unavailable, detail shows localized fallback text.
 - If detail query returns `TRIAL_NOT_FOUND`, show dedicated `notFound` state card (not generic error state).
+- Detail view renders the validation panel and evaluates both missing and incomplete categories against selected row data.
+- Search/list view renders the same panel in baseline mode and shows only model-level missing fields (incomplete evaluation is detail-only because the list query does not load full row payload).
+- Validation panel is analysis/visualization only and does not mutate data.
+- This panel is a baseline for later read-path migration updates in `BEJ-82`.
 
 ## Tests
 
 - `apps/web/components/admin/trials/__tests__/admin-trials-page-client.test.tsx`
 - `apps/web/components/admin/trials/__tests__/admin-trial-details-page-client.test.tsx`
+- `apps/web/lib/admin/trials/manage/__tests__/trial-validation-gaps.test.ts`
 - `apps/web/queries/admin/trials/manage/__tests__/use-admin-trials-query.test.ts`
 - `apps/web/app/api/admin/trials/__tests__/route.test.ts`
 - `apps/web/app/api/admin/trials/__tests__/detail-route.test.ts`
@@ -61,3 +76,4 @@ Developer notes for the admin trial read-only list/detail flow (`BEJ-76`).
 - Update this file when the trial summary/detail contracts change.
 - Update this file when detail section grouping/visibility changes.
 - Update this file when not-found/error render behavior changes.
+- Update this file when AJOK validation target fields or classification rules change.

--- a/docs/features/admin-trial-management.md
+++ b/docs/features/admin-trial-management.md
@@ -45,6 +45,8 @@ AJOK validation-gap panel baseline (`BEJ-77`).
 - `TRIAL_NOT_FOUND` is returned as an error code from API/service layers for missing IDs.
 - Validation target field source of truth for AJOK baseline is
   `docs/features/trials/ajokoe-koirakohtainen-poytakirja.md`.
+- Flow-gate contract source of truth (versioned status table and minimum
+  pre-switch requirements) is `docs/features/trials/ajok-flow-gate-contract.md`.
 
 ## Render rules
 
@@ -57,7 +59,9 @@ AJOK validation-gap panel baseline (`BEJ-77`).
 - Detail view renders the validation panel and evaluates both missing and incomplete categories against selected row data.
 - Search/list view renders the same panel in baseline mode and shows only model-level missing fields (incomplete evaluation is detail-only because the list query does not load full row payload).
 - Validation panel is analysis/visualization only and does not mutate data.
-- This panel is a baseline for later read-path migration updates in `BEJ-82`.
+- This panel is a baseline input to the locked flow-gate contract in
+  `docs/features/trials/ajok-flow-gate-contract.md` and later read-path
+  migration updates in `BEJ-82`.
 
 ## Tests
 

--- a/docs/features/trials/ajok-flow-gate-contract.md
+++ b/docs/features/trials/ajok-flow-gate-contract.md
@@ -1,0 +1,106 @@
+# AJOK Flow Gate Contract
+
+Versioned source of truth for the BEJ-78 flow gate that locks the future
+poytakirja field contract before BEJ-79 schema work.
+
+## Contract version
+
+- Version: `v2026-04-14`
+- Source tickets: `BEJ-75`, `BEJ-76`, `BEJ-77`, `BEJ-78`
+- Machine-readable source: `apps/web/lib/admin/trials/manage/trial-field-contract.ts`
+
+## Field decision table
+
+Status meanings:
+
+- `typed-now`: field is represented by current `AdminTrialDetails` typed read model.
+- `raw-only`: field is not typed today but can be preserved from source payload when raw exists.
+- `missing`: field is not available in typed read model and not locked as raw-only for read-path parity.
+
+| Group      | Target field              | Status    | Current typed source | Follow-up |
+| ---------- | ------------------------- | --------- | -------------------- | --------- |
+| event      | sklKoeId                  | raw-only  | -                    | BEJ-79    |
+| event      | rotukoodi                 | raw-only  | -                    | BEJ-79    |
+| event      | kennelpiiri               | typed-now | kennelDistrict       | -         |
+| event      | kennelpiirinro            | typed-now | kennelDistrictNo     | -         |
+| event      | koekunta                  | typed-now | eventPlace           | -         |
+| event      | koepaiva                  | typed-now | eventDate            | -         |
+| event      | jarjestaja                | raw-only  | -                    | BEJ-79    |
+| event      | koemuoto                  | raw-only  | -                    | BEJ-79    |
+| dog        | koiranNimi                | typed-now | dogName              | -         |
+| dog        | rekisterinumero           | typed-now | registrationNo       | -         |
+| dog        | isanNimi                  | missing   | -                    | BEJ-79    |
+| dog        | isanRekisterinumero       | missing   | -                    | BEJ-79    |
+| dog        | emanNimi                  | missing   | -                    | BEJ-79    |
+| dog        | emanRekisterinumero       | missing   | -                    | BEJ-79    |
+| dog        | omistaja                  | missing   | -                    | BEJ-79    |
+| dog        | omistajanKotikunta        | missing   | -                    | BEJ-79    |
+| dog        | sukupuoli                 | missing   | -                    | BEJ-79    |
+| dog        | rokotusOk                 | missing   | -                    | BEJ-82    |
+| dog        | tunnistusOk               | missing   | -                    | BEJ-82    |
+| result     | era1Alkoi                 | missing   | -                    | BEJ-79    |
+| result     | era2Alkoi                 | missing   | -                    | BEJ-79    |
+| result     | hakuMin1                  | missing   | -                    | BEJ-79    |
+| result     | hakuMin2                  | missing   | -                    | BEJ-79    |
+| result     | ajoMin1                   | missing   | -                    | BEJ-79    |
+| result     | ajoMin2                   | missing   | -                    | BEJ-79    |
+| result     | hyvaksytytAjominuutit     | missing   | -                    | BEJ-79    |
+| result     | ajoajanPisteet            | missing   | -                    | BEJ-79    |
+| result     | hakuKeskiarvo             | typed-now | haku                 | -         |
+| result     | haukkuKeskiarvo           | typed-now | hauk                 | -         |
+| result     | ajotaitoKeskiarvo         | missing   | -                    | BEJ-79    |
+| result     | ansiopisteetYhteensa      | typed-now | piste                | -         |
+| result     | hakuloysyysTappioYhteensa | typed-now | hlo                  | -         |
+| result     | ajoloysyysTappioYhteensa  | typed-now | alo                  | -         |
+| result     | tappiopisteetYhteensa     | missing   | -                    | BEJ-79    |
+| result     | loppupisteet              | typed-now | piste                | -         |
+| result     | palkinto                  | typed-now | pa                   | -         |
+| result     | sijoitus                  | typed-now | sija                 | -         |
+| result     | koiriaLuokassa            | missing   | -                    | BEJ-79    |
+| conditions | keli                      | typed-now | ke                   | -         |
+| conditions | paljasMaa                 | missing   | -                    | BEJ-82    |
+| conditions | lumikeli                  | missing   | -                    | BEJ-82    |
+| status     | luopui                    | missing   | -                    | BEJ-79    |
+| status     | suljettu                  | missing   | -                    | BEJ-79    |
+| status     | keskeytetty               | missing   | -                    | BEJ-79    |
+| status     | huomautusTeksti           | missing   | -                    | BEJ-79    |
+| additional | lisatiedotJson            | raw-only  | -                    | BEJ-80    |
+| judges     | ryhmatuomariNimi          | typed-now | judge                | -         |
+| judges     | palkintotuomariNimi       | raw-only  | -                    | BEJ-79    |
+| judges     | ylituomariNimi            | raw-only  | -                    | BEJ-79    |
+| judges     | ylituomariNumero          | raw-only  | -                    | BEJ-79    |
+
+## Minimum contract before UI read switch
+
+The pre-switch gate for moving admin/public read paths from `TrialResult` to the
+new AJOK schema is the minimum required set below. The gate passes only when all
+required fields are `typed-now`.
+
+Required fields:
+
+- `koepaiva`
+- `koekunta`
+- `koiranNimi`
+- `rekisterinumero`
+- `loppupisteet`
+- `palkinto`
+- `sijoitus`
+- `hakuKeskiarvo`
+- `haukkuKeskiarvo`
+- `hakuloysyysTappioYhteensa`
+- `ajoloysyysTappioYhteensa`
+- `keli`
+- `ryhmatuomariNimi`
+
+Machine gate implementation: `apps/web/lib/admin/trials/manage/trial-flow-gate.ts`
+
+## Mapping notes from BEJ-75/76/77
+
+- BEJ-75 confirmed list-level parity requirements are currently met by typed
+  `TrialResult` read fields for dog, event date/place, and result summary.
+- BEJ-76 confirmed detail-level read-only rendering and raw payload visibility
+  behavior, with no schema or write-path change.
+- BEJ-77 established the AJOK gap panel baseline and validated which fields are
+  currently typed vs not represented in the read model.
+- This contract locks that baseline for BEJ-79/80/82 so schema/import/read-switch
+  work can track explicit per-field status without re-deciding the matrix.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -70,3 +70,30 @@ Use this format for new entries:
 - Suggested fix: Add explicit multi-judge support to the public show contract/UI instead of collapsing to one value.
 - Trigger to revisit: Next public show UI/contract redesign or workbook-driven show presentation task.
 - Ticket: BEJ-45 follow-up.
+
+## 2026-04-14 - AJOK missing event/dog contract fields
+
+- Area: AJOK future poytakirja event and dog field parity.
+- Issue: `TrialResult`-based read model does not type event metadata (`sklKoeId`, `rotukoodi`, `jarjestaja`, `koemuoto`) or most dog identity snapshot fields required by the locked flow-gate contract.
+- Impact: BEJ-79 schema rollout can drift from BEJ-78 contract unless these fields are implemented with explicit mapping rules.
+- Suggested fix: In BEJ-79, add canonical `TrialEvent` and `TrialEntry` typed fields and map them from API/legacy sources with per-field tests against the BEJ-78 contract table.
+- Trigger to revisit: BEJ-79 implementation kickoff and schema mapping PR review.
+- Ticket: BEJ-79.
+
+## 2026-04-14 - AJOK missing era/result/status contract fields
+
+- Area: AJOK result/era/status read parity.
+- Issue: Current read model lacks era-level timing/score fields and explicit status flags (`luopui`, `suljettu`, `keskeytetty`, `huomautusTeksti`) expected by the future poytakirja contract.
+- Impact: Read-path switch readiness cannot be expanded beyond the BEJ-78 minimum set until these fields are typed and validated.
+- Suggested fix: Implement missing result/status fields in BEJ-79 schema and BEJ-80 import mapping, then re-run BEJ-78 flow-gate tests with updated statuses.
+- Trigger to revisit: BEJ-80 backfill/import mapping work and BEJ-82 read-switch preparation.
+- Ticket: BEJ-80.
+
+## 2026-04-14 - AJOK additional/conditions detail gap follow-up
+
+- Area: AJOK lisatiedot and condition-detail completeness.
+- Issue: `lisatiedotJson`, `paljasMaa`, `lumikeli`, `rokotusOk`, and `tunnistusOk` remain outside typed read-path parity in the current model.
+- Impact: Detail-level validation and future PDF/structured rendering remain partial until these fields are carried through canonical storage and read adapters.
+- Suggested fix: Preserve and normalize additional/condition detail fields during schema/import steps, then update BEJ-82 gap panel to consume new typed sources.
+- Trigger to revisit: BEJ-82 panel/read-path migration update.
+- Ticket: BEJ-82.


### PR DESCRIPTION
## Summary
- lock the AJOK future-poytakirja field contract into a versioned flow-gate baseline before BEJ-79 schema work
- add a machine-readable contract catalog and gate evaluator to prevent drift
- keep BEJ-77 validation panel behavior aligned by reusing the shared contract source

## Changes
- add `docs/features/trials/ajok-flow-gate-contract.md` with versioned decision table (`typed-now` / `raw-only` / `missing`) and minimum pre-switch contract
- add `trial-field-contract` + `trial-flow-gate` modules under admin trials manage lib
- refactor `trial-validation-gaps` to consume the canonical catalog instead of duplicating field mapping
- add invariant tests for contract coverage/status counts and gate pass/fail behavior
- update admin trial management docs and add grouped follow-up items to `docs/tech-debt.md`

## Files
- `apps/web/components/admin/trials/admin-trial-validation-panel.tsx`
- `apps/web/components/admin/trials/admin-trial-details-page-client.tsx`
- `apps/web/components/admin/trials/admin-trials-page-client.tsx`
- `apps/web/components/admin/trials/index.ts`
- `apps/web/components/admin/trials/__tests__/admin-trial-details-page-client.test.tsx`
- `apps/web/components/admin/trials/__tests__/admin-trials-page-client.test.tsx`
- `apps/web/lib/admin/trials/manage/trial-field-contract.ts`
- `apps/web/lib/admin/trials/manage/trial-flow-gate.ts`
- `apps/web/lib/admin/trials/manage/trial-validation-gaps.ts`
- `apps/web/lib/admin/trials/manage/index.ts`
- `apps/web/lib/admin/trials/manage/__tests__/trial-field-contract.test.ts`
- `apps/web/lib/admin/trials/manage/__tests__/trial-flow-gate.test.ts`
- `apps/web/lib/admin/trials/manage/__tests__/trial-validation-gaps.test.ts`
- `apps/web/lib/i18n/messages/admin/trials.ts`
- `docs/features/admin-trial-management.md`
- `docs/features/trials/ajok-flow-gate-contract.md`
- `docs/tech-debt.md`

## Testing
- `pnpm --filter @beagle/web test:unit -- apps/web/lib/admin/trials/manage/__tests__/trial-field-contract.test.ts apps/web/lib/admin/trials/manage/__tests__/trial-flow-gate.test.ts apps/web/lib/admin/trials/manage/__tests__/trial-validation-gaps.test.ts`

closes bej-77
closes bej-78
