### PR TITLE
add canonical AJOK trial tables

### DIFF
--- a/docs/features/admin-trial-management.md
+++ b/docs/features/admin-trial-management.md
@@ -47,6 +47,8 @@ AJOK validation-gap panel baseline (`BEJ-77`).
   `docs/features/trials/ajokoe-koirakohtainen-poytakirja.md`.
 - Flow-gate contract source of truth (versioned status table and minimum
   pre-switch requirements) is `docs/features/trials/ajok-flow-gate-contract.md`.
+- During BEJ-79 schema rollout, admin list/detail reads remain on `TrialResult`
+  until BEJ-81 read-path switch.
 
 ## Render rules
 

--- a/docs/features/schema/schema.md
+++ b/docs/features/schema/schema.md
@@ -14,6 +14,7 @@ For show-domain deep details, see:
 - `ImportStatus`: `PENDING`, `RUNNING`, `SUCCEEDED`, `FAILED`
 - `ImportIssueSeverity`: `INFO`, `WARNING`, `ERROR`
 - `ShowSourceTag`: source tagging for legacy/workbook/manual show data
+- `TrialSourceTag`: source tagging for canonical trial entry writes
 - `ShowResultValueType`: `FLAG`, `CODE`, `TEXT`, `NUMERIC`, `DATE`
 - `AuditAction`: `INSERT`, `UPDATE`, `DELETE`
 - `AuditSource`: `WEB`, `SCRIPT`, `SYSTEM`
