### PR TITLE
Feature/bej-91 finalise ajokoepöytäkirja pdf generator 

### DIFF
--- a/apps/web/app/api/trials/[trialId]/pdf/route.ts
+++ b/apps/web/app/api/trials/[trialId]/pdf/route.ts
@@ -108,6 +108,8 @@ export async function GET(
 
     const ryhmatuomariNimi = result.body.data.ryhmatuomariNimi;
     const palkintotuomariNimi = result.body.data.palkintotuomariNimi;
+    const ylituomariNumeroSnapshot = result.body.data.ylituomariNumeroSnapshot;
+    const ylituomariNimiSnapshot = result.body.data.ylituomariNimiSnapshot;
 
     const pdfBytes = await renderTrialDogPdf({
       registrationNo,
@@ -160,6 +162,8 @@ export async function GET(
       huomautusTeksti,
       ryhmatuomariNimi,
       palkintotuomariNimi,
+      ylituomariNumeroSnapshot,
+      ylituomariNimiSnapshot,
     });
 
     log.info(

--- a/apps/web/app/api/trials/[trialId]/pdf/route.ts
+++ b/apps/web/app/api/trials/[trialId]/pdf/route.ts
@@ -107,6 +107,7 @@ export async function GET(
     const huomautusTeksti = result.body.data.huomautusTeksti;
 
     const ryhmatuomariNimi = result.body.data.ryhmatuomariNimi;
+    const palkintotuomariNimi = result.body.data.palkintotuomariNimi;
 
     const pdfBytes = await renderTrialDogPdf({
       registrationNo,
@@ -158,6 +159,7 @@ export async function GET(
       Palkinto,
       huomautusTeksti,
       ryhmatuomariNimi,
+      palkintotuomariNimi,
     });
 
     log.info(

--- a/apps/web/app/api/trials/[trialId]/pdf/route.ts
+++ b/apps/web/app/api/trials/[trialId]/pdf/route.ts
@@ -110,6 +110,7 @@ export async function GET(
     const palkintotuomariNimi = result.body.data.palkintotuomariNimi;
     const ylituomariNumeroSnapshot = result.body.data.ylituomariNumeroSnapshot;
     const ylituomariNimiSnapshot = result.body.data.ylituomariNimiSnapshot;
+    const lisatiedotRows = result.body.data.lisatiedotRows;
 
     const pdfBytes = await renderTrialDogPdf({
       registrationNo,
@@ -164,6 +165,7 @@ export async function GET(
       palkintotuomariNimi,
       ylituomariNumeroSnapshot,
       ylituomariNimiSnapshot,
+      lisatiedotRows,
     });
 
     log.info(

--- a/apps/web/app/api/trials/[trialId]/pdf/route.ts
+++ b/apps/web/app/api/trials/[trialId]/pdf/route.ts
@@ -106,6 +106,8 @@ export async function GET(
     const Palkinto = result.body.data.Palkinto;
     const huomautusTeksti = result.body.data.huomautusTeksti;
 
+    const ryhmatuomariNimi = result.body.data.ryhmatuomariNimi;
+
     const pdfBytes = await renderTrialDogPdf({
       registrationNo,
       dogName,
@@ -155,6 +157,7 @@ export async function GET(
       koiriaLuokassa,
       Palkinto,
       huomautusTeksti,
+      ryhmatuomariNimi,
     });
 
     log.info(

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-allekirjoitukset.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-allekirjoitukset.test.ts
@@ -1,0 +1,39 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { drawTrialDogPdfAllekirjoitukset } from "../internal/allekirjoitukset";
+
+describe("drawTrialDogPdfAllekirjoitukset", () => {
+  const page = {
+    drawText: vi.fn(),
+  } as unknown as PDFPage;
+  const font = {} as PDFFont;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders dashes for missing judge names", () => {
+    drawTrialDogPdfAllekirjoitukset({
+      ryhmatuomariNimi: null,
+      palkintotuomariNimi: "",
+      page,
+      font,
+    });
+
+    expect(page.drawText).toHaveBeenCalledTimes(2);
+    expect(page.drawText).toHaveBeenNthCalledWith(1, "-", {
+      x: 513,
+      y: 161.6,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(2, "-", {
+      x: 513,
+      y: 122.6,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+  });
+});

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-allekirjoitukset.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-allekirjoitukset.test.ts
@@ -16,11 +16,13 @@ describe("drawTrialDogPdfAllekirjoitukset", () => {
     drawTrialDogPdfAllekirjoitukset({
       ryhmatuomariNimi: null,
       palkintotuomariNimi: "",
+      ylituomariNumeroSnapshot: "123445",
+      ylituomariNimiSnapshot: "Testi Nimi",
       page,
       font,
     });
 
-    expect(page.drawText).toHaveBeenCalledTimes(2);
+    expect(page.drawText).toHaveBeenCalledTimes(4);
     expect(page.drawText).toHaveBeenNthCalledWith(1, "-", {
       x: 513,
       y: 161.6,
@@ -31,6 +33,20 @@ describe("drawTrialDogPdfAllekirjoitukset", () => {
     expect(page.drawText).toHaveBeenNthCalledWith(2, "-", {
       x: 513,
       y: 122.6,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(3, "123445", {
+      x: 513,
+      y: 82.7,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(4, "Testi Nimi", {
+      x: 570,
+      y: 82.7,
       size: 10,
       font,
       color: expect.any(Object),

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-ajo.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-ajo.test.ts
@@ -1,0 +1,130 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { drawTrialDogPdfLisatiedotAjo } from "../internal/lisatiedot/ajo";
+
+describe("drawTrialDogPdfLisatiedotAjo", () => {
+  const page = {
+    drawText: vi.fn(),
+  } as unknown as PDFPage;
+  const font = {} as PDFFont;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders ajo 50-56 with one-decimal formatting", () => {
+    drawTrialDogPdfLisatiedotAjo({
+      lisatiedotRows: [
+        { koodi: "50", era1: "2.00", era2: "0.00" },
+        { koodi: "51", era1: "3.00", era2: "0.00" },
+        { koodi: "52", era1: "3.00", era2: "0.00" },
+        { koodi: "53", era1: "2.00", era2: "0.00" },
+        { koodi: "54", era1: "6.00", era2: "0.00" },
+        { koodi: "55", era1: "0.00", era2: "0.00" },
+        { koodi: "56", era1: "5.00", era2: "0.00" },
+      ],
+      page,
+      font,
+    });
+
+    expect(page.drawText).toHaveBeenCalledTimes(14);
+    expect(page.drawText).toHaveBeenNthCalledWith(1, "2.0", {
+      x: 782,
+      y: 431.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(2, "0.0", {
+      x: 799,
+      y: 431.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(3, "3.0", {
+      x: 782,
+      y: 417.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(4, "0.0", {
+      x: 799,
+      y: 417.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(5, "3.0", {
+      x: 782,
+      y: 403.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(6, "0.0", {
+      x: 799,
+      y: 403.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(7, "2.0", {
+      x: 782,
+      y: 389.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(8, "0.0", {
+      x: 799,
+      y: 389.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(9, "6.0", {
+      x: 782,
+      y: 375.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(10, "0.0", {
+      x: 799,
+      y: 375.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(11, "0.0", {
+      x: 782,
+      y: 361.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(12, "0.0", {
+      x: 799,
+      y: 361.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(13, "5.0", {
+      x: 782,
+      y: 347.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(14, "0.0", {
+      x: 799,
+      y: 347.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+  });
+});

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-ajo.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-ajo.test.ts
@@ -30,98 +30,98 @@ describe("drawTrialDogPdfLisatiedotAjo", () => {
     expect(page.drawText).toHaveBeenCalledTimes(14);
     expect(page.drawText).toHaveBeenNthCalledWith(1, "2.0", {
       x: 782,
-      y: 431.5,
+      y: 431,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(2, "0.0", {
       x: 799,
-      y: 431.5,
+      y: 431,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(3, "3.0", {
       x: 782,
-      y: 417.5,
+      y: 417,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(4, "0.0", {
       x: 799,
-      y: 417.5,
+      y: 417,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(5, "3.0", {
       x: 782,
-      y: 403.5,
+      y: 403,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(6, "0.0", {
       x: 799,
-      y: 403.5,
+      y: 403,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(7, "2.0", {
       x: 782,
-      y: 389.5,
+      y: 389,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(8, "0.0", {
       x: 799,
-      y: 389.5,
+      y: 389,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(9, "6.0", {
       x: 782,
-      y: 375.5,
+      y: 375,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(10, "0.0", {
       x: 799,
-      y: 375.5,
+      y: 375,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(11, "0.0", {
       x: 782,
-      y: 361.5,
+      y: 361,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(12, "0.0", {
       x: 799,
-      y: 361.5,
+      y: 361,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(13, "5.0", {
       x: 782,
-      y: 347.5,
+      y: 347,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(14, "0.0", {
       x: 799,
-      y: 347.5,
+      y: 347,
       size: 10,
       font,
       color: expect.any(Object),

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-haku.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-haku.test.ts
@@ -1,0 +1,80 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { drawTrialDogPdfLisatiedotHaku } from "../internal/lisatiedot/haku";
+
+describe("drawTrialDogPdfLisatiedotHaku", () => {
+  const page = {
+    drawText: vi.fn(),
+  } as unknown as PDFPage;
+  const font = {} as PDFFont;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders haku 20-22 with integer and one-decimal formatting", () => {
+    drawTrialDogPdfLisatiedotHaku({
+      lisatiedotRows: [
+        { koodi: "20", era1: "4", era2: "0" },
+        { koodi: "21", era1: "3.00", era2: "0.00" },
+        { koodi: "22", era1: "2,25", era2: "1.00" },
+      ],
+      page,
+      font,
+    });
+
+    expect(page.drawText).toHaveBeenCalledTimes(6);
+    expect(page.drawText).toHaveBeenNthCalledWith(1, "4", {
+      x: 590,
+      y: 360.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(2, "0", {
+      x: 607,
+      y: 360.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(3, "3.0", {
+      x: 590,
+      y: 346.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(4, "0.0", {
+      x: 607,
+      y: 346.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(5, "2.3", {
+      x: 590,
+      y: 332.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(6, "1.0", {
+      x: 607,
+      y: 332.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+  });
+
+  it("skips empty haku values", () => {
+    drawTrialDogPdfLisatiedotHaku({
+      lisatiedotRows: [{ koodi: "20", era1: null, era2: null }],
+      page,
+      font,
+    });
+
+    expect(page.drawText).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-haukku.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-haukku.test.ts
@@ -30,98 +30,98 @@ describe("drawTrialDogPdfLisatiedotHaukku", () => {
     expect(page.drawText).toHaveBeenCalledTimes(14);
     expect(page.drawText).toHaveBeenNthCalledWith(1, "4.0", {
       x: 590,
-      y: 304.5,
+      y: 303.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(2, "0.0", {
       x: 607,
-      y: 304.5,
+      y: 303.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(3, "3.0", {
       x: 590,
-      y: 290.5,
+      y: 289.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(4, "0.0", {
       x: 607,
-      y: 290.5,
+      y: 289.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(5, "3.0", {
       x: 590,
-      y: 276.5,
+      y: 275.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(6, "0.0", {
       x: 607,
-      y: 276.5,
+      y: 275.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(7, "3.0", {
       x: 590,
-      y: 262.5,
+      y: 261.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(8, "0.0", {
       x: 607,
-      y: 262.5,
+      y: 261.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(9, "3.0", {
       x: 590,
-      y: 248.5,
+      y: 247.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(10, "0.0", {
       x: 607,
-      y: 248.5,
+      y: 247.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(11, "5.0", {
       x: 590,
-      y: 234.5,
+      y: 233.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(12, "0.0", {
       x: 607,
-      y: 234.5,
+      y: 233.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(13, "4", {
       x: 590,
-      y: 220.5,
+      y: 219.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(14, "0", {
       x: 607,
-      y: 220.5,
+      y: 219.5,
       size: 10,
       font,
       color: expect.any(Object),

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-haukku.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-haukku.test.ts
@@ -1,0 +1,130 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { drawTrialDogPdfLisatiedotHaukku } from "../internal/lisatiedot/haukku";
+
+describe("drawTrialDogPdfLisatiedotHaukku", () => {
+  const page = {
+    drawText: vi.fn(),
+  } as unknown as PDFPage;
+  const font = {} as PDFFont;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders haukku 30-36 with decimal and integer formatting", () => {
+    drawTrialDogPdfLisatiedotHaukku({
+      lisatiedotRows: [
+        { koodi: "30", era1: "4.00", era2: "0.00" },
+        { koodi: "31", era1: "3.00", era2: "0.00" },
+        { koodi: "32", era1: "3.00", era2: "0.00" },
+        { koodi: "33", era1: "3.00", era2: "0.00" },
+        { koodi: "34", era1: "3.00", era2: "0.00" },
+        { koodi: "35", era1: "5.00", era2: "0.00" },
+        { koodi: "36", era1: "4", era2: "0" },
+      ],
+      page,
+      font,
+    });
+
+    expect(page.drawText).toHaveBeenCalledTimes(14);
+    expect(page.drawText).toHaveBeenNthCalledWith(1, "4.0", {
+      x: 591,
+      y: 304.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(2, "0.0", {
+      x: 608,
+      y: 304.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(3, "3.0", {
+      x: 591,
+      y: 290.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(4, "0.0", {
+      x: 608,
+      y: 290.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(5, "3.0", {
+      x: 591,
+      y: 276.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(6, "0.0", {
+      x: 608,
+      y: 276.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(7, "3.0", {
+      x: 591,
+      y: 262.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(8, "0.0", {
+      x: 608,
+      y: 262.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(9, "3.0", {
+      x: 591,
+      y: 248.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(10, "0.0", {
+      x: 608,
+      y: 248.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(11, "5.0", {
+      x: 591,
+      y: 234.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(12, "0.0", {
+      x: 608,
+      y: 234.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(13, "4", {
+      x: 591,
+      y: 220.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(14, "0", {
+      x: 608,
+      y: 220.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+  });
+});

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-haukku.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-haukku.test.ts
@@ -29,98 +29,98 @@ describe("drawTrialDogPdfLisatiedotHaukku", () => {
 
     expect(page.drawText).toHaveBeenCalledTimes(14);
     expect(page.drawText).toHaveBeenNthCalledWith(1, "4.0", {
-      x: 591,
+      x: 590,
       y: 304.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(2, "0.0", {
-      x: 608,
+      x: 607,
       y: 304.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(3, "3.0", {
-      x: 591,
+      x: 590,
       y: 290.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(4, "0.0", {
-      x: 608,
+      x: 607,
       y: 290.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(5, "3.0", {
-      x: 591,
+      x: 590,
       y: 276.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(6, "0.0", {
-      x: 608,
+      x: 607,
       y: 276.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(7, "3.0", {
-      x: 591,
+      x: 590,
       y: 262.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(8, "0.0", {
-      x: 608,
+      x: 607,
       y: 262.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(9, "3.0", {
-      x: 591,
+      x: 590,
       y: 248.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(10, "0.0", {
-      x: 608,
+      x: 607,
       y: 248.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(11, "5.0", {
-      x: 591,
+      x: 590,
       y: 234.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(12, "0.0", {
-      x: 608,
+      x: 607,
       y: 234.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(13, "4", {
-      x: 591,
+      x: 590,
       y: 220.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(14, "0", {
-      x: 608,
+      x: 607,
       y: 220.5,
       size: 10,
       font,

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-metsastysinto.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-metsastysinto.test.ts
@@ -1,0 +1,70 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { drawTrialDogPdfLisatiedotMetsastysinto } from "../internal/lisatiedot/metsastysinto";
+
+describe("drawTrialDogPdfLisatiedotMetsastysinto", () => {
+  const page = {
+    drawText: vi.fn(),
+  } as unknown as PDFPage;
+  const font = {} as PDFFont;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders metsästysinto 40-42 with one-decimal formatting", () => {
+    drawTrialDogPdfLisatiedotMetsastysinto({
+      lisatiedotRows: [
+        { koodi: "40", era1: "4.00", era2: "0.00" },
+        { koodi: "41", era1: "3.00", era2: "0.00" },
+        { koodi: "42", era1: "3.00", era2: "0.00" },
+      ],
+      page,
+      font,
+    });
+
+    expect(page.drawText).toHaveBeenCalledTimes(6);
+    expect(page.drawText).toHaveBeenNthCalledWith(1, "4.0", {
+      x: 670,
+      y: 487.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(2, "0.0", {
+      x: 687,
+      y: 487.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(3, "3.0", {
+      x: 670,
+      y: 473.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(4, "0.0", {
+      x: 687,
+      y: 473.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(5, "3.0", {
+      x: 670,
+      y: 459.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(6, "0.0", {
+      x: 687,
+      y: 459.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+  });
+});

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-metsastysinto.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-metsastysinto.test.ts
@@ -25,42 +25,42 @@ describe("drawTrialDogPdfLisatiedotMetsastysinto", () => {
 
     expect(page.drawText).toHaveBeenCalledTimes(6);
     expect(page.drawText).toHaveBeenNthCalledWith(1, "4.0", {
-      x: 670,
+      x: 782,
       y: 487.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(2, "0.0", {
-      x: 687,
+      x: 799,
       y: 487.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(3, "3.0", {
-      x: 670,
+      x: 782,
       y: 473.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(4, "0.0", {
-      x: 687,
+      x: 799,
       y: 473.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(5, "3.0", {
-      x: 670,
+      x: 782,
       y: 459.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(6, "0.0", {
-      x: 687,
+      x: 799,
       y: 459.5,
       size: 10,
       font,

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-muut-ominaisuudet.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-muut-ominaisuudet.test.ts
@@ -1,0 +1,55 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { drawTrialDogPdfLisatiedotMuutOminaisuudet } from "../internal/lisatiedot/muut-ominaisuudet";
+
+describe("drawTrialDogPdfLisatiedotMuutOminaisuudet", () => {
+  const page = {
+    drawText: vi.fn(),
+  } as unknown as PDFPage;
+  const font = {} as PDFFont;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders muut ominaisuudet 60-61 with one-decimal formatting", () => {
+    drawTrialDogPdfLisatiedotMuutOminaisuudet({
+      lisatiedotRows: [
+        { koodi: "60", era1: "3.00", era2: "0.00" },
+        { koodi: "61", era1: "0.00", era2: "0.00" },
+      ],
+      page,
+      font,
+    });
+
+    expect(page.drawText).toHaveBeenCalledTimes(4);
+    expect(page.drawText).toHaveBeenNthCalledWith(1, "3.0", {
+      x: 782,
+      y: 303.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(2, "0.0", {
+      x: 799,
+      y: 303.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(3, "0.0", {
+      x: 782,
+      y: 289.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(4, "0.0", {
+      x: 799,
+      y: 289.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+  });
+});

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-olosuhteet.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-olosuhteet.test.ts
@@ -1,8 +1,8 @@
 import type { PDFFont, PDFPage } from "pdf-lib";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { drawTrialDogPdfLisatieto11 } from "../internal/lisatieto-11";
+import { drawTrialDogPdfLisatiedotOlosuhteet } from "../internal/lisatiedot/olosuhteet";
 
-describe("drawTrialDogPdfLisatieto11", () => {
+describe("drawTrialDogPdfLisatiedotOlosuhteet", () => {
   const page = {
     drawText: vi.fn(),
   } as unknown as PDFPage;
@@ -13,7 +13,7 @@ describe("drawTrialDogPdfLisatieto11", () => {
   });
 
   it("renders lisatieto 11 era values with separate coordinates", () => {
-    drawTrialDogPdfLisatieto11({
+    drawTrialDogPdfLisatiedotOlosuhteet({
       lisatiedotRows: [
         { koodi: "11", era1: "1", era2: null },
         { koodi: "12", era1: "5", era2: "7" },
@@ -40,7 +40,7 @@ describe("drawTrialDogPdfLisatieto11", () => {
   });
 
   it("does not render when paljas maa marker is missing", () => {
-    drawTrialDogPdfLisatieto11({
+    drawTrialDogPdfLisatiedotOlosuhteet({
       lisatiedotRows: [{ koodi: "11", era1: null, era2: null }],
       page,
       font,
@@ -50,7 +50,7 @@ describe("drawTrialDogPdfLisatieto11", () => {
   });
 
   it("renders empty text for zero marker values", () => {
-    drawTrialDogPdfLisatieto11({
+    drawTrialDogPdfLisatiedotOlosuhteet({
       lisatiedotRows: [{ koodi: "11", era1: "1", era2: "0" }],
       page,
       font,

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-olosuhteet.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-olosuhteet.test.ts
@@ -12,17 +12,23 @@ describe("drawTrialDogPdfLisatiedotOlosuhteet", () => {
     vi.clearAllMocks();
   });
 
-  it("renders lisatieto 11 era values with separate coordinates", () => {
+  it("renders olosuhteet 11-18 with marker and numeric rules", () => {
     drawTrialDogPdfLisatiedotOlosuhteet({
       lisatiedotRows: [
         { koodi: "11", era1: "1", era2: null },
-        { koodi: "12", era1: "5", era2: "7" },
+        { koodi: "12", era1: "0", era2: "0" },
+        { koodi: "13", era1: "0", era2: "1" },
+        { koodi: "14", era1: "1", era2: "1" },
+        { koodi: "15", era1: "0", era2: "0" },
+        { koodi: "16", era1: "0", era2: "0" },
+        { koodi: "17", era1: "5", era2: "0" },
+        { koodi: "18", era1: "0", era2: "5" },
       ],
       page,
       font,
     });
 
-    expect(page.drawText).toHaveBeenCalledTimes(2);
+    expect(page.drawText).toHaveBeenCalledTimes(10);
     expect(page.drawText).toHaveBeenNthCalledWith(1, "X", {
       x: 592,
       y: 487.5,
@@ -30,10 +36,66 @@ describe("drawTrialDogPdfLisatiedotOlosuhteet", () => {
       font,
       color: expect.any(Object),
     });
-    expect(page.drawText).toHaveBeenNthCalledWith(2, "", {
+    expect(page.drawText).toHaveBeenNthCalledWith(2, "0", {
+      x: 591,
+      y: 474.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(3, "0", {
+      x: 608,
+      y: 474.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(4, "X", {
       x: 609,
-      y: 487.5,
+      y: 459.5,
       size: 12,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(5, "X", {
+      x: 592,
+      y: 445.5,
+      size: 12,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(6, "X", {
+      x: 609,
+      y: 445.5,
+      size: 12,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(7, "5", {
+      x: 591,
+      y: 402.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(8, "0", {
+      x: 608,
+      y: 402.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(9, "0", {
+      x: 591,
+      y: 388.5,
+      size: 10,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(10, "5", {
+      x: 608,
+      y: 388.5,
+      size: 10,
       font,
       color: expect.any(Object),
     });
@@ -63,12 +125,6 @@ describe("drawTrialDogPdfLisatiedotOlosuhteet", () => {
       font,
       color: expect.any(Object),
     });
-    expect(page.drawText).toHaveBeenNthCalledWith(2, "", {
-      x: 609,
-      y: 487.5,
-      size: 12,
-      font,
-      color: expect.any(Object),
-    });
+    expect(page.drawText).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-olosuhteet.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatiedot-olosuhteet.test.ts
@@ -30,70 +30,70 @@ describe("drawTrialDogPdfLisatiedotOlosuhteet", () => {
 
     expect(page.drawText).toHaveBeenCalledTimes(10);
     expect(page.drawText).toHaveBeenNthCalledWith(1, "X", {
-      x: 592,
+      x: 591,
       y: 487.5,
       size: 12,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(2, "0", {
-      x: 591,
+      x: 590,
       y: 474.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(3, "0", {
-      x: 608,
+      x: 607,
       y: 474.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(4, "X", {
-      x: 609,
+      x: 608,
       y: 459.5,
       size: 12,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(5, "X", {
-      x: 592,
+      x: 591,
       y: 445.5,
       size: 12,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(6, "X", {
-      x: 609,
+      x: 608,
       y: 445.5,
       size: 12,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(7, "5", {
-      x: 591,
+      x: 590,
       y: 402.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(8, "0", {
-      x: 608,
+      x: 607,
       y: 402.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(9, "0", {
-      x: 591,
+      x: 590,
       y: 388.5,
       size: 10,
       font,
       color: expect.any(Object),
     });
     expect(page.drawText).toHaveBeenNthCalledWith(10, "5", {
-      x: 608,
+      x: 607,
       y: 388.5,
       size: 10,
       font,
@@ -119,7 +119,7 @@ describe("drawTrialDogPdfLisatiedotOlosuhteet", () => {
     });
 
     expect(page.drawText).toHaveBeenNthCalledWith(1, "X", {
-      x: 592,
+      x: 591,
       y: 487.5,
       size: 12,
       font,

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatieto-11.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-lisatieto-11.test.ts
@@ -1,0 +1,74 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { drawTrialDogPdfLisatieto11 } from "../internal/lisatieto-11";
+
+describe("drawTrialDogPdfLisatieto11", () => {
+  const page = {
+    drawText: vi.fn(),
+  } as unknown as PDFPage;
+  const font = {} as PDFFont;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders lisatieto 11 era values with separate coordinates", () => {
+    drawTrialDogPdfLisatieto11({
+      lisatiedotRows: [
+        { koodi: "11", era1: "1", era2: null },
+        { koodi: "12", era1: "5", era2: "7" },
+      ],
+      page,
+      font,
+    });
+
+    expect(page.drawText).toHaveBeenCalledTimes(2);
+    expect(page.drawText).toHaveBeenNthCalledWith(1, "X", {
+      x: 592,
+      y: 487.5,
+      size: 12,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(2, "", {
+      x: 609,
+      y: 487.5,
+      size: 12,
+      font,
+      color: expect.any(Object),
+    });
+  });
+
+  it("does not render when paljas maa marker is missing", () => {
+    drawTrialDogPdfLisatieto11({
+      lisatiedotRows: [{ koodi: "11", era1: null, era2: null }],
+      page,
+      font,
+    });
+
+    expect(page.drawText).not.toHaveBeenCalled();
+  });
+
+  it("renders empty text for zero marker values", () => {
+    drawTrialDogPdfLisatieto11({
+      lisatiedotRows: [{ koodi: "11", era1: "1", era2: "0" }],
+      page,
+      font,
+    });
+
+    expect(page.drawText).toHaveBeenNthCalledWith(1, "X", {
+      x: 592,
+      y: 487.5,
+      size: 12,
+      font,
+      color: expect.any(Object),
+    });
+    expect(page.drawText).toHaveBeenNthCalledWith(2, "", {
+      x: 609,
+      y: 487.5,
+      size: 12,
+      font,
+      color: expect.any(Object),
+    });
+  });
+});

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-loppupisteet.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf-loppupisteet.test.ts
@@ -64,7 +64,7 @@ describe("drawTrialDogPdfLoppuppisteet", () => {
     expect(drawTextMock).toHaveBeenNthCalledWith(5, page, font, "1", {
       x: 220,
       y: 110.3,
-      size: 12,
+      size: 14,
     });
   });
 
@@ -106,7 +106,7 @@ describe("drawTrialDogPdfLoppuppisteet", () => {
     expect(drawTextMock).toHaveBeenNthCalledWith(5, page, font, "1", {
       x: 220,
       y: 110.3,
-      size: 12,
+      size: 14,
     });
   });
 
@@ -143,7 +143,7 @@ describe("drawTrialDogPdfLoppuppisteet", () => {
     expect(drawTextMock).toHaveBeenNthCalledWith(4, page, font, "1", {
       x: 220,
       y: 110.3,
-      size: 12,
+      size: 14,
     });
   });
 
@@ -190,7 +190,7 @@ describe("drawTrialDogPdfLoppuppisteet", () => {
     expect(drawTextMock).toHaveBeenNthCalledWith(7, page, font, "1", {
       x: 220,
       y: 110.3,
-      size: 12,
+      size: 14,
     });
   });
 

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf.test.ts
@@ -53,6 +53,7 @@ describe("renderTrialDogPdf", () => {
       Palkinto: "1",
       huomautusTeksti: null,
       ryhmatuomariNimi: null,
+      palkintotuomariNimi: null,
     });
 
     expect(Buffer.from(bytes).toString("latin1", 0, 4)).toBe("%PDF");

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { renderTrialDogPdf } from "../trial-dog-pdf";
 
 describe("renderTrialDogPdf", () => {
-  it("renders pdf bytes from a registration number", async () => {
+  it("renders pdf bytes when lisatiedot sections are omitted", async () => {
     const bytes = await renderTrialDogPdf({
       registrationNo: "FI12345/21",
       dogName: null,

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf.test.ts
@@ -52,6 +52,7 @@ describe("renderTrialDogPdf", () => {
       koiriaLuokassa: null,
       Palkinto: "1",
       huomautusTeksti: null,
+      ryhmatuomariNimi: null,
     });
 
     expect(Buffer.from(bytes).toString("latin1", 0, 4)).toBe("%PDF");

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf.test.ts
@@ -54,6 +54,8 @@ describe("renderTrialDogPdf", () => {
       huomautusTeksti: null,
       ryhmatuomariNimi: null,
       palkintotuomariNimi: null,
+      ylituomariNumeroSnapshot: null,
+      ylituomariNimiSnapshot: null,
     });
 
     expect(Buffer.from(bytes).toString("latin1", 0, 4)).toBe("%PDF");

--- a/apps/web/lib/public/beagle/trials/pdf/internal/allekirjoitukset.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/allekirjoitukset.ts
@@ -15,6 +15,18 @@ const PALKINTOTUOMARI_FIELD = {
   size: 10,
 } as const;
 
+const YLITUOMARI_NUMERO_FIELD = {
+  x: 513,
+  y: 82.7,
+  size: 10,
+} as const;
+
+const YLITUOMARI_NIMI_FIELD = {
+  x: 570,
+  y: 82.7,
+  size: 10,
+} as const;
+
 export function drawTrialDogPdfAllekirjoitukset(
   input: TrialDogPdfAllekirjoitukset & {
     page: PDFPage;
@@ -35,5 +47,19 @@ export function drawTrialDogPdfAllekirjoitukset(
     font,
     formatKoeEraValue(input.palkintotuomariNimi),
     PALKINTOTUOMARI_FIELD,
+  );
+
+  drawText(
+    page,
+    font,
+    formatKoeEraValue(input.ylituomariNumeroSnapshot),
+    YLITUOMARI_NUMERO_FIELD,
+  );
+
+  drawText(
+    page,
+    font,
+    formatKoeEraValue(input.ylituomariNimiSnapshot),
+    YLITUOMARI_NIMI_FIELD,
   );
 }

--- a/apps/web/lib/public/beagle/trials/pdf/internal/allekirjoitukset.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/allekirjoitukset.ts
@@ -8,6 +8,12 @@ const RYHMATUOMARI_FIELD = {
   size: 10,
 } as const;
 
+const PALKINTOTUOMARI_FIELD = {
+  x: 513,
+  y: 122.6,
+  size: 10,
+} as const;
+
 function drawText(
   page: PDFPage,
   font: PDFFont,
@@ -33,5 +39,9 @@ export function drawTrialDogPdfAllekirjoitukset(
 
   if (input.ryhmatuomariNimi) {
     drawText(page, font, input.ryhmatuomariNimi, RYHMATUOMARI_FIELD);
+  }
+
+  if (input.palkintotuomariNimi) {
+    drawText(page, font, input.palkintotuomariNimi, PALKINTOTUOMARI_FIELD);
   }
 }

--- a/apps/web/lib/public/beagle/trials/pdf/internal/allekirjoitukset.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/allekirjoitukset.ts
@@ -1,0 +1,37 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import { rgb } from "pdf-lib";
+import type { TrialDogPdfAllekirjoitukset } from "@contracts/trials/trial-dog-pdf";
+
+const RYHMATUOMARI_FIELD = {
+  x: 513,
+  y: 161.6,
+  size: 10,
+} as const;
+
+function drawText(
+  page: PDFPage,
+  font: PDFFont,
+  text: string,
+  field: { x: number; y: number; size: number },
+): void {
+  page.drawText(text, {
+    x: field.x,
+    y: field.y,
+    size: field.size,
+    font,
+    color: rgb(0, 0, 0),
+  });
+}
+
+export function drawTrialDogPdfAllekirjoitukset(
+  input: TrialDogPdfAllekirjoitukset & {
+    page: PDFPage;
+    font: PDFFont;
+  },
+): void {
+  const { page, font } = input;
+
+  if (input.ryhmatuomariNimi) {
+    drawText(page, font, input.ryhmatuomariNimi, RYHMATUOMARI_FIELD);
+  }
+}

--- a/apps/web/lib/public/beagle/trials/pdf/internal/allekirjoitukset.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/allekirjoitukset.ts
@@ -1,5 +1,4 @@
 import type { PDFFont, PDFPage } from "pdf-lib";
-import { rgb } from "pdf-lib";
 import type { TrialDogPdfAllekirjoitukset } from "@contracts/trials/trial-dog-pdf";
 import { drawText, formatKoeEraValue } from "./koe-erat-common";
 

--- a/apps/web/lib/public/beagle/trials/pdf/internal/allekirjoitukset.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/allekirjoitukset.ts
@@ -1,6 +1,7 @@
 import type { PDFFont, PDFPage } from "pdf-lib";
 import { rgb } from "pdf-lib";
 import type { TrialDogPdfAllekirjoitukset } from "@contracts/trials/trial-dog-pdf";
+import { drawText, formatKoeEraValue } from "./koe-erat-common";
 
 const RYHMATUOMARI_FIELD = {
   x: 513,
@@ -14,21 +15,6 @@ const PALKINTOTUOMARI_FIELD = {
   size: 10,
 } as const;
 
-function drawText(
-  page: PDFPage,
-  font: PDFFont,
-  text: string,
-  field: { x: number; y: number; size: number },
-): void {
-  page.drawText(text, {
-    x: field.x,
-    y: field.y,
-    size: field.size,
-    font,
-    color: rgb(0, 0, 0),
-  });
-}
-
 export function drawTrialDogPdfAllekirjoitukset(
   input: TrialDogPdfAllekirjoitukset & {
     page: PDFPage;
@@ -37,11 +23,17 @@ export function drawTrialDogPdfAllekirjoitukset(
 ): void {
   const { page, font } = input;
 
-  if (input.ryhmatuomariNimi) {
-    drawText(page, font, input.ryhmatuomariNimi, RYHMATUOMARI_FIELD);
-  }
+  drawText(
+    page,
+    font,
+    formatKoeEraValue(input.ryhmatuomariNimi),
+    RYHMATUOMARI_FIELD,
+  );
 
-  if (input.palkintotuomariNimi) {
-    drawText(page, font, input.palkintotuomariNimi, PALKINTOTUOMARI_FIELD);
-  }
+  drawText(
+    page,
+    font,
+    formatKoeEraValue(input.palkintotuomariNimi),
+    PALKINTOTUOMARI_FIELD,
+  );
 }

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/ajo.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/ajo.ts
@@ -1,12 +1,67 @@
 import type { PDFFont, PDFPage } from "pdf-lib";
 import type { TrialDogPdfLisatiedot } from "@contracts";
+import { drawText, formatKoeEraValue } from "../koe-erat-common";
 
-// Ajo group (50-56). Reserved for future row rendering.
+// Renders ajo rows (50-56) from lisätiedot onto fixed PDF coordinates.
+// All rows use one decimal formatting.
+const AJO_ERA1_X = 782;
+const AJO_ERA2_X = 799;
+const AJO_TEXT_SIZE = 10;
+
+type AjoRowConfig = {
+  koodi: string;
+  y: number;
+};
+
+const AJO_ROWS: AjoRowConfig[] = [
+  { koodi: "50", y: 431 },
+  { koodi: "51", y: 417 },
+  { koodi: "52", y: 403 },
+  { koodi: "53", y: 389 },
+  { koodi: "54", y: 375 },
+  { koodi: "55", y: 361 },
+  { koodi: "56", y: 347 },
+];
+
+function normalizeOneDecimalValue(raw: string | null | undefined): string {
+  const value = formatKoeEraValue(raw).trim();
+  if (value === "-") {
+    return "";
+  }
+
+  const parsed = Number.parseFloat(value.replace(",", "."));
+  return Number.isFinite(parsed) ? parsed.toFixed(1) : value;
+}
+
 export function drawTrialDogPdfLisatiedotAjo(
-  _input: TrialDogPdfLisatiedot & {
+  input: TrialDogPdfLisatiedot & {
     page: PDFPage;
     font: PDFFont;
   },
 ): void {
-  return;
+  const rowsByCode = new Map(
+    (input.lisatiedotRows ?? []).map((row) => [row.koodi, row]),
+  );
+
+  for (const rowConfig of AJO_ROWS) {
+    const row = rowsByCode.get(rowConfig.koodi);
+    const era1 = normalizeOneDecimalValue(row?.era1);
+    const era2 = normalizeOneDecimalValue(row?.era2);
+
+    if (era1) {
+      drawText(input.page, input.font, era1, {
+        x: AJO_ERA1_X,
+        y: rowConfig.y,
+        size: AJO_TEXT_SIZE,
+      });
+    }
+
+    if (era2) {
+      drawText(input.page, input.font, era2, {
+        x: AJO_ERA2_X,
+        y: rowConfig.y,
+        size: AJO_TEXT_SIZE,
+      });
+    }
+  }
 }

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/ajo.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/ajo.ts
@@ -1,0 +1,12 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import type { TrialDogPdfLisatiedot } from "@contracts";
+
+// Ajo group (50-56). Reserved for future row rendering.
+export function drawTrialDogPdfLisatiedotAjo(
+  _input: TrialDogPdfLisatiedot & {
+    page: PDFPage;
+    font: PDFFont;
+  },
+): void {
+  return;
+}

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/haku.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/haku.ts
@@ -1,0 +1,12 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import type { TrialDogPdfLisatiedot } from "@contracts";
+
+// Haku group (20-22). Reserved for future row rendering.
+export function drawTrialDogPdfLisatiedotHaku(
+  _input: TrialDogPdfLisatiedot & {
+    page: PDFPage;
+    font: PDFFont;
+  },
+): void {
+  return;
+}

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/haku.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/haku.ts
@@ -1,12 +1,77 @@
 import type { PDFFont, PDFPage } from "pdf-lib";
 import type { TrialDogPdfLisatiedot } from "@contracts";
+import { drawText, formatKoeEraValue } from "../koe-erat-common";
 
-// Haku group (20-22). Reserved for future row rendering.
+// Renders haku rows (20-22) from lisätiedot onto fixed PDF coordinates.
+// Row 20 shows the raw integer value; rows 21 and 22 show one decimal.
+const HAKU_ERA1_X = 590;
+const HAKU_ERA2_X = 607;
+const HAKU_TEXT_SIZE = 10;
+
+type HakuRowKind = "INTEGER" | "ONE_DECIMAL";
+
+type HakuRowConfig = {
+  koodi: string;
+  y: number;
+  kind: HakuRowKind;
+};
+
+const HAKU_ROWS: HakuRowConfig[] = [
+  { koodi: "20", y: 360.5, kind: "INTEGER" },
+  { koodi: "21", y: 346.5, kind: "ONE_DECIMAL" },
+  { koodi: "22", y: 332.5, kind: "ONE_DECIMAL" },
+];
+
+function normalizeIntegerValue(raw: string | null | undefined): string {
+  const value = formatKoeEraValue(raw).trim();
+  return value === "-" ? "" : value;
+}
+
+function normalizeOneDecimalValue(raw: string | null | undefined): string {
+  const value = formatKoeEraValue(raw).trim();
+  if (value === "-") {
+    return "";
+  }
+
+  const parsed = Number.parseFloat(value.replace(",", "."));
+  return Number.isFinite(parsed) ? parsed.toFixed(1) : value;
+}
+
 export function drawTrialDogPdfLisatiedotHaku(
-  _input: TrialDogPdfLisatiedot & {
+  input: TrialDogPdfLisatiedot & {
     page: PDFPage;
     font: PDFFont;
   },
 ): void {
-  return;
+  const rowsByCode = new Map(
+    (input.lisatiedotRows ?? []).map((row) => [row.koodi, row]),
+  );
+
+  for (const rowConfig of HAKU_ROWS) {
+    const row = rowsByCode.get(rowConfig.koodi);
+    const era1 =
+      rowConfig.kind === "ONE_DECIMAL"
+        ? normalizeOneDecimalValue(row?.era1)
+        : normalizeIntegerValue(row?.era1);
+    const era2 =
+      rowConfig.kind === "ONE_DECIMAL"
+        ? normalizeOneDecimalValue(row?.era2)
+        : normalizeIntegerValue(row?.era2);
+
+    if (era1) {
+      drawText(input.page, input.font, era1, {
+        x: HAKU_ERA1_X,
+        y: rowConfig.y,
+        size: HAKU_TEXT_SIZE,
+      });
+    }
+
+    if (era2) {
+      drawText(input.page, input.font, era2, {
+        x: HAKU_ERA2_X,
+        y: rowConfig.y,
+        size: HAKU_TEXT_SIZE,
+      });
+    }
+  }
 }

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/haukku.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/haukku.ts
@@ -1,12 +1,81 @@
 import type { PDFFont, PDFPage } from "pdf-lib";
 import type { TrialDogPdfLisatiedot } from "@contracts";
+import { drawText, formatKoeEraValue } from "../koe-erat-common";
 
-// Haukku group (30-36). Reserved for future row rendering.
+// Renders haukku rows (30-36) from lisätiedot onto fixed PDF coordinates.
+// Rows 30-35 show one decimal; row 36 shows the raw integer value.
+const HAUKKU_ERA1_X = 590;
+const HAUKKU_ERA2_X = 607;
+const HAUKKU_TEXT_SIZE = 10;
+
+type HaukkuRowKind = "ONE_DECIMAL" | "INTEGER";
+
+type HaukkuRowConfig = {
+  koodi: string;
+  y: number;
+  kind: HaukkuRowKind;
+};
+
+const HAUKKU_ROWS: HaukkuRowConfig[] = [
+  { koodi: "30", y: 303.5, kind: "ONE_DECIMAL" },
+  { koodi: "31", y: 289.5, kind: "ONE_DECIMAL" },
+  { koodi: "32", y: 275.5, kind: "ONE_DECIMAL" },
+  { koodi: "33", y: 261.5, kind: "ONE_DECIMAL" },
+  { koodi: "34", y: 247.5, kind: "ONE_DECIMAL" },
+  { koodi: "35", y: 233.5, kind: "ONE_DECIMAL" },
+  { koodi: "36", y: 219.5, kind: "INTEGER" },
+];
+
+function normalizeIntegerValue(raw: string | null | undefined): string {
+  const value = formatKoeEraValue(raw).trim();
+  return value === "-" ? "" : value;
+}
+
+function normalizeOneDecimalValue(raw: string | null | undefined): string {
+  const value = formatKoeEraValue(raw).trim();
+  if (value === "-") {
+    return "";
+  }
+
+  const parsed = Number.parseFloat(value.replace(",", "."));
+  return Number.isFinite(parsed) ? parsed.toFixed(1) : value;
+}
+
 export function drawTrialDogPdfLisatiedotHaukku(
-  _input: TrialDogPdfLisatiedot & {
+  input: TrialDogPdfLisatiedot & {
     page: PDFPage;
     font: PDFFont;
   },
 ): void {
-  return;
+  const rowsByCode = new Map(
+    (input.lisatiedotRows ?? []).map((row) => [row.koodi, row]),
+  );
+
+  for (const rowConfig of HAUKKU_ROWS) {
+    const row = rowsByCode.get(rowConfig.koodi);
+    const era1 =
+      rowConfig.kind === "ONE_DECIMAL"
+        ? normalizeOneDecimalValue(row?.era1)
+        : normalizeIntegerValue(row?.era1);
+    const era2 =
+      rowConfig.kind === "ONE_DECIMAL"
+        ? normalizeOneDecimalValue(row?.era2)
+        : normalizeIntegerValue(row?.era2);
+
+    if (era1) {
+      drawText(input.page, input.font, era1, {
+        x: HAUKKU_ERA1_X,
+        y: rowConfig.y,
+        size: HAUKKU_TEXT_SIZE,
+      });
+    }
+
+    if (era2) {
+      drawText(input.page, input.font, era2, {
+        x: HAUKKU_ERA2_X,
+        y: rowConfig.y,
+        size: HAUKKU_TEXT_SIZE,
+      });
+    }
+  }
 }

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/haukku.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/haukku.ts
@@ -1,0 +1,12 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import type { TrialDogPdfLisatiedot } from "@contracts";
+
+// Haukku group (30-36). Reserved for future row rendering.
+export function drawTrialDogPdfLisatiedotHaukku(
+  _input: TrialDogPdfLisatiedot & {
+    page: PDFPage;
+    font: PDFFont;
+  },
+): void {
+  return;
+}

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/index.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/index.ts
@@ -1,0 +1,6 @@
+export { drawTrialDogPdfLisatiedotOlosuhteet } from "./olosuhteet";
+export { drawTrialDogPdfLisatiedotHaku } from "./haku";
+export { drawTrialDogPdfLisatiedotHaukku } from "./haukku";
+export { drawTrialDogPdfLisatiedotMetsastysinto } from "./metsastysinto";
+export { drawTrialDogPdfLisatiedotAjo } from "./ajo";
+export { drawTrialDogPdfLisatiedotMuutOminaisuudet } from "./muut-ominaisuudet";

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/metsastysinto.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/metsastysinto.ts
@@ -1,12 +1,63 @@
 import type { PDFFont, PDFPage } from "pdf-lib";
 import type { TrialDogPdfLisatiedot } from "@contracts";
+import { drawText, formatKoeEraValue } from "../koe-erat-common";
 
-// Metsästysinto group (40-42). Reserved for future row rendering.
+// Renders metsästysinto rows (40-42) from lisätiedot onto fixed PDF coordinates.
+// All three rows use one decimal formatting.
+const METSASTYSINTO_ERA1_X = 782;
+const METSASTYSINTO_ERA2_X = 799;
+const METSASTYSINTO_TEXT_SIZE = 10;
+
+type MetsastysintoRowConfig = {
+  koodi: string;
+  y: number;
+};
+
+const METSASTYSINTO_ROWS: MetsastysintoRowConfig[] = [
+  { koodi: "40", y: 487.5 },
+  { koodi: "41", y: 473.5 },
+  { koodi: "42", y: 459.5 },
+];
+
+function normalizeOneDecimalValue(raw: string | null | undefined): string {
+  const value = formatKoeEraValue(raw).trim();
+  if (value === "-") {
+    return "";
+  }
+
+  const parsed = Number.parseFloat(value.replace(",", "."));
+  return Number.isFinite(parsed) ? parsed.toFixed(1) : value;
+}
+
 export function drawTrialDogPdfLisatiedotMetsastysinto(
-  _input: TrialDogPdfLisatiedot & {
+  input: TrialDogPdfLisatiedot & {
     page: PDFPage;
     font: PDFFont;
   },
 ): void {
-  return;
+  const rowsByCode = new Map(
+    (input.lisatiedotRows ?? []).map((row) => [row.koodi, row]),
+  );
+
+  for (const rowConfig of METSASTYSINTO_ROWS) {
+    const row = rowsByCode.get(rowConfig.koodi);
+    const era1 = normalizeOneDecimalValue(row?.era1);
+    const era2 = normalizeOneDecimalValue(row?.era2);
+
+    if (era1) {
+      drawText(input.page, input.font, era1, {
+        x: METSASTYSINTO_ERA1_X,
+        y: rowConfig.y,
+        size: METSASTYSINTO_TEXT_SIZE,
+      });
+    }
+
+    if (era2) {
+      drawText(input.page, input.font, era2, {
+        x: METSASTYSINTO_ERA2_X,
+        y: rowConfig.y,
+        size: METSASTYSINTO_TEXT_SIZE,
+      });
+    }
+  }
 }

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/metsastysinto.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/metsastysinto.ts
@@ -1,0 +1,12 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import type { TrialDogPdfLisatiedot } from "@contracts";
+
+// Metsästysinto group (40-42). Reserved for future row rendering.
+export function drawTrialDogPdfLisatiedotMetsastysinto(
+  _input: TrialDogPdfLisatiedot & {
+    page: PDFPage;
+    font: PDFFont;
+  },
+): void {
+  return;
+}

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/muut-ominaisuudet.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/muut-ominaisuudet.ts
@@ -1,0 +1,12 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import type { TrialDogPdfLisatiedot } from "@contracts";
+
+// Muut ominaisuudet group (60-61). Reserved for future row rendering.
+export function drawTrialDogPdfLisatiedotMuutOminaisuudet(
+  _input: TrialDogPdfLisatiedot & {
+    page: PDFPage;
+    font: PDFFont;
+  },
+): void {
+  return;
+}

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/muut-ominaisuudet.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/muut-ominaisuudet.ts
@@ -1,12 +1,62 @@
 import type { PDFFont, PDFPage } from "pdf-lib";
 import type { TrialDogPdfLisatiedot } from "@contracts";
+import { drawText, formatKoeEraValue } from "../koe-erat-common";
 
-// Muut ominaisuudet group (60-61). Reserved for future row rendering.
+// Renders muut ominaisuudet rows (60-61) from lisätiedot onto fixed PDF coordinates.
+// Both rows use one decimal formatting.
+const MUUT_OMINAISUUDET_ERA1_X = 782;
+const MUUT_OMINAISUUDET_ERA2_X = 799;
+const MUUT_OMINAISUUDET_TEXT_SIZE = 10;
+
+type MuutOminaisuudetRowConfig = {
+  koodi: string;
+  y: number;
+};
+
+const MUUT_OMINAISUUDET_ROWS: MuutOminaisuudetRowConfig[] = [
+  { koodi: "60", y: 303.5 },
+  { koodi: "61", y: 289.5 },
+];
+
+function normalizeOneDecimalValue(raw: string | null | undefined): string {
+  const value = formatKoeEraValue(raw).trim();
+  if (value === "-") {
+    return "";
+  }
+
+  const parsed = Number.parseFloat(value.replace(",", "."));
+  return Number.isFinite(parsed) ? parsed.toFixed(1) : value;
+}
+
 export function drawTrialDogPdfLisatiedotMuutOminaisuudet(
-  _input: TrialDogPdfLisatiedot & {
+  input: TrialDogPdfLisatiedot & {
     page: PDFPage;
     font: PDFFont;
   },
 ): void {
-  return;
+  const rowsByCode = new Map(
+    (input.lisatiedotRows ?? []).map((row) => [row.koodi, row]),
+  );
+
+  for (const rowConfig of MUUT_OMINAISUUDET_ROWS) {
+    const row = rowsByCode.get(rowConfig.koodi);
+    const era1 = normalizeOneDecimalValue(row?.era1);
+    const era2 = normalizeOneDecimalValue(row?.era2);
+
+    if (era1) {
+      drawText(input.page, input.font, era1, {
+        x: MUUT_OMINAISUUDET_ERA1_X,
+        y: rowConfig.y,
+        size: MUUT_OMINAISUUDET_TEXT_SIZE,
+      });
+    }
+
+    if (era2) {
+      drawText(input.page, input.font, era2, {
+        x: MUUT_OMINAISUUDET_ERA2_X,
+        y: rowConfig.y,
+        size: MUUT_OMINAISUUDET_TEXT_SIZE,
+      });
+    }
+  }
 }

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/olosuhteet.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/olosuhteet.ts
@@ -50,7 +50,7 @@ function normalizeRowValue(
     : normalizeMarkerValue(raw);
 }
 
-// Olosuhteet group (11-18). Currently draws only koodi 11.
+// Olosuhteet group (11-18). Renders marker rows and numeric rows on fixed positions.
 export function drawTrialDogPdfLisatiedotOlosuhteet(
   input: TrialDogPdfLisatiedot & {
     page: PDFPage;

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/olosuhteet.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/olosuhteet.ts
@@ -4,11 +4,11 @@ import { drawText, formatKoeEraValue } from "../koe-erat-common";
 
 // Renders olosuhteet rows (11-18) from lisätiedot onto fixed PDF coordinates.
 // Marker rows show X for true (1/X); numeric rows show their raw number values.
-const OLOSUHDE_ERA1_X = 592;
-const OLOSUHDE_ERA2_X = 609;
+const OLOSUHDE_ERA1_X = 591;
+const OLOSUHDE_ERA2_X = 608;
 const OLOSUHDE_TEXT_SIZE = 12;
-const NUMERIC_ERA1_X = 591;
-const NUMERIC_ERA2_X = 608;
+const NUMERIC_ERA1_X = 590;
+const NUMERIC_ERA2_X = 607;
 const NUMERIC_TEXT_SIZE = 10;
 const LUMIKELI_Y = 474.5;
 

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/olosuhteet.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/olosuhteet.ts
@@ -2,17 +2,53 @@ import type { PDFFont, PDFPage } from "pdf-lib";
 import type { TrialDogPdfLisatiedot } from "@contracts";
 import { drawText, formatKoeEraValue } from "../koe-erat-common";
 
-const LISATIETO_11_ERA1_FIELD = {
-  x: 592,
-  y: 487.5,
-  size: 12,
-} as const;
+// Renders olosuhteet rows (11-18) from lisätiedot onto fixed PDF coordinates.
+// Marker rows show X for true (1/X); numeric rows show their raw number values.
+const OLOSUHDE_ERA1_X = 592;
+const OLOSUHDE_ERA2_X = 609;
+const OLOSUHDE_TEXT_SIZE = 12;
+const NUMERIC_ERA1_X = 591;
+const NUMERIC_ERA2_X = 608;
+const NUMERIC_TEXT_SIZE = 10;
+const LUMIKELI_Y = 474.5;
 
-const LISATIETO_11_ERA2_FIELD = {
-  x: 609,
-  y: 487.5,
-  size: 12,
-} as const;
+type OlosuhdeRowKind = "MARKER" | "NUMBER";
+
+type OlosuhdeRowConfig = {
+  koodi: string;
+  y: number;
+  kind: OlosuhdeRowKind;
+};
+
+const OLOSUHDE_ROWS: OlosuhdeRowConfig[] = [
+  { koodi: "11", y: 487.5, kind: "MARKER" },
+  { koodi: "12", y: 473.5, kind: "NUMBER" },
+  { koodi: "13", y: 459.5, kind: "MARKER" },
+  { koodi: "14", y: 445.5, kind: "MARKER" },
+  { koodi: "15", y: 430.5, kind: "MARKER" },
+  { koodi: "16", y: 416.5, kind: "MARKER" },
+  { koodi: "17", y: 402.5, kind: "NUMBER" },
+  { koodi: "18", y: 388.5, kind: "NUMBER" },
+];
+
+function normalizeMarkerValue(raw: string | null | undefined): string {
+  const value = formatKoeEraValue(raw).trim().toUpperCase();
+  return value === "1" || value === "X" ? "X" : "";
+}
+
+function normalizeCentimeterValue(raw: string | null | undefined): string {
+  const value = formatKoeEraValue(raw).trim();
+  return value === "-" ? "" : value;
+}
+
+function normalizeRowValue(
+  kind: OlosuhdeRowKind,
+  raw: string | null | undefined,
+): string {
+  return kind === "NUMBER"
+    ? normalizeCentimeterValue(raw)
+    : normalizeMarkerValue(raw);
+}
 
 // Olosuhteet group (11-18). Currently draws only koodi 11.
 export function drawTrialDogPdfLisatiedotOlosuhteet(
@@ -21,16 +57,31 @@ export function drawTrialDogPdfLisatiedotOlosuhteet(
     font: PDFFont;
   },
 ): void {
-  const row11 = input.lisatiedotRows?.find((row) => row.koodi === "11");
-  const era1Source = formatKoeEraValue(row11?.era1).trim().toUpperCase();
-  const era2Source = formatKoeEraValue(row11?.era2).trim().toUpperCase();
-  const era1 = era1Source === "1" || era1Source === "X" ? "X" : "";
-  const era2 = era2Source === "1" || era2Source === "X" ? "X" : "";
+  const rowsByCode = new Map(
+    (input.lisatiedotRows ?? []).map((row) => [row.koodi, row]),
+  );
 
-  if (!era1 && !era2) {
-    return;
+  for (const rowConfig of OLOSUHDE_ROWS) {
+    const row = rowsByCode.get(rowConfig.koodi);
+    const era1 = normalizeRowValue(rowConfig.kind, row?.era1);
+    const era2 = normalizeRowValue(rowConfig.kind, row?.era2);
+
+    if (era1) {
+      const isNumeric = rowConfig.kind === "NUMBER";
+      drawText(input.page, input.font, era1, {
+        x: isNumeric ? NUMERIC_ERA1_X : OLOSUHDE_ERA1_X,
+        y: isNumeric && rowConfig.koodi === "12" ? LUMIKELI_Y : rowConfig.y,
+        size: isNumeric ? NUMERIC_TEXT_SIZE : OLOSUHDE_TEXT_SIZE,
+      });
+    }
+
+    if (era2) {
+      const isNumeric = rowConfig.kind === "NUMBER";
+      drawText(input.page, input.font, era2, {
+        x: isNumeric ? NUMERIC_ERA2_X : OLOSUHDE_ERA2_X,
+        y: isNumeric && rowConfig.koodi === "12" ? LUMIKELI_Y : rowConfig.y,
+        size: isNumeric ? NUMERIC_TEXT_SIZE : OLOSUHDE_TEXT_SIZE,
+      });
+    }
   }
-
-  drawText(input.page, input.font, era1, LISATIETO_11_ERA1_FIELD);
-  drawText(input.page, input.font, era2, LISATIETO_11_ERA2_FIELD);
 }

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/olosuhteet.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatiedot/olosuhteet.ts
@@ -1,6 +1,6 @@
 import type { PDFFont, PDFPage } from "pdf-lib";
 import type { TrialDogPdfLisatiedot } from "@contracts";
-import { drawText, formatKoeEraValue } from "./koe-erat-common";
+import { drawText, formatKoeEraValue } from "../koe-erat-common";
 
 const LISATIETO_11_ERA1_FIELD = {
   x: 592,
@@ -14,8 +14,8 @@ const LISATIETO_11_ERA2_FIELD = {
   size: 12,
 } as const;
 
-// Draws lisätieto 11 values near the signatures block for quick visibility.
-export function drawTrialDogPdfLisatieto11(
+// Olosuhteet group (11-18). Currently draws only koodi 11.
+export function drawTrialDogPdfLisatiedotOlosuhteet(
   input: TrialDogPdfLisatiedot & {
     page: PDFPage;
     font: PDFFont;

--- a/apps/web/lib/public/beagle/trials/pdf/internal/lisatieto-11.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/lisatieto-11.ts
@@ -1,0 +1,36 @@
+import type { PDFFont, PDFPage } from "pdf-lib";
+import type { TrialDogPdfLisatiedot } from "@contracts";
+import { drawText, formatKoeEraValue } from "./koe-erat-common";
+
+const LISATIETO_11_ERA1_FIELD = {
+  x: 592,
+  y: 487.5,
+  size: 12,
+} as const;
+
+const LISATIETO_11_ERA2_FIELD = {
+  x: 609,
+  y: 487.5,
+  size: 12,
+} as const;
+
+// Draws lisätieto 11 values near the signatures block for quick visibility.
+export function drawTrialDogPdfLisatieto11(
+  input: TrialDogPdfLisatiedot & {
+    page: PDFPage;
+    font: PDFFont;
+  },
+): void {
+  const row11 = input.lisatiedotRows?.find((row) => row.koodi === "11");
+  const era1Source = formatKoeEraValue(row11?.era1).trim().toUpperCase();
+  const era2Source = formatKoeEraValue(row11?.era2).trim().toUpperCase();
+  const era1 = era1Source === "1" || era1Source === "X" ? "X" : "";
+  const era2 = era2Source === "1" || era2Source === "X" ? "X" : "";
+
+  if (!era1 && !era2) {
+    return;
+  }
+
+  drawText(input.page, input.font, era1, LISATIETO_11_ERA1_FIELD);
+  drawText(input.page, input.font, era2, LISATIETO_11_ERA2_FIELD);
+}

--- a/apps/web/lib/public/beagle/trials/pdf/internal/loppupisteet.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/internal/loppupisteet.ts
@@ -53,7 +53,7 @@ const KOIRIA_LUOKASSA_FIELD = {
 const PALKINTO = {
   x: 220,
   y: 110.3,
-  size: 12,
+  size: 14,
 } as const;
 
 export function drawTrialDogPdfLoppuppisteet(

--- a/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
@@ -11,7 +11,14 @@ import { drawTrialDogPdfKoiranTausta } from "./internal/koiran-tausta";
 import { drawTrialDogPdfTappiopisteet } from "./internal/tappiopisteet";
 import { drawTrialDogPdfLoppuppisteet } from "./internal/loppupisteet";
 import { drawTrialDogPdfAllekirjoitukset } from "./internal/allekirjoitukset";
-import { drawTrialDogPdfLisatieto11 } from "./internal/lisatieto-11";
+import {
+  drawTrialDogPdfLisatiedotAjo,
+  drawTrialDogPdfLisatiedotHaku,
+  drawTrialDogPdfLisatiedotHaukku,
+  drawTrialDogPdfLisatiedotMetsastysinto,
+  drawTrialDogPdfLisatiedotMuutOminaisuudet,
+  drawTrialDogPdfLisatiedotOlosuhteet,
+} from "./internal/lisatiedot";
 
 export { DOG_REGISTRATION_NO_FIELD } from "./internal/koiran-tiedot";
 
@@ -140,11 +147,16 @@ export async function renderTrialDogPdf(
     font,
   });
 
-  drawTrialDogPdfLisatieto11({
+  drawTrialDogPdfLisatiedotOlosuhteet({
     lisatiedotRows,
     page,
     font,
   });
+  drawTrialDogPdfLisatiedotHaku({ lisatiedotRows, page, font });
+  drawTrialDogPdfLisatiedotHaukku({ lisatiedotRows, page, font });
+  drawTrialDogPdfLisatiedotMetsastysinto({ lisatiedotRows, page, font });
+  drawTrialDogPdfLisatiedotAjo({ lisatiedotRows, page, font });
+  drawTrialDogPdfLisatiedotMuutOminaisuudet({ lisatiedotRows, page, font });
 
   drawTrialDogPdfAllekirjoitukset({
     ryhmatuomariNimi: input.ryhmatuomariNimi,

--- a/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
@@ -51,7 +51,6 @@ export async function renderTrialDogPdf(
   input: TrialDogPdfPayload,
 ): Promise<Uint8Array> {
   const lisatiedotRows = input.lisatiedotRows ?? [];
-  void lisatiedotRows;
 
   const templatePath = await resolveTemplatePath();
   const templateBytes = await readFile(templatePath);

--- a/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
@@ -11,6 +11,7 @@ import { drawTrialDogPdfKoiranTausta } from "./internal/koiran-tausta";
 import { drawTrialDogPdfTappiopisteet } from "./internal/tappiopisteet";
 import { drawTrialDogPdfLoppuppisteet } from "./internal/loppupisteet";
 import { drawTrialDogPdfAllekirjoitukset } from "./internal/allekirjoitukset";
+import { Omega } from "lucide-react";
 
 export { DOG_REGISTRATION_NO_FIELD } from "./internal/koiran-tiedot";
 
@@ -139,6 +140,8 @@ export async function renderTrialDogPdf(
   drawTrialDogPdfAllekirjoitukset({
     ryhmatuomariNimi: input.ryhmatuomariNimi,
     palkintotuomariNimi: input.palkintotuomariNimi,
+    ylituomariNumeroSnapshot: input.ylituomariNumeroSnapshot,
+    ylituomariNimiSnapshot: input.ylituomariNimiSnapshot,
     page,
     font,
   });

--- a/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
@@ -10,6 +10,7 @@ import { drawTrialDogPdfKoiranTiedot } from "./internal/koiran-tiedot";
 import { drawTrialDogPdfKoiranTausta } from "./internal/koiran-tausta";
 import { drawTrialDogPdfTappiopisteet } from "./internal/tappiopisteet";
 import { drawTrialDogPdfLoppuppisteet } from "./internal/loppupisteet";
+import { drawTrialDogPdfAllekirjoitukset } from "./internal/allekirjoitukset";
 
 export { DOG_REGISTRATION_NO_FIELD } from "./internal/koiran-tiedot";
 
@@ -134,5 +135,12 @@ export async function renderTrialDogPdf(
     page,
     font,
   });
+
+  drawTrialDogPdfAllekirjoitukset({
+    ryhmatuomariNimi: input.ryhmatuomariNimi,
+    page,
+    font,
+  });
+
   return pdfDocument.save();
 }

--- a/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
@@ -138,6 +138,7 @@ export async function renderTrialDogPdf(
 
   drawTrialDogPdfAllekirjoitukset({
     ryhmatuomariNimi: input.ryhmatuomariNimi,
+    palkintotuomariNimi: input.palkintotuomariNimi,
     page,
     font,
   });

--- a/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
@@ -11,7 +11,7 @@ import { drawTrialDogPdfKoiranTausta } from "./internal/koiran-tausta";
 import { drawTrialDogPdfTappiopisteet } from "./internal/tappiopisteet";
 import { drawTrialDogPdfLoppuppisteet } from "./internal/loppupisteet";
 import { drawTrialDogPdfAllekirjoitukset } from "./internal/allekirjoitukset";
-import { Omega } from "lucide-react";
+import { drawTrialDogPdfLisatieto11 } from "./internal/lisatieto-11";
 
 export { DOG_REGISTRATION_NO_FIELD } from "./internal/koiran-tiedot";
 
@@ -43,6 +43,9 @@ async function resolveTemplatePath(): Promise<string> {
 export async function renderTrialDogPdf(
   input: TrialDogPdfPayload,
 ): Promise<Uint8Array> {
+  const lisatiedotRows = input.lisatiedotRows ?? [];
+  void lisatiedotRows;
+
   const templatePath = await resolveTemplatePath();
   const templateBytes = await readFile(templatePath);
   const pdfDocument = await PDFDocument.load(templateBytes);
@@ -133,6 +136,12 @@ export async function renderTrialDogPdf(
 
   drawTrialDogPdfHuomautus({
     huomautusTeksti: input.huomautusTeksti,
+    page,
+    font,
+  });
+
+  drawTrialDogPdfLisatieto11({
+    lisatiedotRows,
     page,
     font,
   });

--- a/docs/features/trials/ajokoe-koirakohtainen-pdf.md
+++ b/docs/features/trials/ajokoe-koirakohtainen-pdf.md
@@ -218,6 +218,9 @@ Rules:
 - Current rendering also uses `koodi = 20-22` in the `haku` block.
 - `20` renders as the raw value.
 - `21` and `22` render with one decimal place.
+- Current rendering also uses `koodi = 30-36` in the `haukku` block.
+- `30-35` render with one decimal place.
+- `36` renders as the raw value.
 
 ## Registration rule
 

--- a/docs/features/trials/ajokoe-koirakohtainen-pdf.md
+++ b/docs/features/trials/ajokoe-koirakohtainen-pdf.md
@@ -212,8 +212,9 @@ Input data:
 Rules:
 
 - Each row contains `koodi`, `era1`, and `era2`.
-- Current rendering uses row `koodi = 11` only (`paljas maa` markers).
-- If `koodi = 11` is missing or both eras are false/empty, nothing is drawn.
+- Current rendering uses `koodi = 11-18` in the `olosuhteet` block.
+- Marker rows (`11`, `13`, `14`, `15`, `16`) render `1`/`X` as `X`.
+- Numeric rows (`12`, `17`, `18`) render their raw number values.
 
 ## Registration rule
 

--- a/docs/features/trials/ajokoe-koirakohtainen-pdf.md
+++ b/docs/features/trials/ajokoe-koirakohtainen-pdf.md
@@ -225,6 +225,8 @@ Rules:
 - All three rows render with one decimal place.
 - Current rendering also uses `koodi = 50-56` in the `ajo` block.
 - All seven rows render with one decimal place.
+- Current rendering also uses `koodi = 60-61` in the `muut ominaisuudet` block.
+- Both rows render with one decimal place.
 
 ## Registration rule
 

--- a/docs/features/trials/ajokoe-koirakohtainen-pdf.md
+++ b/docs/features/trials/ajokoe-koirakohtainen-pdf.md
@@ -215,6 +215,9 @@ Rules:
 - Current rendering uses `koodi = 11-18` in the `olosuhteet` block.
 - Marker rows (`11`, `13`, `14`, `15`, `16`) render `1`/`X` as `X`.
 - Numeric rows (`12`, `17`, `18`) render their raw number values.
+- Current rendering also uses `koodi = 20-22` in the `haku` block.
+- `20` renders as the raw value.
+- `21` and `22` render with one decimal place.
 
 ## Registration rule
 

--- a/docs/features/trials/ajokoe-koirakohtainen-pdf.md
+++ b/docs/features/trials/ajokoe-koirakohtainen-pdf.md
@@ -221,6 +221,8 @@ Rules:
 - Current rendering also uses `koodi = 30-36` in the `haukku` block.
 - `30-35` render with one decimal place.
 - `36` renders as the raw value.
+- Current rendering also uses `koodi = 40-42` in the `metsästysinto` block.
+- All three rows render with one decimal place.
 
 ## Registration rule
 

--- a/docs/features/trials/ajokoe-koirakohtainen-pdf.md
+++ b/docs/features/trials/ajokoe-koirakohtainen-pdf.md
@@ -223,6 +223,8 @@ Rules:
 - `36` renders as the raw value.
 - Current rendering also uses `koodi = 40-42` in the `metsästysinto` block.
 - All three rows render with one decimal place.
+- Current rendering also uses `koodi = 50-56` in the `ajo` block.
+- All seven rows render with one decimal place.
 
 ## Registration rule
 

--- a/docs/features/trials/ajokoe-koirakohtainen-pdf.md
+++ b/docs/features/trials/ajokoe-koirakohtainen-pdf.md
@@ -203,6 +203,18 @@ Rules:
   wrapping can be tuned independently from the result block.
 - Missing values render as nothing.
 
+### 9) `lisätiedot` rows
+
+Input data:
+
+- `lisatiedotRows` (optional)
+
+Rules:
+
+- Each row contains `koodi`, `era1`, and `era2`.
+- Current rendering uses row `koodi = 11` only (`paljas maa` markers).
+- If `koodi = 11` is missing or both eras are false/empty, nothing is drawn.
+
 ## Registration rule
 
 The PDF uses the primary registration number for the dog itself.

--- a/packages/contracts/index.ts
+++ b/packages/contracts/index.ts
@@ -143,6 +143,8 @@ export type {
   TrialDogPdfKoiranTausta,
   TrialDogPdfKoiranTiedot,
   TrialDogPdfHuomautus,
+  TrialDogPdfLisatiedot,
+  TrialDogPdfLisatietoRow,
   TrialDogPdfPayload,
   TrialDogPdfPayloadWithTrialId,
   TrialDogPdfTappiopisteet,

--- a/packages/contracts/trials/index.ts
+++ b/packages/contracts/trials/index.ts
@@ -18,6 +18,8 @@ export type {
   TrialDogPdfKoiranTausta,
   TrialDogPdfKoiranTiedot,
   TrialDogPdfHuomautus,
+  TrialDogPdfLisatiedot,
+  TrialDogPdfLisatietoRow,
   TrialDogPdfPayload,
   TrialDogPdfPayloadWithTrialId,
   TrialDogPdfTappiopisteet,

--- a/packages/contracts/trials/trial-dog-pdf.ts
+++ b/packages/contracts/trials/trial-dog-pdf.ts
@@ -92,4 +92,5 @@ export type TrialDogPdfPayloadWithTrialId = TrialDogPdfPayload & {
 
 export type TrialDogPdfAllekirjoitukset = {
   ryhmatuomariNimi: string | null;
+  palkintotuomariNimi: string | null;
 };

--- a/packages/contracts/trials/trial-dog-pdf.ts
+++ b/packages/contracts/trials/trial-dog-pdf.ts
@@ -1,3 +1,13 @@
+export type TrialDogPdfPayload = TrialDogPdfKokeenTiedot &
+  TrialDogPdfKoiranTiedot &
+  TrialDogPdfKoiranTausta &
+  TrialDogPdfAjoajanPisteytys &
+  TrialDogPdfAnsiopisteet &
+  TrialDogPdfTappiopisteet &
+  TrialDogPdfLoppupisteet &
+  TrialDogPdfHuomautus &
+  TrialDogPdfAllekirjoitukset;
+
 export type TrialDogSex = "MALE" | "FEMALE" | "UNKNOWN";
 
 export type TrialDogPdfDataRequest = {
@@ -76,15 +86,10 @@ export type TrialDogPdfHuomautus = {
   huomautusTeksti: string | null;
 };
 
-export type TrialDogPdfPayload = TrialDogPdfKokeenTiedot &
-  TrialDogPdfKoiranTiedot &
-  TrialDogPdfKoiranTausta &
-  TrialDogPdfAjoajanPisteytys &
-  TrialDogPdfAnsiopisteet &
-  TrialDogPdfTappiopisteet &
-  TrialDogPdfLoppupisteet &
-  TrialDogPdfHuomautus;
-
 export type TrialDogPdfPayloadWithTrialId = TrialDogPdfPayload & {
   trialId: string;
+};
+
+export type TrialDogPdfAllekirjoitukset = {
+  ryhmatuomariNimi: string | null;
 };

--- a/packages/contracts/trials/trial-dog-pdf.ts
+++ b/packages/contracts/trials/trial-dog-pdf.ts
@@ -6,7 +6,8 @@ export type TrialDogPdfPayload = TrialDogPdfKokeenTiedot &
   TrialDogPdfTappiopisteet &
   TrialDogPdfLoppupisteet &
   TrialDogPdfHuomautus &
-  TrialDogPdfAllekirjoitukset;
+  TrialDogPdfAllekirjoitukset &
+  TrialDogPdfLisatiedot;
 
 export type TrialDogSex = "MALE" | "FEMALE" | "UNKNOWN";
 
@@ -84,6 +85,16 @@ export type TrialDogPdfLoppupisteet = {
 
 export type TrialDogPdfHuomautus = {
   huomautusTeksti: string | null;
+};
+
+export type TrialDogPdfLisatietoRow = {
+  koodi: string;
+  era1: string | null;
+  era2: string | null;
+};
+
+export type TrialDogPdfLisatiedot = {
+  lisatiedotRows?: TrialDogPdfLisatietoRow[];
 };
 
 export type TrialDogPdfPayloadWithTrialId = TrialDogPdfPayload & {

--- a/packages/contracts/trials/trial-dog-pdf.ts
+++ b/packages/contracts/trials/trial-dog-pdf.ts
@@ -93,4 +93,6 @@ export type TrialDogPdfPayloadWithTrialId = TrialDogPdfPayload & {
 export type TrialDogPdfAllekirjoitukset = {
   ryhmatuomariNimi: string | null;
   palkintotuomariNimi: string | null;
+  ylituomariNumeroSnapshot: string | null;
+  ylituomariNimiSnapshot: string | null;
 };

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -423,7 +423,7 @@ model TrialEntry {
 
   // 10) tuomarit ja vahvistus (entry-taso)
   ylituomariNimiSnapshot    String?
-  ylituomariNumeroSnapshot  String?
+  ylituomariNumeroSnapshot  String?  // this should be int i think?
   ryhmatuomariNimi          String?
   palkintotuomariNimi       String?
 

--- a/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
@@ -64,6 +64,8 @@ export type TrialDogPdfDataDbRow = {
 
   ryhmatuomariNimi: string | null;
   palkintotuomariNimi: string | null;
+  ylituomariNumeroSnapshot: string | null;
+  ylituomariNimiSnapshot: string | null;
 };
 
 export async function getTrialDogPdfDataDb(
@@ -160,6 +162,8 @@ export async function getTrialDogPdfDataDb(
       huomautusTeksti: true,
       ryhmatuomariNimi: true,
       palkintotuomariNimi: true,
+      ylituomariNumeroSnapshot: true,
+      ylituomariNimiSnapshot: true,
     },
   });
 
@@ -220,5 +224,7 @@ export async function getTrialDogPdfDataDb(
     huomautusTeksti: row.huomautusTeksti,
     ryhmatuomariNimi: row.ryhmatuomariNimi ?? null,
     palkintotuomariNimi: row.palkintotuomariNimi ?? null,
+    ylituomariNumeroSnapshot: row.ylituomariNumeroSnapshot ?? null,
+    ylituomariNimiSnapshot: row.ylituomariNimiSnapshot ?? null,
   };
 }

--- a/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
@@ -61,6 +61,8 @@ export type TrialDogPdfDataDbRow = {
   koiriaLuokassa: number | null;
   palkinto: string | null;
   huomautusTeksti: string | null;
+
+  ryhmatuomariNimi: string | null;
 };
 
 export async function getTrialDogPdfDataDb(
@@ -155,6 +157,7 @@ export async function getTrialDogPdfDataDb(
       koiriaLuokassa: true,
       palkinto: true,
       huomautusTeksti: true,
+      ryhmatuomariNimi: true,
     },
   });
 
@@ -213,5 +216,6 @@ export async function getTrialDogPdfDataDb(
     koiriaLuokassa: row.koiriaLuokassa,
     palkinto: row.palkinto,
     huomautusTeksti: row.huomautusTeksti,
+    ryhmatuomariNimi: row.ryhmatuomariNimi ?? null,
   };
 }

--- a/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
@@ -66,6 +66,9 @@ export type TrialDogPdfDataDbRow = {
   palkintotuomariNimi: string | null;
   ylituomariNumeroSnapshot: string | null;
   ylituomariNimiSnapshot: string | null;
+
+  lisatieto11Era1Arvo: string | null;
+  lisatieto11Era2Arvo: string | null;
 };
 
 export async function getTrialDogPdfDataDb(
@@ -164,6 +167,16 @@ export async function getTrialDogPdfDataDb(
       palkintotuomariNimi: true,
       ylituomariNumeroSnapshot: true,
       ylituomariNimiSnapshot: true,
+      lisatiedot: {
+        where: {
+          koodi: "11",
+        },
+        select: {
+          era1Arvo: true,
+          era2Arvo: true,
+        },
+        take: 1,
+      },
     },
   });
 
@@ -226,5 +239,7 @@ export async function getTrialDogPdfDataDb(
     palkintotuomariNimi: row.palkintotuomariNimi ?? null,
     ylituomariNumeroSnapshot: row.ylituomariNumeroSnapshot ?? null,
     ylituomariNimiSnapshot: row.ylituomariNimiSnapshot ?? null,
+    lisatieto11Era1Arvo: row.lisatiedot[0]?.era1Arvo ?? null,
+    lisatieto11Era2Arvo: row.lisatiedot[0]?.era2Arvo ?? null,
   };
 }

--- a/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
@@ -88,6 +88,7 @@ const OLOSUHDE_KOODIT = [
 
 const HAKU_KOODIT = ["20", "21", "22"] as const;
 const HAUKKU_KOODIT = ["30", "31", "32", "33", "34", "35", "36"] as const;
+const METSASTYSINTO_KOODIT = ["40", "41", "42"] as const;
 
 export async function getTrialDogPdfDataDb(
   input: TrialDogPdfDataDbInput,
@@ -188,7 +189,12 @@ export async function getTrialDogPdfDataDb(
       lisatiedot: {
         where: {
           koodi: {
-            in: [...OLOSUHDE_KOODIT, ...HAKU_KOODIT, ...HAUKKU_KOODIT],
+            in: [
+              ...OLOSUHDE_KOODIT,
+              ...HAKU_KOODIT,
+              ...HAUKKU_KOODIT,
+              ...METSASTYSINTO_KOODIT,
+            ],
           },
         },
         select: {

--- a/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
@@ -11,6 +11,12 @@ export type TrialDogPdfDataDbInput = {
 
 export type TrialDogPdfDataDbDogSex = "MALE" | "FEMALE" | "UNKNOWN";
 
+export type TrialDogPdfDataDbLisatietoRow = {
+  koodi: string;
+  era1Arvo: string | null;
+  era2Arvo: string | null;
+};
+
 export type TrialDogPdfDataDbRow = {
   trialId: string;
   registrationNo: string;
@@ -66,10 +72,19 @@ export type TrialDogPdfDataDbRow = {
   palkintotuomariNimi: string | null;
   ylituomariNumeroSnapshot: string | null;
   ylituomariNimiSnapshot: string | null;
-
-  lisatieto11Era1Arvo: string | null;
-  lisatieto11Era2Arvo: string | null;
+  lisatiedotRows: TrialDogPdfDataDbLisatietoRow[];
 };
+
+const OLOSUHDE_KOODIT = [
+  "11",
+  "12",
+  "13",
+  "14",
+  "15",
+  "16",
+  "17",
+  "18",
+] as const;
 
 export async function getTrialDogPdfDataDb(
   input: TrialDogPdfDataDbInput,
@@ -169,13 +184,18 @@ export async function getTrialDogPdfDataDb(
       ylituomariNimiSnapshot: true,
       lisatiedot: {
         where: {
-          koodi: "11",
+          koodi: {
+            in: [...OLOSUHDE_KOODIT],
+          },
         },
         select: {
+          koodi: true,
           era1Arvo: true,
           era2Arvo: true,
         },
-        take: 1,
+        orderBy: {
+          koodi: "asc",
+        },
       },
     },
   });
@@ -239,7 +259,10 @@ export async function getTrialDogPdfDataDb(
     palkintotuomariNimi: row.palkintotuomariNimi ?? null,
     ylituomariNumeroSnapshot: row.ylituomariNumeroSnapshot ?? null,
     ylituomariNimiSnapshot: row.ylituomariNimiSnapshot ?? null,
-    lisatieto11Era1Arvo: row.lisatiedot[0]?.era1Arvo ?? null,
-    lisatieto11Era2Arvo: row.lisatiedot[0]?.era2Arvo ?? null,
+    lisatiedotRows: row.lisatiedot.map((item) => ({
+      koodi: item.koodi,
+      era1Arvo: item.era1Arvo ?? null,
+      era2Arvo: item.era2Arvo ?? null,
+    })),
   };
 }

--- a/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
@@ -90,6 +90,7 @@ const HAKU_KOODIT = ["20", "21", "22"] as const;
 const HAUKKU_KOODIT = ["30", "31", "32", "33", "34", "35", "36"] as const;
 const METSASTYSINTO_KOODIT = ["40", "41", "42"] as const;
 const AJO_KOODIT = ["50", "51", "52", "53", "54", "55", "56"] as const;
+const MUUT_OMINAISUUDET_KOODIT = ["60", "61"] as const;
 
 export async function getTrialDogPdfDataDb(
   input: TrialDogPdfDataDbInput,
@@ -196,6 +197,7 @@ export async function getTrialDogPdfDataDb(
               ...HAUKKU_KOODIT,
               ...METSASTYSINTO_KOODIT,
               ...AJO_KOODIT,
+              ...MUUT_OMINAISUUDET_KOODIT,
             ],
           },
         },

--- a/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
@@ -87,6 +87,7 @@ const OLOSUHDE_KOODIT = [
 ] as const;
 
 const HAKU_KOODIT = ["20", "21", "22"] as const;
+const HAUKKU_KOODIT = ["30", "31", "32", "33", "34", "35", "36"] as const;
 
 export async function getTrialDogPdfDataDb(
   input: TrialDogPdfDataDbInput,
@@ -187,7 +188,7 @@ export async function getTrialDogPdfDataDb(
       lisatiedot: {
         where: {
           koodi: {
-            in: [...OLOSUHDE_KOODIT, ...HAKU_KOODIT],
+            in: [...OLOSUHDE_KOODIT, ...HAKU_KOODIT, ...HAUKKU_KOODIT],
           },
         },
         select: {

--- a/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
@@ -63,6 +63,7 @@ export type TrialDogPdfDataDbRow = {
   huomautusTeksti: string | null;
 
   ryhmatuomariNimi: string | null;
+  palkintotuomariNimi: string | null;
 };
 
 export async function getTrialDogPdfDataDb(
@@ -158,6 +159,7 @@ export async function getTrialDogPdfDataDb(
       palkinto: true,
       huomautusTeksti: true,
       ryhmatuomariNimi: true,
+      palkintotuomariNimi: true,
     },
   });
 
@@ -217,5 +219,6 @@ export async function getTrialDogPdfDataDb(
     palkinto: row.palkinto,
     huomautusTeksti: row.huomautusTeksti,
     ryhmatuomariNimi: row.ryhmatuomariNimi ?? null,
+    palkintotuomariNimi: row.palkintotuomariNimi ?? null,
   };
 }

--- a/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
@@ -89,6 +89,7 @@ const OLOSUHDE_KOODIT = [
 const HAKU_KOODIT = ["20", "21", "22"] as const;
 const HAUKKU_KOODIT = ["30", "31", "32", "33", "34", "35", "36"] as const;
 const METSASTYSINTO_KOODIT = ["40", "41", "42"] as const;
+const AJO_KOODIT = ["50", "51", "52", "53", "54", "55", "56"] as const;
 
 export async function getTrialDogPdfDataDb(
   input: TrialDogPdfDataDbInput,
@@ -194,6 +195,7 @@ export async function getTrialDogPdfDataDb(
               ...HAKU_KOODIT,
               ...HAUKKU_KOODIT,
               ...METSASTYSINTO_KOODIT,
+              ...AJO_KOODIT,
             ],
           },
         },

--- a/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/db/trials/pdf/get-trial-dog-pdf-data.ts
@@ -86,6 +86,8 @@ const OLOSUHDE_KOODIT = [
   "18",
 ] as const;
 
+const HAKU_KOODIT = ["20", "21", "22"] as const;
+
 export async function getTrialDogPdfDataDb(
   input: TrialDogPdfDataDbInput,
 ): Promise<TrialDogPdfDataDbRow | null> {
@@ -185,7 +187,7 @@ export async function getTrialDogPdfDataDb(
       lisatiedot: {
         where: {
           koodi: {
-            in: [...OLOSUHDE_KOODIT],
+            in: [...OLOSUHDE_KOODIT, ...HAKU_KOODIT],
           },
         },
         select: {

--- a/packages/server/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/server/trials/pdf/get-trial-dog-pdf-data.ts
@@ -125,6 +125,7 @@ export async function getTrialDogPdfDataService(
           Palkinto: result.palkinto,
           huomautusTeksti: result.huomautusTeksti,
           ryhmatuomariNimi: result.ryhmatuomariNimi,
+          palkintotuomariNimi: result.palkintotuomariNimi,
         },
       },
     };

--- a/packages/server/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/server/trials/pdf/get-trial-dog-pdf-data.ts
@@ -124,6 +124,7 @@ export async function getTrialDogPdfDataService(
           koiriaLuokassa: result.koiriaLuokassa,
           Palkinto: result.palkinto,
           huomautusTeksti: result.huomautusTeksti,
+          ryhmatuomariNimi: result.ryhmatuomariNimi,
         },
       },
     };

--- a/packages/server/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/server/trials/pdf/get-trial-dog-pdf-data.ts
@@ -128,13 +128,11 @@ export async function getTrialDogPdfDataService(
           palkintotuomariNimi: result.palkintotuomariNimi,
           ylituomariNumeroSnapshot: result.ylituomariNumeroSnapshot,
           ylituomariNimiSnapshot: result.ylituomariNimiSnapshot,
-          lisatiedotRows: [
-            {
-              koodi: "11",
-              era1: result.lisatieto11Era1Arvo,
-              era2: result.lisatieto11Era2Arvo,
-            },
-          ],
+          lisatiedotRows: result.lisatiedotRows.map((row) => ({
+            koodi: row.koodi,
+            era1: row.era1Arvo,
+            era2: row.era2Arvo,
+          })),
         },
       },
     };

--- a/packages/server/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/server/trials/pdf/get-trial-dog-pdf-data.ts
@@ -126,6 +126,8 @@ export async function getTrialDogPdfDataService(
           huomautusTeksti: result.huomautusTeksti,
           ryhmatuomariNimi: result.ryhmatuomariNimi,
           palkintotuomariNimi: result.palkintotuomariNimi,
+          ylituomariNumeroSnapshot: result.ylituomariNumeroSnapshot,
+          ylituomariNimiSnapshot: result.ylituomariNimiSnapshot,
         },
       },
     };

--- a/packages/server/trials/pdf/get-trial-dog-pdf-data.ts
+++ b/packages/server/trials/pdf/get-trial-dog-pdf-data.ts
@@ -128,6 +128,13 @@ export async function getTrialDogPdfDataService(
           palkintotuomariNimi: result.palkintotuomariNimi,
           ylituomariNumeroSnapshot: result.ylituomariNumeroSnapshot,
           ylituomariNimiSnapshot: result.ylituomariNimiSnapshot,
+          lisatiedotRows: [
+            {
+              koodi: "11",
+              era1: result.lisatieto11Era1Arvo,
+              era2: result.lisatieto11Era2Arvo,
+            },
+          ],
         },
       },
     };


### PR DESCRIPTION
## Summary

-  ajokoekohtainen pöytäkirja is generated fully. only some missing columns. koemaasto for example needs schema change and is added later. 
closes bed-91
