### PR TITLE
Feature/bej 94 ajok readpdf stabilization before develop merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ This project uses a user-facing changelog format.
 
 ### Changed
 
+- Tukemattomat AJOK PDF -sääntöikkunat palauttavat nyt virheen tyhjän PDF:n sijaan. Aiempi `blank-only`-tila on nimetty `not-supported`-tilaksi selkeyden vuoksi.
+
 ### Fixed
 
 - Ajokokeen koirakohtainen PDF näyttää nyt koiran oman primary-rekisterinumeron eli ensimmäisenä lisätyn rekisterinumeron.

--- a/apps/web/app/api/trials/[trialId]/pdf/route.ts
+++ b/apps/web/app/api/trials/[trialId]/pdf/route.ts
@@ -57,23 +57,9 @@ export async function GET(
       });
     }
 
-    const registrationNo = result.body.data.registrationNo.trim();
-    const dogName = result.body.data.dogName?.trim() ?? null;
-    const sireName = result.body.data.sireName?.trim() ?? null;
-    const sireRegistrationNo =
-      result.body.data.sireRegistrationNo?.trim() ?? null;
-    const damName = result.body.data.damName?.trim() ?? null;
-    const damRegistrationNo =
-      result.body.data.damRegistrationNo?.trim() ?? null;
-    const omistaja = result.body.data.omistaja?.trim() ?? null;
-    const omistajanKotikunta =
-      result.body.data.omistajanKotikunta?.trim() ?? null;
-    const kennelpiiri = result.body.data.kennelpiiri?.trim() ?? null;
-    const kennelpiirinro = result.body.data.kennelpiirinro?.trim() ?? null;
-    const koekunta = result.body.data.koekunta?.trim() ?? null;
-    const koemaasto = result.body.data.koemaasto?.trim() ?? null;
-    const koepaiva = result.body.data.koepaiva;
-    const trialRuleWindowId = result.body.data.trialRuleWindowId;
+    // trialId is a server-only field not part of TrialDogPdfPayload; it stays in restData
+    // but TypeScript won't flag the extra property when the payload variable is passed to a function.
+    const { trialRuleWindowId, ...restData } = result.body.data;
     if (!canRenderTrialDogPdf(trialRuleWindowId)) {
       const ruleSetId = getTrialDogPdfRuleSetId(trialRuleWindowId);
       log.warn(
@@ -101,123 +87,36 @@ export async function GET(
       );
     }
 
-    const jarjestaja = result.body.data.jarjestaja?.trim() ?? null;
-    const dogSex = result.body.data.dogSex;
-    const era1Alkoi = result.body.data.era1Alkoi?.trim() ?? null;
-    const era2Alkoi = result.body.data.era2Alkoi?.trim() ?? null;
-    const hakuMin1 = result.body.data.hakuMin1;
-    const hakuMin2 = result.body.data.hakuMin2;
-    const ajoMin1 = result.body.data.ajoMin1;
-    const ajoMin2 = result.body.data.ajoMin2;
-    const hyvaksytytAjominuutit = result.body.data.hyvaksytytAjominuutit;
-    const ajoajanPisteet = result.body.data.ajoajanPisteet;
-    const hakuEra1 = result.body.data.hakuEra1;
-    const hakuEra2 = result.body.data.hakuEra2;
-    const hakuKeskiarvo = result.body.data.hakuKeskiarvo;
-    const haukkuEra1 = result.body.data.haukkuEra1;
-    const haukkuEra2 = result.body.data.haukkuEra2;
-    const haukkuKeskiarvo = result.body.data.haukkuKeskiarvo;
-    const metsastysintoEra1 = result.body.data.metsastysintoEra1;
-    const metsastysintoEra2 = result.body.data.metsastysintoEra2;
-    const metsastysintoKeskiarvo = result.body.data.metsastysintoKeskiarvo;
-    const ajotaitoEra1 = result.body.data.ajotaitoEra1;
-    const ajotaitoEra2 = result.body.data.ajotaitoEra2;
-    const ajotaitoKeskiarvo = result.body.data.ajotaitoKeskiarvo;
-    const hakuloysyysTappioEra1 = result.body.data.hakuloysyysTappioEra1;
-    const hakuloysyysTappioEra2 = result.body.data.hakuloysyysTappioEra2;
-    const hakuloysyysTappioYhteensa =
-      result.body.data.hakuloysyysTappioYhteensa;
-    const ajoloysyysTappioEra1 = result.body.data.ajoloysyysTappioEra1;
-    const ajoloysyysTappioEra2 = result.body.data.ajoloysyysTappioEra2;
-    const ajoloysyysTappioYhteensa = result.body.data.ajoloysyysTappioYhteensa;
-    const tappiopisteetYhteensa = result.body.data.tappiopisteetYhteensa;
-    const ansiopisteetYhteensa = result.body.data.ansiopisteetYhteensa;
-    const loppupisteet = result.body.data.loppupisteet;
-    const paljasMaaTaiLumi = result.body.data.paljasMaaTaiLumi;
-    const luopui = result.body.data.luopui;
-    const suljettu = result.body.data.suljettu;
-    const keskeytetty = result.body.data.keskeytetty;
-    const koetyyppi = result.body.data.koetyyppi;
-    const sijoitus = result.body.data.sijoitus;
-    const koiriaLuokassa = result.body.data.koiriaLuokassa;
-    const Palkinto = result.body.data.Palkinto;
-    const huomautusTeksti = result.body.data.huomautusTeksti;
-
-    const ryhmatuomariNimi = result.body.data.ryhmatuomariNimi;
-    const palkintotuomariNimi = result.body.data.palkintotuomariNimi;
-    const ylituomariNumeroSnapshot = result.body.data.ylituomariNumeroSnapshot;
-    const ylituomariNimiSnapshot = result.body.data.ylituomariNimiSnapshot;
-    const lisatiedotRows = result.body.data.lisatiedotRows;
-
-    const pdfBytes = await renderTrialDogPdf({
+    // Spread all payload fields; only trim the string fields that may arrive with whitespace.
+    const payload = {
+      ...restData,
       trialRuleWindowId,
-      registrationNo,
-      dogName,
-      dogSex,
-      sireName,
-      sireRegistrationNo,
-      damName,
-      damRegistrationNo,
-      omistaja,
-      omistajanKotikunta,
-      kennelpiiri,
-      kennelpiirinro,
-      koekunta,
-      koemaasto,
-      koepaiva,
-      jarjestaja,
-      era1Alkoi,
-      era2Alkoi,
-      hakuMin1,
-      hakuMin2,
-      ajoMin1,
-      ajoMin2,
-      hyvaksytytAjominuutit,
-      ajoajanPisteet,
-      hakuEra1,
-      hakuEra2,
-      hakuKeskiarvo,
-      haukkuEra1,
-      haukkuEra2,
-      haukkuKeskiarvo,
-      metsastysintoEra1,
-      metsastysintoEra2,
-      metsastysintoKeskiarvo,
-      ajotaitoEra1,
-      ajotaitoEra2,
-      ajotaitoKeskiarvo,
-      hakuloysyysTappioEra1,
-      hakuloysyysTappioEra2,
-      hakuloysyysTappioYhteensa,
-      ajoloysyysTappioEra1,
-      ajoloysyysTappioEra2,
-      ajoloysyysTappioYhteensa,
-      tappiopisteetYhteensa,
-      ansiopisteetYhteensa,
-      loppupisteet,
-      paljasMaaTaiLumi,
-      luopui,
-      suljettu,
-      keskeytetty,
-      koetyyppi,
-      sijoitus,
-      koiriaLuokassa,
-      Palkinto,
-      huomautusTeksti,
-      ryhmatuomariNimi,
-      palkintotuomariNimi,
-      ylituomariNumeroSnapshot,
-      ylituomariNimiSnapshot,
-      lisatiedotRows,
-    });
+      registrationNo: restData.registrationNo.trim(),
+      dogName: restData.dogName?.trim() ?? null,
+      sireName: restData.sireName?.trim() ?? null,
+      sireRegistrationNo: restData.sireRegistrationNo?.trim() ?? null,
+      damName: restData.damName?.trim() ?? null,
+      damRegistrationNo: restData.damRegistrationNo?.trim() ?? null,
+      omistaja: restData.omistaja?.trim() ?? null,
+      omistajanKotikunta: restData.omistajanKotikunta?.trim() ?? null,
+      kennelpiiri: restData.kennelpiiri?.trim() ?? null,
+      kennelpiirinro: restData.kennelpiirinro?.trim() ?? null,
+      koekunta: restData.koekunta?.trim() ?? null,
+      koemaasto: restData.koemaasto?.trim() ?? null,
+      jarjestaja: restData.jarjestaja?.trim() ?? null,
+      era1Alkoi: restData.era1Alkoi?.trim() ?? null,
+      era2Alkoi: restData.era2Alkoi?.trim() ?? null,
+    };
+
+    const pdfBytes = await renderTrialDogPdf(payload);
 
     log.info(
       {
         event: "success",
         trialId: normalizedTrialId,
-        registrationNo,
-        dogName,
-        kennelpiiri,
+        registrationNo: payload.registrationNo,
+        dogName: payload.dogName,
+        kennelpiiri: payload.kennelpiiri,
         durationMs: Date.now() - startedAt,
       },
       "trial pdf generation succeeded",

--- a/apps/web/components/admin/trials/__tests__/admin-trial-selected-event-panel.test.tsx
+++ b/apps/web/components/admin/trials/__tests__/admin-trial-selected-event-panel.test.tsx
@@ -37,11 +37,9 @@ vi.mock("@/components/ui/card", () => ({
 
 vi.mock("@/components/ui/button", () => ({
   Button: ({
-    asChild: _asChild,
     children,
     ...props
   }: {
-    asChild?: boolean;
     children: React.ReactNode;
     [key: string]: unknown;
   }) => React.createElement("button", props, children),

--- a/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf.test.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/__tests__/trial-dog-pdf.test.ts
@@ -166,12 +166,16 @@ describe("renderTrialDogPdf", () => {
     ]);
   });
 
-  it("keeps unfinished rule sets blank-only", () => {
-    expect(getTrialDogPdfRuleSetStatus("trw_pre_20020801")).toBe("blank-only");
-    expect(getTrialDogPdfRuleSetStatus("trw_range_2002_2005")).toBe(
-      "blank-only",
+  it("marks unimplemented rule sets as not-supported", () => {
+    expect(getTrialDogPdfRuleSetStatus("trw_pre_20020801")).toBe(
+      "not-supported",
     );
-    expect(getTrialDogPdfRuleSetStatus("trw_post_20230801")).toBe("blank-only");
+    expect(getTrialDogPdfRuleSetStatus("trw_range_2002_2005")).toBe(
+      "not-supported",
+    );
+    expect(getTrialDogPdfRuleSetStatus("trw_post_20230801")).toBe(
+      "not-supported",
+    );
   });
 
   it("marks template-backed timelines as renderable", () => {
@@ -192,9 +196,79 @@ describe("renderTrialDogPdf", () => {
     expect(getTrialDogPdfRuleSetId("trw_post_20230801")).toBe(
       "post-2023-unimplemented",
     );
-    expect(getTrialDogPdfRuleSetStatus("trw_post_20230801")).toBe("blank-only");
+    expect(getTrialDogPdfRuleSetStatus("trw_post_20230801")).toBe(
+      "not-supported",
+    );
     expect(canRenderTrialDogPdf("trw_post_20230801")).toBe(false);
   });
+
+  it.each(["trw_pre_20020801", "trw_range_2002_2005", "trw_post_20230801"])(
+    "throws for not-supported rule window %s instead of returning a blank PDF",
+    async (trialRuleWindowId) => {
+      await expect(
+        renderTrialDogPdf({
+          trialRuleWindowId,
+          registrationNo: "FI00000/00",
+          dogName: null,
+          dogSex: "MALE",
+          sireName: null,
+          sireRegistrationNo: null,
+          damName: null,
+          damRegistrationNo: null,
+          omistaja: null,
+          omistajanKotikunta: null,
+          kennelpiiri: null,
+          kennelpiirinro: null,
+          koekunta: null,
+          koemaasto: null,
+          koepaiva: new Date("2025-01-01T00:00:00.000Z"),
+          jarjestaja: null,
+          era1Alkoi: null,
+          era2Alkoi: null,
+          hakuMin1: null,
+          hakuMin2: null,
+          ajoMin1: null,
+          ajoMin2: null,
+          hyvaksytytAjominuutit: null,
+          ajoajanPisteet: null,
+          hakuEra1: null,
+          hakuEra2: null,
+          hakuKeskiarvo: null,
+          haukkuEra1: null,
+          haukkuEra2: null,
+          haukkuKeskiarvo: null,
+          metsastysintoEra1: null,
+          metsastysintoEra2: null,
+          metsastysintoKeskiarvo: null,
+          hakuloysyysTappioEra1: null,
+          hakuloysyysTappioEra2: null,
+          hakuloysyysTappioYhteensa: null,
+          ajoloysyysTappioEra1: null,
+          ajoloysyysTappioEra2: null,
+          ajoloysyysTappioYhteensa: null,
+          tappiopisteetYhteensa: null,
+          ajotaitoEra1: null,
+          ajotaitoEra2: null,
+          ajotaitoKeskiarvo: null,
+          ansiopisteetYhteensa: null,
+          loppupisteet: null,
+          paljasMaaTaiLumi: null,
+          luopui: false,
+          suljettu: false,
+          keskeytetty: false,
+          koetyyppi: "NORMAL",
+          sijoitus: null,
+          koiriaLuokassa: null,
+          Palkinto: null,
+          huomautusTeksti: null,
+          ryhmatuomariNimi: null,
+          palkintotuomariNimi: null,
+          ylituomariNumeroSnapshot: null,
+          ylituomariNimiSnapshot: null,
+        }),
+      ).rejects.toThrow("has no template.");
+    },
+  );
 
   it("does not fall back to another timeline for unknown rule windows", async () => {
     await expect(

--- a/apps/web/lib/public/beagle/trials/pdf/rule-sets/registry.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/rule-sets/registry.ts
@@ -25,7 +25,7 @@ const TEMPLATE_2005_2011_RELATIVE_PATH = path.join(
 const UNSUPPORTED_RULE_SET: TrialDogPdfRuleSet = {
   id: "unsupported",
   templateRelativePath: null,
-  status: "blank-only",
+  status: "not-supported",
 };
 
 const LEGACY_2011_2023_RULE_SET: TrialDogPdfRuleSet = {
@@ -46,19 +46,19 @@ const TRIAL_DOG_PDF_RULE_SETS = {
   [TRIAL_RULE_WINDOW_IDS.PRE_2002]: {
     id: "legacy-pre-2002",
     templateRelativePath: null,
-    status: "blank-only",
+    status: "not-supported",
   },
   [TRIAL_RULE_WINDOW_IDS.RANGE_2002_2005]: {
     id: "legacy-2002-2005",
     templateRelativePath: null,
-    status: "blank-only",
+    status: "not-supported",
   },
   [TRIAL_RULE_WINDOW_IDS.RANGE_2005_2011]: LEGACY_2005_2011_RULE_SET,
   [TRIAL_RULE_WINDOW_IDS.RANGE_2011_2023]: LEGACY_2011_2023_RULE_SET,
   [TRIAL_RULE_WINDOW_IDS.POST_2023]: {
     id: "post-2023-unimplemented",
     templateRelativePath: null,
-    status: "blank-only",
+    status: "not-supported",
   },
 } as const satisfies Record<string, TrialDogPdfRuleSet>;
 

--- a/apps/web/lib/public/beagle/trials/pdf/rule-sets/types.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/rule-sets/types.ts
@@ -1,7 +1,7 @@
 import type { TrialDogPdfPayload } from "@contracts";
 import type { PDFFont, PDFDocument, PDFPage } from "pdf-lib";
 
-export type TrialDogPdfRuleSetStatus = "blank-only" | "implemented";
+export type TrialDogPdfRuleSetStatus = "not-supported" | "implemented";
 
 export type TrialDogPdfRenderContext = {
   pdfDocument: PDFDocument;

--- a/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
+++ b/apps/web/lib/public/beagle/trials/pdf/trial-dog-pdf.ts
@@ -58,10 +58,6 @@ export async function renderTrialDogPdf(
   const templateBytes = await readFile(templatePath);
   const pdfDocument = await PDFDocument.load(templateBytes);
 
-  if (ruleSet.status === "blank-only") {
-    return pdfDocument.save();
-  }
-
   if (!ruleSet.renderFields) {
     throw new Error(`PDF rule set ${ruleSet.id} is missing a field renderer.`);
   }

--- a/packages/server/admin/trials/manage/__tests__/parse-admin-trial-event-search-input.test.ts
+++ b/packages/server/admin/trials/manage/__tests__/parse-admin-trial-event-search-input.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getTrialBusinessDateStartUtc } from "../../../../trials/core/business-date";
+import { getTrialBusinessDateStartUtc } from "@server/trials/core/business-date";
 import { parseAdminTrialEventSearchInput } from "../internal/parse-admin-trial-event-search-input";
 
 describe("parseAdminTrialEventSearchInput", () => {

--- a/packages/server/admin/trials/manage/internal/map-admin-trial-event-search-response.ts
+++ b/packages/server/admin/trials/manage/internal/map-admin-trial-event-search-response.ts
@@ -3,10 +3,9 @@ import type {
   AdminTrialEventSearchFilters,
   AdminTrialEventSearchResponse,
 } from "@beagle/contracts";
-import type { AdminTrialEventSearchResponseDb } from "@beagle/db";
 import type { ParsedAdminTrialEventSearchInput } from "./parse-admin-trial-event-search-input";
 import type { ResolvedAdminTrialEventSearch } from "./resolve-admin-trial-event-defaults";
-import { toTrialBusinessYear } from "../../../../trials/core/business-date";
+import { toTrialBusinessYear } from "@server/trials/core/business-date";
 
 function resolveFilters(
   input: ParsedAdminTrialEventSearchInput,

--- a/packages/server/admin/trials/manage/internal/parse-admin-trial-event-search-input.ts
+++ b/packages/server/admin/trials/manage/internal/parse-admin-trial-event-search-input.ts
@@ -3,7 +3,7 @@ import type {
   AdminTrialEventSearchSort,
 } from "@beagle/contracts";
 import type { AdminTrialEventSearchSortDb } from "@beagle/db";
-import { getTrialBusinessDateUtcRange } from "../../../../trials/core/business-date";
+import { getTrialBusinessDateUtcRange } from "@server/trials/core/business-date";
 
 export type ParsedAdminTrialEventSearchInput = {
   query: string;

--- a/packages/server/admin/trials/manage/internal/resolve-admin-trial-event-defaults.ts
+++ b/packages/server/admin/trials/manage/internal/resolve-admin-trial-event-defaults.ts
@@ -2,7 +2,7 @@ import { searchAdminTrialsDb } from "@beagle/db";
 import {
   getTrialBusinessYearUtcRange,
   toTrialBusinessYear,
-} from "../../../../trials/core/business-date";
+} from "@server/trials/core/business-date";
 import type { ParsedAdminTrialEventSearchInput } from "./parse-admin-trial-event-search-input";
 
 export type ResolvedAdminTrialEventSearch = {

--- a/packages/server/trials/core/business-date.ts
+++ b/packages/server/trials/core/business-date.ts
@@ -1,4 +1,4 @@
-import { BUSINESS_TIME_ZONE, toBusinessDateOnly } from "../../core/date-only";
+import { BUSINESS_TIME_ZONE, toBusinessDateOnly } from "@server/core/date-only";
 
 function parseIsoDateOnlyParts(value: string): {
   year: number;

--- a/packages/server/trials/internal/__tests__/business-date.test.ts
+++ b/packages/server/trials/internal/__tests__/business-date.test.ts
@@ -4,7 +4,7 @@ import {
   getTrialBusinessDateUtcRange,
   getTrialBusinessYearUtcRange,
   toTrialBusinessYear,
-} from "../../core/business-date";
+} from "@server/trials/core/business-date";
 
 describe("business-date helpers", () => {
   it("builds a business date start from an iso date", () => {


### PR DESCRIPTION
## Summary

Stabilizes AJOK dog PDF generation before merging the AJOK feature branch forward.

## Changes

- return a clear error for unsupported AJOK PDF rule windows instead of blank PDFs
- rename `blank-only` rule set status to `not-supported`
- simplify PDF route payload mapping while preserving string trimming
- clean up internal trial business-date imports
- update PDF rule-set tests

## Notes

- Supported PDF rule windows still render normally
- Unsupported older rule windows return `TRIAL_PDF_NOT_AVAILABLE`