@@ -31,6 +32,9 @@ erDiagram
   Dog ||--o{ DogOwnership : "ownership history"
   Owner ||--o{ DogOwnership : "owns dogs"
   Dog ||--o{ TrialResult : "trial results"
+  Dog ||--o{ TrialEntry : "canonical trial entries (optional)"
+  TrialEvent ||--o{ TrialEntry : "canonical AJOK entries"
+  TrialEntry ||--o{ TrialLisatietoItem : "canonical AJOK lisatieto rows"
   Dog ||--o{ ShowEntry : "canonical show entries (optional)"
 
   ImportRun ||--o{ ImportRunIssue : "issues"
@@ -65,6 +69,9 @@ erDiagram
 ### Results
 
 - `TrialResult`: canonical trial rows keyed by unique `sourceKey`.
+- `TrialEvent`: canonical AJOK trial event (new schema event level).
+- `TrialEntry`: canonical AJOK trial dog entry (new schema entry level).
+- `TrialLisatietoItem`: canonical AJOK lisatieto rows (koodi 11-61) per trial entry.
 - `ShowEvent`: canonical show event.
 - `ShowEntry`: canonical show participation row; `dogId` nullable.
 - `ShowResultCategory`: UI/admin managed grouping for show definitions.
@@ -82,6 +89,9 @@ erDiagram
 - `BetterAuthUser -> BetterAuthSession/BetterAuthAccount`: `Cascade`
 - `BetterAuthUser -> ImportRun(createdByUser)`: `SetNull`
 - `Dog -> DogRegistration/DogOwnership/TrialResult`: `Cascade`
+- `Dog -> TrialEntry`: `SetNull` (allows trial rows without local dog)
+- `TrialEvent -> TrialEntry`: `Cascade`
+- `TrialEntry -> TrialLisatietoItem`: `Cascade`
 - `Dog -> ShowEntry`: `SetNull` (allows show rows without local dog)
 - `ShowEvent -> ShowEntry`: `Cascade`
 - `ShowEntry -> ShowResultItem`: `Cascade`
@@ -95,6 +105,10 @@ erDiagram
 - `Dog.ekNo` unique
 - `DogRegistration.registrationNo` unique
 - `TrialResult.sourceKey` unique
+- `TrialEvent.sklKoeId` unique
+- `TrialEntry.yksilointiAvain` unique
+- `TrialEntry.[trialEventId, rekisterinumeroSnapshot]` unique
+- `TrialLisatietoItem.[trialEntryId, koodi]` unique
 - `ShowEvent.eventLookupKey` unique
 - `ShowEntry.entryLookupKey` unique
 - `ShowResultItem.itemLookupKey` unique

--- a/docs/features/trials/ajokoe-suunnitelma-yksinkertainen-nyt.md
+++ b/docs/features/trials/ajokoe-suunnitelma-yksinkertainen-nyt.md
@@ -1,4 +1,10 @@
-# AJOK suunnitelma - yksinkertainen nyt
+# AJOK suunnitelma - yksinkertainen nyt (ARCHIVED)
+
+## Status
+
+- Tämä dokumentti on arkistoitu 2026-04-15.
+- Aktiivinen lähde on `docs/features/trials/ajokoe-suunnitelma.md`.
+- Uudet toteutuspäätökset ja muutokset kirjataan vain aktiiviseen dokumenttiin.
 
 Tama on erillinen uusi dokumentti nykyista toteutusta varten.
 Ei oletuksia seuraavista vaiheista.

--- a/docs/features/trials/ajokoe-suunnitelma.md
+++ b/docs/features/trials/ajokoe-suunnitelma.md
@@ -23,6 +23,11 @@
 - `rekisterinumeroSnapshot` on pakollinen.
 - Lisätiedot 11-61 tallennetaan rakenteisesti.
 - Koko saapuva payload tallennetaan myös `raakadataJson`-kenttään.
+- Järjestelmätimestampit ovat DB-omisteisia:
+  - `createdAt` asetetaan vain luontihetkellä.
+  - `updatedAt` päivittyy aina DB/Prisma-mekanismin kautta.
+  - Kirjoituskoodit (BEJ-80/84) eivät saa asettaa `createdAt` tai `updatedAt`
+    manuaalisesti create/update payloadiin.
 
 ## Tietomalli
 

--- a/packages/db/prisma/migrations/20260414161000_bej79_add_ajok_trial_event_entry/migration.sql
+++ b/packages/db/prisma/migrations/20260414161000_bej79_add_ajok_trial_event_entry/migration.sql
@@ -1,0 +1,151 @@
+-- CreateEnum
+CREATE TYPE "TrialSourceTag" AS ENUM ('LEGACY_AKOEALL', 'KOIRATIETOKANTA_API');
+
+-- CreateTable
+CREATE TABLE "TrialEvent" (
+    "id" TEXT NOT NULL,
+    "sklKoeId" INTEGER NOT NULL,
+    "koepaiva" TIMESTAMP(3) NOT NULL,
+    "koekunta" TEXT NOT NULL,
+    "jarjestaja" TEXT,
+    "kennelpiiri" TEXT,
+    "kennelpiirinro" TEXT,
+    "koemuoto" TEXT,
+    "rotukoodi" TEXT,
+    "ylituomariNimi" TEXT,
+    "ylituomariNumero" TEXT,
+    "ytKertomus" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TrialEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TrialEntry" (
+    "id" TEXT NOT NULL,
+    "trialEventId" TEXT NOT NULL,
+    "dogId" TEXT,
+    "rekisterinumeroSnapshot" TEXT NOT NULL,
+    "yksilointiAvain" TEXT NOT NULL,
+    "lahde" "TrialSourceTag" NOT NULL,
+    "raakadataJson" TEXT,
+    "koiranNimiSnapshot" TEXT,
+    "omistajaSnapshot" TEXT,
+    "palkinto" TEXT,
+    "sijoitus" TEXT,
+    "koiriaLuokassa" INTEGER,
+    "loppupisteet" DECIMAL(6,2),
+    "hakuMin1" INTEGER,
+    "hakuMin2" INTEGER,
+    "hakuMin3" INTEGER,
+    "hakuMin4" INTEGER,
+    "ajoMin1" INTEGER,
+    "ajoMin2" INTEGER,
+    "ajoMin3" INTEGER,
+    "ajoMin4" INTEGER,
+    "hakuKeskiarvo" DECIMAL(6,2),
+    "haukkuKeskiarvo" DECIMAL(6,2),
+    "ajotaitoKeskiarvo" DECIMAL(6,2),
+    "hakuloysyysTappioYhteensa" DECIMAL(6,2),
+    "ajoloysyysTappioYhteensa" DECIMAL(6,2),
+    "keli" TEXT,
+    "luopui" BOOLEAN,
+    "suljettu" BOOLEAN,
+    "keskeytetty" BOOLEAN,
+    "huomautusTeksti" TEXT,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TrialEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TrialLisatietoItem" (
+    "id" TEXT NOT NULL,
+    "trialEntryId" TEXT NOT NULL,
+    "koodi" TEXT NOT NULL,
+    "nimi" TEXT NOT NULL,
+    "era1Arvo" TEXT,
+    "era2Arvo" TEXT,
+    "era3Arvo" TEXT,
+    "era4Arvo" TEXT,
+    "jarjestys" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TrialLisatietoItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TrialEvent_sklKoeId_key" ON "TrialEvent"("sklKoeId");
+
+-- CreateIndex
+CREATE INDEX "TrialEvent_koepaiva_idx" ON "TrialEvent"("koepaiva");
+
+-- CreateIndex
+CREATE INDEX "TrialEvent_koekunta_koepaiva_idx" ON "TrialEvent"("koekunta", "koepaiva");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TrialEntry_yksilointiAvain_key" ON "TrialEntry"("yksilointiAvain");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TrialEntry_trialEventId_rekisterinumeroSnapshot_key" ON "TrialEntry"("trialEventId", "rekisterinumeroSnapshot");
+
+-- CreateIndex
+CREATE INDEX "TrialEntry_dogId_idx" ON "TrialEntry"("dogId");
+
+-- CreateIndex
+CREATE INDEX "TrialEntry_trialEventId_idx" ON "TrialEntry"("trialEventId");
+
+-- CreateIndex
+CREATE INDEX "TrialEntry_loppupisteet_idx" ON "TrialEntry"("loppupisteet");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TrialLisatietoItem_trialEntryId_koodi_key" ON "TrialLisatietoItem"("trialEntryId", "koodi");
+
+-- CreateIndex
+CREATE INDEX "TrialLisatietoItem_koodi_idx" ON "TrialLisatietoItem"("koodi");
+
+-- CreateIndex
+CREATE INDEX "TrialLisatietoItem_trialEntryId_idx" ON "TrialLisatietoItem"("trialEntryId");
+
+-- AddForeignKey
+ALTER TABLE "TrialEntry" ADD CONSTRAINT "TrialEntry_trialEventId_fkey" FOREIGN KEY ("trialEventId") REFERENCES "TrialEvent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TrialEntry" ADD CONSTRAINT "TrialEntry_dogId_fkey" FOREIGN KEY ("dogId") REFERENCES "Dog"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TrialLisatietoItem" ADD CONSTRAINT "TrialLisatietoItem_trialEntryId_fkey" FOREIGN KEY ("trialEntryId") REFERENCES "TrialEntry"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Table/column comments for AJOK canonical trial schema
+COMMENT ON TABLE "TrialEvent" IS 'AJOK-kokeen tapahtumatason kanoninen rivi.';
+COMMENT ON COLUMN "TrialEvent"."sklKoeId" IS 'SKL:n tapahtuma-avain (uniikki).';
+COMMENT ON COLUMN "TrialEvent"."koepaiva" IS 'Kokeen paivamaara.';
+COMMENT ON COLUMN "TrialEvent"."koekunta" IS 'Kokeen paikkakunta.';
+COMMENT ON COLUMN "TrialEvent"."ylituomariNimi" IS 'Ylituomarin nimi tapahtumatasolla.';
+COMMENT ON COLUMN "TrialEvent"."ylituomariNumero" IS 'Ylituomarin numero tapahtumatasolla.';
+
+COMMENT ON TABLE "TrialEntry" IS 'AJOK-kokeen koirakohtainen tulosrivi tapahtuman alla.';
+COMMENT ON COLUMN "TrialEntry"."rekisterinumeroSnapshot" IS 'Koiran rekisterinumero snapshot import/upsert-hetkella.';
+COMMENT ON COLUMN "TrialEntry"."yksilointiAvain" IS 'Tekninen yksilointiavain import/upsert-ajoon.';
+COMMENT ON COLUMN "TrialEntry"."lahde" IS 'Lahdetunniste (legacy/API).';
+COMMENT ON COLUMN "TrialEntry"."raakadataJson" IS 'Koko alkuperainen payload audit/debug/replay-kayttoon.';
+
+COMMENT ON TABLE "TrialLisatietoItem" IS 'AJOK-lisatieto (koodi 11-61) koirakohtaiselle trial entrylle.';
+COMMENT ON COLUMN "TrialLisatietoItem"."koodi" IS 'Lisatietokoodi (esim. 11, 42, 61).';
+COMMENT ON COLUMN "TrialLisatietoItem"."nimi" IS 'Lisatietorivin nimi.';
+
+CREATE TRIGGER trg_audit_trial_event
+AFTER INSERT OR UPDATE OR DELETE ON "TrialEvent"
+FOR EACH ROW EXECUTE FUNCTION audit_capture_row_change();
+
+CREATE TRIGGER trg_audit_trial_entry
+AFTER INSERT OR UPDATE OR DELETE ON "TrialEntry"
+FOR EACH ROW EXECUTE FUNCTION audit_capture_row_change();
+
+CREATE TRIGGER trg_audit_trial_lisatieto_item
+AFTER INSERT OR UPDATE OR DELETE ON "TrialLisatietoItem"
+FOR EACH ROW EXECUTE FUNCTION audit_capture_row_change();

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -45,6 +45,11 @@ enum ShowSourceTag {
   MANUAL_ADMIN
 }
 
+enum TrialSourceTag {
+  LEGACY_AKOEALL
+  KOIRATIETOKANTA_API
+}
+
 enum ShowResultValueType {
   FLAG
   CODE
@@ -184,6 +189,7 @@ model Dog {
   ownerships      DogOwnership[]
   titles          DogTitle[]
   trialResults    TrialResult[]
+  trialEntries    TrialEntry[]
   showEntries     ShowEntry[]
   createdAt       DateTime          @default(now())
   updatedAt       DateTime          @updatedAt
@@ -297,6 +303,91 @@ model TrialResult {
 
   @@index([eventDate])
   @@index([dogId, eventDate])
+}
+
+model TrialEvent {
+  id               String       @id @default(cuid())
+  sklKoeId         Int          @unique
+  koepaiva         DateTime
+  koekunta         String
+  jarjestaja       String?
+  kennelpiiri      String?
+  kennelpiirinro   String?
+  koemuoto         String?
+  rotukoodi        String?
+  ylituomariNimi   String?
+  ylituomariNumero String?
+  ytKertomus       String?      @db.Text
+  entries          TrialEntry[]
+  createdAt        DateTime     @default(now())
+  updatedAt        DateTime     @updatedAt
+
+  @@index([koepaiva])
+  @@index([koekunta, koepaiva])
+}
+
+model TrialEntry {
+  id                        String         @id @default(cuid())
+  trialEventId              String
+  dogId                     String?
+  rekisterinumeroSnapshot   String
+  yksilointiAvain           String         @unique
+  lahde                     TrialSourceTag
+  raakadataJson             String?        @db.Text
+  koiranNimiSnapshot        String?
+  omistajaSnapshot          String?
+  palkinto                  String?
+  sijoitus                  String?
+  koiriaLuokassa            Int?
+  loppupisteet              Decimal?       @db.Decimal(6, 2)
+  hakuMin1                  Int?
+  hakuMin2                  Int?
+  hakuMin3                  Int?
+  hakuMin4                  Int?
+  ajoMin1                   Int?
+  ajoMin2                   Int?
+  ajoMin3                   Int?
+  ajoMin4                   Int?
+  hakuKeskiarvo             Decimal?       @db.Decimal(6, 2)
+  haukkuKeskiarvo           Decimal?       @db.Decimal(6, 2)
+  ajotaitoKeskiarvo         Decimal?       @db.Decimal(6, 2)
+  hakuloysyysTappioYhteensa Decimal?       @db.Decimal(6, 2)
+  ajoloysyysTappioYhteensa  Decimal?       @db.Decimal(6, 2)
+  keli                      String?
+  luopui                    Boolean?
+  suljettu                  Boolean?
+  keskeytetty               Boolean?
+  huomautusTeksti           String?        @db.Text
+  notes                     String?        @db.Text
+  lisatiedot                TrialLisatietoItem[]
+  trialEvent                TrialEvent     @relation(fields: [trialEventId], references: [id], onDelete: Cascade)
+  dog                       Dog?           @relation(fields: [dogId], references: [id], onDelete: SetNull)
+  createdAt                 DateTime       @default(now())
+  updatedAt                 DateTime       @updatedAt
+
+  @@unique([trialEventId, rekisterinumeroSnapshot])
+  @@index([dogId])
+  @@index([trialEventId])
+  @@index([loppupisteet])
+}
+
+model TrialLisatietoItem {
+  id           String     @id @default(cuid())
+  trialEntryId String
+  koodi        String
+  nimi         String
+  era1Arvo     String?
+  era2Arvo     String?
+  era3Arvo     String?
+  era4Arvo     String?
+  jarjestys    Int?
+  trialEntry   TrialEntry @relation(fields: [trialEntryId], references: [id], onDelete: Cascade)
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
+
+  @@unique([trialEntryId, koodi])
+  @@index([koodi])
+  @@index([trialEntryId])
 }
 
 model ShowEvent {


### PR DESCRIPTION
- add `TrialEvent`, `TrialEntry`, and `TrialLisatietoItem` to Prisma with indexes, relations, audit triggers, and source tagging
- update trial/schema docs to describe the new canonical model and the BEJ-79 rollout constraints

closes: BEJ-79
