### PR TITLE
fix(api): use canonical trial event ids for public trials

### DIFF
--- a/packages/db/trials/__tests__/repository.test.ts
+++ b/packages/db/trials/__tests__/repository.test.ts
@@ -1,24 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DogSex } from "@prisma/client";
 
-const { trialEventFindManyMock, trialEntryFindManyMock, prismaMock } =
-  vi.hoisted(() => {
-    const trialEventFindMany = vi.fn();
-    const trialEntryFindMany = vi.fn();
+const {
+  trialEventFindManyMock,
+  trialEventFindUniqueMock,
+  trialEntryFindManyMock,
+  prismaMock,
+} = vi.hoisted(() => {
+  const trialEventFindMany = vi.fn();
+  const trialEventFindUnique = vi.fn();
+  const trialEntryFindMany = vi.fn();
 
-    return {
-      trialEventFindManyMock: trialEventFindMany,
-      trialEntryFindManyMock: trialEntryFindMany,
-      prismaMock: {
-        trialEvent: {
-          findMany: trialEventFindMany,
-        },
-        trialEntry: {
-          findMany: trialEntryFindMany,
-        },
+  return {
+    trialEventFindManyMock: trialEventFindMany,
+    trialEventFindUniqueMock: trialEventFindUnique,
+    trialEntryFindManyMock: trialEntryFindMany,
+    prismaMock: {
+      trialEvent: {
+        findMany: trialEventFindMany,
+        findUnique: trialEventFindUnique,
       },
-    };
-  });
+      trialEntry: {
+        findMany: trialEntryFindMany,
+      },
+    },
+  };
+});
 
 vi.mock("../../core/prisma", () => ({
   prisma: prismaMock,
@@ -39,22 +46,22 @@ describe("searchBeagleTrialsDb", () => {
     trialEventFindManyMock.mockReset();
   });
 
-  it("groups TrialEvent rows by koepaiva+koekunta and returns available dates", async () => {
+  it("returns one row per TrialEvent and available dates", async () => {
     trialEventFindManyMock
-      // call 1: distinct koepaiva (available dates)
       .mockResolvedValueOnce([
         { koepaiva: new Date("2025-08-01T00:00:00.000Z") },
         { koepaiva: new Date("2024-07-01T00:00:00.000Z") },
       ])
-      // call 2: event rows in date window
       .mockResolvedValueOnce([
         {
+          id: "event-2",
           koepaiva: new Date("2025-06-01T00:00:00.000Z"),
           koekunta: "Helsinki",
           ylituomariNimi: "Judge A",
           _count: { entries: 7 },
         },
         {
+          id: "event-1",
           koepaiva: new Date("2025-09-01T00:00:00.000Z"),
           koekunta: "Turku",
           ylituomariNimi: "Judge B",
@@ -74,6 +81,10 @@ describe("searchBeagleTrialsDb", () => {
       "2025-08-01T00:00:00.000Z",
       "2024-07-01T00:00:00.000Z",
     ]);
+    expect(result.items.map((r) => r.trialEventId)).toEqual([
+      "event-1",
+      "event-2",
+    ]);
     expect(result.items.map((r) => r.eventPlace)).toEqual([
       "Turku",
       "Helsinki",
@@ -83,7 +94,6 @@ describe("searchBeagleTrialsDb", () => {
     expect(result.total).toBe(2);
     expect(result.totalPages).toBe(1);
 
-    // Verify the date window was forwarded to the event-rows query.
     const eventRowsCall = trialEventFindManyMock.mock.calls[1]?.[0] as {
       where: { koepaiva: { gte: Date; lt: Date } };
     };
@@ -95,19 +105,21 @@ describe("searchBeagleTrialsDb", () => {
     );
   });
 
-  it("folds multiple TrialEvent rows with same koepaiva+koekunta into one public row", async () => {
+  it("keeps same-date same-place TrialEvent rows separate", async () => {
     trialEventFindManyMock
       .mockResolvedValueOnce([
         { koepaiva: new Date("2025-06-01T00:00:00.000Z") },
       ])
       .mockResolvedValueOnce([
         {
+          id: "event-a",
           koepaiva: new Date("2025-06-01T00:00:00.000Z"),
           koekunta: "Helsinki",
           ylituomariNimi: "Judge A",
           _count: { entries: 5 },
         },
         {
+          id: "event-b",
           koepaiva: new Date("2025-06-01T00:00:00.000Z"),
           koekunta: "Helsinki",
           ylituomariNimi: "Judge A",
@@ -123,76 +135,12 @@ describe("searchBeagleTrialsDb", () => {
       pageSize: 10,
     });
 
-    expect(result.total).toBe(1);
-    expect(result.items[0]?.dogCount).toBe(8);
-    expect(result.items[0]?.judge).toBe("Judge A");
-  });
-
-  it("returns null judge when folded events disagree on ylituomariNimi", async () => {
-    trialEventFindManyMock
-      .mockResolvedValueOnce([
-        { koepaiva: new Date("2025-06-01T00:00:00.000Z") },
-      ])
-      .mockResolvedValueOnce([
-        {
-          koepaiva: new Date("2025-06-01T00:00:00.000Z"),
-          koekunta: "Helsinki",
-          ylituomariNimi: "Judge A",
-          _count: { entries: 2 },
-        },
-        {
-          koepaiva: new Date("2025-06-01T00:00:00.000Z"),
-          koekunta: "Helsinki",
-          ylituomariNimi: "Judge B",
-          _count: { entries: 2 },
-        },
-      ]);
-
-    const result = await searchBeagleTrialsDb({
-      dateFrom: new Date("2024-12-31T22:00:00.000Z"),
-      dateTo: new Date("2025-12-31T22:00:00.000Z"),
-      sort: "date-desc",
-      page: 1,
-      pageSize: 10,
-    });
-
-    expect(result.items[0]?.judge).toBeNull();
-  });
-
-  it("folds events on the same Helsinki business date even when koepaiva timestamps differ", async () => {
-    // 2025-05-31T21:00:00Z = 2025-06-01T00:00:00 Helsinki (EEST UTC+3)
-    // 2025-06-01T00:00:00Z = 2025-06-01T03:00:00 Helsinki — same calendar day
-    trialEventFindManyMock
-      .mockResolvedValueOnce([
-        { koepaiva: new Date("2025-05-31T21:00:00.000Z") },
-      ])
-      .mockResolvedValueOnce([
-        {
-          koepaiva: new Date("2025-05-31T21:00:00.000Z"),
-          koekunta: "Helsinki",
-          ylituomariNimi: "Judge A",
-          _count: { entries: 3 },
-        },
-        {
-          koepaiva: new Date("2025-06-01T00:00:00.000Z"),
-          koekunta: "Helsinki",
-          ylituomariNimi: "Judge A",
-          _count: { entries: 4 },
-        },
-      ]);
-
-    const result = await searchBeagleTrialsDb({
-      dateFrom: new Date("2025-05-31T21:00:00.000Z"),
-      dateTo: new Date("2025-06-01T21:00:00.000Z"),
-      sort: "date-desc",
-      page: 1,
-      pageSize: 10,
-    });
-
-    // Both events fall on 2025-06-01 in Helsinki — must fold into one public row.
-    expect(result.total).toBe(1);
-    expect(result.items[0]?.dogCount).toBe(7);
-    expect(result.items[0]?.judge).toBe("Judge A");
+    expect(result.total).toBe(2);
+    expect(result.items.map((row) => row.trialEventId)).toEqual([
+      "event-a",
+      "event-b",
+    ]);
+    expect(result.items.map((row) => row.dogCount)).toEqual([5, 3]);
   });
 
   it("applies entries:{ some:{} } filter to both available-dates and event-rows queries", async () => {
@@ -226,12 +174,14 @@ describe("searchBeagleTrialsDb", () => {
       .mockResolvedValueOnce([{ koepaiva: new Date("2025-02-01T00:00:00Z") }])
       .mockResolvedValueOnce([
         {
+          id: "event-b",
           koepaiva: new Date("2025-03-01T00:00:00.000Z"),
           koekunta: "Akaa",
           ylituomariNimi: "Judge A",
           _count: { entries: 1 },
         },
         {
+          id: "event-a",
           koepaiva: new Date("2025-04-01T00:00:00.000Z"),
           koekunta: "Borga",
           ylituomariNimi: "Judge B",
@@ -250,6 +200,7 @@ describe("searchBeagleTrialsDb", () => {
     expect(result.page).toBe(2);
     expect(result.totalPages).toBe(2);
     expect(result.items[0]?.eventPlace).toBe("Borga");
+    expect(result.items[0]?.trialEventId).toBe("event-a");
   });
 });
 
@@ -259,126 +210,117 @@ describe("searchBeagleTrialsDb", () => {
 
 describe("getBeagleTrialDetailsDb", () => {
   beforeEach(() => {
-    trialEventFindManyMock.mockReset();
+    trialEventFindUniqueMock.mockReset();
   });
 
   it("returns null when no TrialEvent is found", async () => {
-    trialEventFindManyMock.mockResolvedValue([]);
+    trialEventFindUniqueMock.mockResolvedValue(null);
 
     const result = await getBeagleTrialDetailsDb({
-      eventDateStart: new Date("2025-05-31T21:00:00.000Z"),
-      eventDateEndExclusive: new Date("2025-06-01T21:00:00.000Z"),
-      eventPlace: "Helsinki",
+      trialEventId: "event-missing",
     });
 
     expect(result).toBeNull();
   });
 
   it("returns null when TrialEvent exists but has no entries", async () => {
-    trialEventFindManyMock.mockResolvedValue([
-      {
-        koepaiva: new Date("2025-06-01T00:00:00.000Z"),
-        koekunta: "Helsinki",
-        ylituomariNimi: "Judge Main",
-        entries: [],
-      },
-    ]);
+    trialEventFindUniqueMock.mockResolvedValue({
+      id: "event-1",
+      koepaiva: new Date("2025-06-01T00:00:00.000Z"),
+      koekunta: "Helsinki",
+      ylituomariNimi: "Judge Main",
+      trialRuleWindowId: "trw1",
+      entries: [],
+    });
 
     const result = await getBeagleTrialDetailsDb({
-      eventDateStart: new Date("2025-05-31T21:00:00.000Z"),
-      eventDateEndExclusive: new Date("2025-06-01T21:00:00.000Z"),
-      eventPlace: "Helsinki",
+      trialEventId: "event-1",
     });
 
     expect(result).toBeNull();
   });
 
   it("maps TrialEntry fields, resolves judges, and sorts by points desc", async () => {
-    trialEventFindManyMock.mockResolvedValue([
-      {
-        koepaiva: new Date("2025-06-01T12:34:00.000Z"),
-        koekunta: "Helsinki",
-        ylituomariNimi: "Judge Main",
-        entries: [
-          {
-            // unlinked entry — dogId null, no dog relation
-            id: "r3",
-            dogId: null,
-            rekisterinumeroSnapshot: "FI-300/25",
-            ke: null,
-            pa: null,
-            lk: null,
-            sija: null,
-            piste: null,
-            tuom1: null,
-            ylituomariNimiSnapshot: null,
-            haku: null,
-            hauk: null,
-            yva: null,
-            hlo: null,
-            alo: null,
-            tja: null,
-            pin: null,
-            dog: null,
-          },
-          {
-            // linked dog, no tuom1 — falls back to event judge
-            id: "r2",
-            dogId: "d2",
-            rekisterinumeroSnapshot: "FI-200/25",
-            ke: "P",
-            pa: "2",
-            lk: "A",
-            sija: "2",
-            piste: { toNumber: () => 72.5 },
-            tuom1: null,
-            ylituomariNimiSnapshot: null,
-            haku: { toNumber: () => 4.1 },
-            hauk: { toNumber: () => 4.2 },
-            yva: { toNumber: () => 4.3 },
-            hlo: { toNumber: () => 4.4 },
-            alo: { toNumber: () => 4.5 },
-            tja: { toNumber: () => 4.6 },
-            pin: { toNumber: () => 4.7 },
-            dog: { name: "Bella", sex: DogSex.FEMALE },
-          },
-          {
-            // linked dog with per-entry ylituomari snapshot
-            id: "r1",
-            dogId: "d1",
-            rekisterinumeroSnapshot: "FI-100/25",
-            ke: "L",
-            pa: "1",
-            lk: "V",
-            sija: "1",
-            piste: { toNumber: () => 88.25 },
-            tuom1: "Judge Group",
-            ylituomariNimiSnapshot: "Judge Snapshot",
-            haku: { toNumber: () => 5.1 },
-            hauk: { toNumber: () => 5.2 },
-            yva: { toNumber: () => 5.3 },
-            hlo: { toNumber: () => 5.4 },
-            alo: { toNumber: () => 5.5 },
-            tja: { toNumber: () => 5.6 },
-            pin: { toNumber: () => 5.7 },
-            dog: { name: "Aatu", sex: DogSex.MALE },
-          },
-        ],
-      },
-    ]);
+    trialEventFindUniqueMock.mockResolvedValue({
+      id: "event-1",
+      koepaiva: new Date("2025-06-01T12:34:00.000Z"),
+      koekunta: "Helsinki",
+      ylituomariNimi: "Judge Main",
+      trialRuleWindowId: "trw1",
+      entries: [
+        {
+          id: "r3",
+          dogId: null,
+          rekisterinumeroSnapshot: "FI-300/25",
+          ke: null,
+          pa: null,
+          lk: null,
+          sija: null,
+          piste: null,
+          tuom1: null,
+          ylituomariNimiSnapshot: null,
+          haku: null,
+          hauk: null,
+          yva: null,
+          hlo: null,
+          alo: null,
+          tja: null,
+          pin: null,
+          dog: null,
+        },
+        {
+          id: "r2",
+          dogId: "d2",
+          rekisterinumeroSnapshot: "FI-200/25",
+          ke: "P",
+          pa: "2",
+          lk: "A",
+          sija: "2",
+          piste: { toNumber: () => 72.5 },
+          tuom1: null,
+          ylituomariNimiSnapshot: null,
+          haku: { toNumber: () => 4.1 },
+          hauk: { toNumber: () => 4.2 },
+          yva: { toNumber: () => 4.3 },
+          hlo: { toNumber: () => 4.4 },
+          alo: { toNumber: () => 4.5 },
+          tja: { toNumber: () => 4.6 },
+          pin: { toNumber: () => 4.7 },
+          dog: { name: "Bella", sex: DogSex.FEMALE },
+        },
+        {
+          id: "r1",
+          dogId: "d1",
+          rekisterinumeroSnapshot: "FI-100/25",
+          ke: "L",
+          pa: "1",
+          lk: "V",
+          sija: "1",
+          piste: { toNumber: () => 88.25 },
+          tuom1: "Judge Group",
+          ylituomariNimiSnapshot: "Judge Snapshot",
+          haku: { toNumber: () => 5.1 },
+          hauk: { toNumber: () => 5.2 },
+          yva: { toNumber: () => 5.3 },
+          hlo: { toNumber: () => 5.4 },
+          alo: { toNumber: () => 5.5 },
+          tja: { toNumber: () => 5.6 },
+          pin: { toNumber: () => 5.7 },
+          dog: { name: "Aatu", sex: DogSex.MALE },
+        },
+      ],
+    });
 
     const result = await getBeagleTrialDetailsDb({
-      eventDateStart: new Date("2025-05-31T21:00:00.000Z"),
-      eventDateEndExclusive: new Date("2025-06-01T21:00:00.000Z"),
-      eventPlace: "Helsinki",
+      trialEventId: "event-1",
     });
 
     expect(result).not.toBeNull();
+    expect(result?.trialEventId).toBe("event-1");
     expect(result?.dogCount).toBe(3);
     expect(result?.judge).toBe("Judge Main");
     expect(result?.items.map((item) => item.id)).toEqual(["r1", "r2", "r3"]);
 
-    // r1: linked dog, tuom1 takes precedence over event judge
     expect(result?.items[0]).toMatchObject({
       dogId: "d1",
       sex: "U",
@@ -392,7 +334,6 @@ describe("getBeagleTrialDetailsDb", () => {
       judge: "Judge Snapshot",
     });
 
-    // r2: linked dog, no tuom1 — falls back to event-level judge
     expect(result?.items[1]).toMatchObject({
       dogId: "d2",
       sex: "N",
@@ -401,7 +342,6 @@ describe("getBeagleTrialDetailsDb", () => {
       judge: "Judge Main",
     });
 
-    // r3: unlinked entry — dogId null, name falls back to registrationNo snapshot
     expect(result?.items[2]).toMatchObject({
       dogId: null,
       sex: "-",
@@ -413,73 +353,44 @@ describe("getBeagleTrialDetailsDb", () => {
     });
   });
 
-  it("folds entries from multiple TrialEvent rows with same koepaiva+koekunta", async () => {
-    trialEventFindManyMock.mockResolvedValue([
-      {
-        koepaiva: new Date("2025-06-01T00:00:00.000Z"),
-        koekunta: "Helsinki",
-        ylituomariNimi: "Judge A",
-        entries: [
-          {
-            id: "r1",
-            dogId: "d1",
-            rekisterinumeroSnapshot: "FI-100/25",
-            ke: null,
-            pa: null,
-            lk: null,
-            sija: null,
-            piste: { toNumber: () => 80 },
-            tuom1: null,
-            ylituomariNimiSnapshot: null,
-            haku: null,
-            hauk: null,
-            yva: null,
-            hlo: null,
-            alo: null,
-            tja: null,
-            pin: null,
-            dog: { name: "Aatu", sex: DogSex.MALE },
-          },
-        ],
-      },
-      {
-        koepaiva: new Date("2025-06-01T00:00:00.000Z"),
-        koekunta: "Helsinki",
-        ylituomariNimi: "Judge A",
-        entries: [
-          {
-            id: "r2",
-            dogId: "d2",
-            rekisterinumeroSnapshot: "FI-200/25",
-            ke: null,
-            pa: null,
-            lk: null,
-            sija: null,
-            piste: { toNumber: () => 70 },
-            tuom1: null,
-            ylituomariNimiSnapshot: null,
-            haku: null,
-            hauk: null,
-            yva: null,
-            hlo: null,
-            alo: null,
-            tja: null,
-            pin: null,
-            dog: { name: "Bella", sex: DogSex.FEMALE },
-          },
-        ],
-      },
-    ]);
-
-    const result = await getBeagleTrialDetailsDb({
-      eventDateStart: new Date("2025-05-31T21:00:00.000Z"),
-      eventDateEndExclusive: new Date("2025-06-01T21:00:00.000Z"),
-      eventPlace: "Helsinki",
+  it("keeps separate TrialEvent ids isolated", async () => {
+    trialEventFindUniqueMock.mockResolvedValue({
+      id: "event-1",
+      koepaiva: new Date("2025-06-01T00:00:00.000Z"),
+      koekunta: "Helsinki",
+      ylituomariNimi: "Judge A",
+      trialRuleWindowId: "trw1",
+      entries: [
+        {
+          id: "r1",
+          dogId: "d1",
+          rekisterinumeroSnapshot: "FI-100/25",
+          ke: null,
+          pa: null,
+          lk: null,
+          sija: null,
+          piste: { toNumber: () => 80 },
+          tuom1: null,
+          ylituomariNimiSnapshot: null,
+          haku: null,
+          hauk: null,
+          yva: null,
+          hlo: null,
+          alo: null,
+          tja: null,
+          pin: null,
+          dog: { name: "Aatu", sex: DogSex.MALE },
+        },
+      ],
     });
 
-    expect(result?.dogCount).toBe(2);
-    expect(result?.judge).toBe("Judge A");
-    expect(result?.items.map((item) => item.id)).toEqual(["r1", "r2"]);
+    const result = await getBeagleTrialDetailsDb({
+      trialEventId: "event-1",
+    });
+
+    expect(result?.trialEventId).toBe("event-1");
+    expect(result?.dogCount).toBe(1);
+    expect(result?.items.map((item) => item.id)).toEqual(["r1"]);
   });
 });
 
@@ -511,6 +422,7 @@ describe("getBeagleTrialsForDogDb", () => {
         tja: { toNumber: () => 0.3 },
         pin: { toNumber: () => 5.6 },
         trialEvent: {
+          id: "event-2",
           koekunta: "Lahti",
           koepaiva: new Date("2025-06-02T00:00:00.000Z"),
           ylituomariNimi: "Chief Judge",
@@ -533,6 +445,7 @@ describe("getBeagleTrialsForDogDb", () => {
         tja: null,
         pin: null,
         trialEvent: {
+          id: "event-1",
           koekunta: "Helsinki",
           koepaiva: new Date("2025-06-01T00:00:00.000Z"),
           ylituomariNimi: null,
@@ -562,6 +475,7 @@ describe("getBeagleTrialsForDogDb", () => {
         pin: true,
         trialEvent: {
           select: {
+            id: true,
             koekunta: true,
             koepaiva: true,
             ylituomariNimi: true,
@@ -578,6 +492,7 @@ describe("getBeagleTrialsForDogDb", () => {
     expect(result).toEqual([
       {
         id: "t2",
+        trialEventId: "event-2",
         place: "Lahti",
         date: new Date("2025-06-02T00:00:00.000Z"),
         weather: "L",
@@ -596,6 +511,7 @@ describe("getBeagleTrialsForDogDb", () => {
       },
       {
         id: "t1",
+        trialEventId: "event-1",
         place: "Helsinki",
         date: new Date("2025-06-01T00:00:00.000Z"),
         weather: null,
@@ -634,6 +550,7 @@ describe("getBeagleTrialsForDogDb", () => {
         tja: null,
         pin: null,
         trialEvent: {
+          id: "event-1",
           koekunta: "Helsinki",
           koepaiva: new Date("2025-06-01T00:00:00.000Z"),
           ylituomariNimi: "Chief",
@@ -656,6 +573,7 @@ describe("getBeagleTrialsForDogDb", () => {
         tja: null,
         pin: null,
         trialEvent: {
+          id: "event-2",
           koekunta: "Turku",
           koepaiva: new Date("2025-06-02T00:00:00.000Z"),
           ylituomariNimi: "Chief",
@@ -665,7 +583,7 @@ describe("getBeagleTrialsForDogDb", () => {
 
     const result = await getBeagleTrialsForDogDb("dog-1");
 
-    expect(result[0]?.judge).toBe("Chief"); // no entry judge -> event fallback
-    expect(result[1]?.judge).toBe("Entry Chief"); // snapshot takes precedence
+    expect(result[0]?.judge).toBe("Chief");
+    expect(result[1]?.judge).toBe("Entry Chief");
   });
 });

--- a/packages/db/trials/get-beagle-trial-details.ts
+++ b/packages/db/trials/get-beagle-trial-details.ts
@@ -1,6 +1,6 @@
-// Reads public beagle trial detail from canonical TrialEvent+TrialEntry tables.
-// Multiple TrialEvent rows can share the same (koepaiva, koekunta) — all matching
-// events are folded into one public response to preserve the date/place URL scheme.
+// Reads a public beagle trial detail from a single canonical TrialEvent row.
+// Entries are loaded only through TrialEntry.trialEventId so the response maps
+// exactly to one event, even when other events share the same date/place.
 import { DogSex, type Prisma } from "@prisma/client";
 import { prisma } from "../core/prisma";
 import type {
@@ -62,15 +62,10 @@ function compareDetailRows(
 export async function getBeagleTrialDetailsDb(
   input: BeagleTrialDetailsRequestDb,
 ): Promise<BeagleTrialDetailsResponseDb | null> {
-  const trialEvents = await prisma.trialEvent.findMany({
-    where: {
-      koepaiva: {
-        gte: input.eventDateStart,
-        lt: input.eventDateEndExclusive,
-      },
-      koekunta: input.eventPlace,
-    },
+  const trialEvent = await prisma.trialEvent.findUnique({
+    where: { id: input.trialEventId },
     select: {
+      id: true,
       koepaiva: true,
       koekunta: true,
       ylituomariNimi: true,
@@ -105,29 +100,15 @@ export async function getBeagleTrialDetailsDb(
     },
   });
 
-  if (trialEvents.length === 0) return null;
+  if (!trialEvent) return null;
+  if (trialEvent.entries.length === 0) return null;
 
-  // Fold entries from all matched events into a flat list so the public
-  // date/place URL resolves consistently even when more than one TrialEvent
-  // exists for the same koepaiva+koekunta.
-  const allEntries = trialEvents.flatMap((event) =>
-    event.entries.map((entry) => ({
-      ...entry,
-      eventYlituomariNimi: event.ylituomariNimi,
-      trialRuleWindowId: event.trialRuleWindowId,
-    })),
-  );
+  const eventJudge = resolveJudge([trialEvent.ylituomariNimi]);
 
-  if (allEntries.length === 0) return null;
-
-  // Event-level judge: use the shared chief judge only when every non-empty
-  // ylituomariNimi value across matched events agrees.
-  const eventJudge = resolveJudge(trialEvents.map((e) => e.ylituomariNimi));
-
-  const items: BeagleTrialDetailsRowDb[] = allEntries
+  const items: BeagleTrialDetailsRowDb[] = trialEvent.entries
     .map((entry) => ({
       id: entry.id,
-      trialRuleWindowId: entry.trialRuleWindowId,
+      trialRuleWindowId: trialEvent.trialRuleWindowId,
       dogId: entry.dogId,
       registrationNo: entry.rekisterinumeroSnapshot,
       // Prefer the linked dog name; fall back to registration snapshot so
@@ -156,8 +137,9 @@ export async function getBeagleTrialDetailsDb(
     .sort(compareDetailRows);
 
   return {
-    eventDate: trialEvents[0]!.koepaiva,
-    eventPlace: trialEvents[0]!.koekunta,
+    trialEventId: trialEvent.id,
+    eventDate: trialEvent.koepaiva,
+    eventPlace: trialEvent.koekunta,
     judge: eventJudge,
     dogCount: items.length,
     items,

--- a/packages/db/trials/get-beagle-trials-for-dog.ts
+++ b/packages/db/trials/get-beagle-trials-for-dog.ts
@@ -28,6 +28,7 @@ export async function getBeagleTrialsForDogDb(
       pin: true,
       trialEvent: {
         select: {
+          id: true,
           koekunta: true,
           koepaiva: true,
           ylituomariNimi: true,
@@ -43,6 +44,7 @@ export async function getBeagleTrialsForDogDb(
 
   return rows.map((row) => ({
     id: row.id,
+    trialEventId: row.trialEvent.id,
     place: row.trialEvent.koekunta,
     date: row.trialEvent.koepaiva,
     weather: row.ke,

--- a/packages/db/trials/search-beagle-trials.ts
+++ b/packages/db/trials/search-beagle-trials.ts
@@ -1,7 +1,3 @@
-// Reads the public beagle trial list from canonical TrialEvent rows.
-// Events are grouped in memory by (koepaiva, koekunta) to produce one public
-// row per date/place — mirrors legacy TrialResult groupBy behavior and
-// preserves the existing public URL scheme.
 import { prisma } from "../core/prisma";
 import type {
   BeagleTrialSearchRequestDb,
@@ -48,36 +44,6 @@ function normalizeSort(
   return value === "date-asc" ? "date-asc" : "date-desc";
 }
 
-// Serialises a Date to a Helsinki business-date string (YYYY-MM-DD).
-// Mirrors toBusinessDateOnly in packages/server/core/date-only.ts so that the
-// grouping key here is always consistent with the public trialId encoding done
-// in the service layer. packages/db cannot import from packages/server (circular
-// dependency), so the logic is kept in sync manually.
-const HELSINKI_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  timeZone: "Europe/Helsinki",
-  year: "numeric",
-  month: "2-digit",
-  day: "2-digit",
-});
-
-function toHelsinkiDateKey(date: Date): string {
-  const parts = HELSINKI_DATE_FORMATTER.formatToParts(date);
-  const year = parts.find((p) => p.type === "year")?.value ?? "";
-  const month = parts.find((p) => p.type === "month")?.value ?? "";
-  const day = parts.find((p) => p.type === "day")?.value ?? "";
-  return `${year}-${month}-${day}`;
-}
-
-// Returns the shared judge name when all non-empty values agree, otherwise null.
-function resolveJudge(names: (string | null | undefined)[]): string | null {
-  const nonEmpty = names
-    .map((n) => n?.trim())
-    .filter((n): n is string => Boolean(n));
-  if (nonEmpty.length === 0) return null;
-  const unique = new Set(nonEmpty);
-  return unique.size === 1 ? [...unique][0]! : null;
-}
-
 function compareRows(
   left: BeagleTrialSearchRowDb,
   right: BeagleTrialSearchRowDb,
@@ -88,7 +54,15 @@ function compareRows(
       ? left.eventDate.getTime() - right.eventDate.getTime()
       : right.eventDate.getTime() - left.eventDate.getTime();
   if (dateComparison !== 0) return dateComparison;
-  return left.eventPlace.localeCompare(right.eventPlace, "fi", {
+  const placeComparison = left.eventPlace.localeCompare(
+    right.eventPlace,
+    "fi",
+    {
+      sensitivity: "base",
+    },
+  );
+  if (placeComparison !== 0) return placeComparison;
+  return left.trialEventId.localeCompare(right.trialEventId, "fi", {
     sensitivity: "base",
   });
 }
@@ -121,6 +95,7 @@ export async function searchBeagleTrialsDb(
     prisma.trialEvent.findMany({
       where: { ...dateWhere, entries: { some: {} } },
       select: {
+        id: true,
         koepaiva: true,
         koekunta: true,
         ylituomariNimi: true,
@@ -130,44 +105,13 @@ export async function searchBeagleTrialsDb(
   ]);
 
   const availableEventDates = availableDateRows.map((row) => row.koepaiva);
-
-  // Group canonical events by (koepaiva, koekunta) into one public row each.
-  // Sums entry counts and resolves a shared judge when all non-empty
-  // ylituomariNimi values agree across matched TrialEvent rows.
-  type GroupAccum = {
-    eventDate: Date;
-    eventPlace: string;
-    dogCount: number;
-    judgeNames: (string | null | undefined)[];
-  };
-
-  const groupMap = new Map<string, GroupAccum>();
-  for (const row of eventRows) {
-    // Use the Helsinki business date so events that share the same Finnish
-    // calendar day but differ in UTC time (e.g. koepaiva stored at local
-    // midnight vs. UTC midnight) still produce one public row — matching the
-    // behaviour of the detail endpoint which uses a full-day UTC range.
-    const key = `${toHelsinkiDateKey(row.koepaiva)}::${row.koekunta}`;
-    const existing = groupMap.get(key);
-    if (existing) {
-      existing.dogCount += row._count.entries;
-      existing.judgeNames.push(row.ylituomariNimi);
-    } else {
-      groupMap.set(key, {
-        eventDate: row.koepaiva,
-        eventPlace: row.koekunta,
-        dogCount: row._count.entries,
-        judgeNames: [row.ylituomariNimi],
-      });
-    }
-  }
-
-  const rows: BeagleTrialSearchRowDb[] = Array.from(groupMap.values())
-    .map((group) => ({
-      eventDate: group.eventDate,
-      eventPlace: group.eventPlace,
-      judge: resolveJudge(group.judgeNames),
-      dogCount: group.dogCount,
+  const rows: BeagleTrialSearchRowDb[] = eventRows
+    .map((row) => ({
+      trialEventId: row.id,
+      eventDate: row.koepaiva,
+      eventPlace: row.koekunta,
+      judge: row.ylituomariNimi?.trim() || null,
+      dogCount: row._count.entries,
     }))
     .sort((left, right) => compareRows(left, right, sort));
 

--- a/packages/db/trials/types.ts
+++ b/packages/db/trials/types.ts
@@ -9,6 +9,7 @@ export type BeagleTrialSearchRequestDb = {
 };
 
 export type BeagleTrialSearchRowDb = {
+  trialEventId: string;
   eventDate: Date;
   eventPlace: string;
   judge: string | null;
@@ -24,9 +25,7 @@ export type BeagleTrialSearchResponseDb = {
 };
 
 export type BeagleTrialDetailsRequestDb = {
-  eventDateStart: Date;
-  eventDateEndExclusive: Date;
-  eventPlace: string;
+  trialEventId: string;
 };
 
 export type BeagleTrialDetailsRowDb = {
@@ -52,6 +51,7 @@ export type BeagleTrialDetailsRowDb = {
 };
 
 export type BeagleTrialDetailsResponseDb = {
+  trialEventId: string;
   eventDate: Date;
   eventPlace: string;
   judge: string | null;
@@ -61,6 +61,7 @@ export type BeagleTrialDetailsResponseDb = {
 
 export type BeagleTrialDogRowDb = {
   id: string;
+  trialEventId: string;
   place: string;
   date: Date;
   weather: string | null;

--- a/packages/server/dogs/__tests__/service.test.ts
+++ b/packages/server/dogs/__tests__/service.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDogsService } from "@server/dogs";
 import { encodeShowId } from "@server/shows/internal/show-id";
-import { encodeTrialId } from "@server/trials/internal/trial-id";
 
 const {
   searchBeagleDogsDbMock,
@@ -355,6 +354,7 @@ describe("dogs service", () => {
     const mockTrials = [
       {
         id: "trial1",
+        trialEventId: "trial-1",
         place: "Town",
         date: new Date("2022-02-02T00:00:00.000Z"),
         weather: "P",
@@ -418,7 +418,7 @@ describe("dogs service", () => {
           trials: [
             {
               id: "trial1",
-              trialId: encodeTrialId("2022-02-02", "Town"),
+              trialId: "trial-1",
               place: "Town",
               date: "2022-02-02",
               weather: "P",
@@ -481,6 +481,7 @@ describe("dogs service", () => {
     const mockTrials = [
       {
         id: "trial2",
+        trialEventId: "trial-2",
         place: "Lahti",
         date: new Date("2022-04-16T00:00:00+03:00"),
         weather: null,
@@ -523,7 +524,7 @@ describe("dogs service", () => {
           trials: [
             {
               id: "trial2",
-              trialId: encodeTrialId("2022-04-16", "Lahti"),
+              trialId: "trial-2",
               place: "Lahti",
               date: "2022-04-16",
               weather: null,

--- a/packages/server/dogs/profile/get-beagle-dog-profile.ts
+++ b/packages/server/dogs/profile/get-beagle-dog-profile.ts
@@ -15,7 +15,6 @@ import type { ServiceResult } from "@server/core/result";
 import { parseDogId } from "@server/dogs/core";
 import { encodeShowId } from "@server/shows/internal/show-id";
 import { formatTrialAward } from "@server/trials/core";
-import { encodeTrialId } from "@server/trials/internal/trial-id";
 
 export type DogsServiceLogContext = {
   requestId?: string;
@@ -76,7 +75,7 @@ function mapDogProfileFromDb(
     }),
     trials: trials.map((trial) => ({
       id: trial.id,
-      trialId: encodeTrialId(toBusinessDateOnly(trial.date), trial.place),
+      trialId: trial.trialEventId,
       place: trial.place,
       date: toBusinessDateOnly(trial.date),
       weather: trial.weather,

--- a/packages/server/trials/__tests__/service.test.ts
+++ b/packages/server/trials/__tests__/service.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTrialsService } from "../service";
 import { getTrialBusinessDateStartUtc } from "../core/business-date";
-import { encodeTrialId, parseTrialId } from "../internal/trial-id";
 
 const { searchBeagleTrialsDbMock, getBeagleTrialDetailsDbMock } = vi.hoisted(
   () => ({
@@ -47,9 +46,9 @@ describe("trials service", () => {
     });
   });
 
-  it("returns 400 for invalid trialId in details", async () => {
+  it("returns 400 for blank trialId in details", async () => {
     const service = createTrialsService();
-    const result = await service.getBeagleTrialDetails("invalid");
+    const result = await service.getBeagleTrialDetails("   ");
 
     expect(result).toEqual({
       status: 400,
@@ -57,7 +56,7 @@ describe("trials service", () => {
     });
   });
 
-  it("uses latest year by default and maps encoded trialId", async () => {
+  it("uses latest year by default and maps canonical trialId", async () => {
     searchBeagleTrialsDbMock
       .mockResolvedValueOnce({
         availableEventDates: [new Date("2025-06-01T00:00:00.000Z")],
@@ -76,6 +75,7 @@ describe("trials service", () => {
         page: 1,
         items: [
           {
+            trialEventId: "event-1",
             eventDate: new Date("2025-06-01T00:00:00.000Z"),
             eventPlace: "Helsinki",
             judge: "Judge Main",
@@ -90,11 +90,7 @@ describe("trials service", () => {
     expect(result.status).toBe(200);
     if (!result.body.ok) throw new Error("Expected ok=true");
 
-    expect(parseTrialId(result.body.data.items[0].trialId)).toEqual({
-      eventDateIsoDate: "2025-06-01",
-      eventDate: new Date("2025-06-01T00:00:00.000Z"),
-      eventPlace: "Helsinki",
-    });
+    expect(result.body.data.items[0].trialId).toBe("event-1");
     expect(searchBeagleTrialsDbMock).toHaveBeenNthCalledWith(1, {
       page: 1,
       pageSize: 1,
@@ -146,8 +142,7 @@ describe("trials service", () => {
   it("returns 404 when trial details are missing", async () => {
     getBeagleTrialDetailsDbMock.mockResolvedValue(null);
     const service = createTrialsService();
-    const trialId = encodeTrialId("2025-06-01", "Helsinki");
-    const result = await service.getBeagleTrialDetails(trialId);
+    const result = await service.getBeagleTrialDetails("event-404");
 
     expect(result).toEqual({
       status: 404,
@@ -157,6 +152,7 @@ describe("trials service", () => {
 
   it("maps details and formats award", async () => {
     getBeagleTrialDetailsDbMock.mockResolvedValue({
+      trialEventId: "event-1",
       eventDate: new Date("2025-06-01T00:00:00.000Z"),
       eventPlace: "Helsinki",
       judge: "Judge Main",
@@ -187,8 +183,7 @@ describe("trials service", () => {
     });
 
     const service = createTrialsService();
-    const trialId = encodeTrialId("2025-06-01", "Helsinki");
-    const result = await service.getBeagleTrialDetails(trialId);
+    const result = await service.getBeagleTrialDetails("event-1");
 
     expect(result.status).toBe(200);
     if (!result.body.ok) throw new Error("Expected ok=true");
@@ -197,11 +192,9 @@ describe("trials service", () => {
     expect(result.body.data.items[0]?.trialRuleWindowId).toBe(
       "trw_post_20230801",
     );
-    expect(result.body.data.trial.trialId).toBe(trialId);
+    expect(result.body.data.trial.trialId).toBe("event-1");
     expect(getBeagleTrialDetailsDbMock).toHaveBeenCalledWith({
-      eventDateStart: getTrialBusinessDateStartUtc("2025-06-01"),
-      eventDateEndExclusive: getTrialBusinessDateStartUtc("2025-06-02"),
-      eventPlace: "Helsinki",
+      trialEventId: "event-1",
     });
   });
 

--- a/packages/server/trials/get-beagle-trial-details.ts
+++ b/packages/server/trials/get-beagle-trial-details.ts
@@ -4,8 +4,6 @@ import { toBusinessDateOnly } from "../core/date-only";
 import { toErrorLog, withLogContext } from "../core/logger";
 import type { ServiceResult } from "../core/result";
 import { formatTrialAward } from "./core";
-import { getTrialBusinessDateUtcRange } from "./core/business-date";
-import { encodeTrialId, parseTrialId } from "./internal/trial-id";
 import type { TrialsServiceLogContext } from "./types";
 
 export async function getBeagleTrialDetailsService(
@@ -20,8 +18,8 @@ export async function getBeagleTrialDetailsService(
     ...(context?.actorUserId ? { actorUserId: context.actorUserId } : {}),
   });
 
-  const parsedTrialId = parseTrialId(trialId);
-  if (!parsedTrialId) {
+  const normalizedTrialId = trialId.trim();
+  if (!normalizedTrialId) {
     log.warn(
       { event: "invalid_trial_id", durationMs: Date.now() - startedAt },
       "trial detail rejected because trialId is invalid",
@@ -35,27 +33,20 @@ export async function getBeagleTrialDetailsService(
   log.info(
     {
       event: "start",
-      eventDate: parsedTrialId.eventDateIsoDate,
-      eventPlace: parsedTrialId.eventPlace,
+      trialId: normalizedTrialId,
     },
     "trial detail fetch started",
   );
 
   try {
-    const eventDateRange = getTrialBusinessDateUtcRange(
-      parsedTrialId.eventDate,
-    );
     const result = await getBeagleTrialDetailsDb({
-      eventDateStart: eventDateRange.start,
-      eventDateEndExclusive: eventDateRange.endExclusive,
-      eventPlace: parsedTrialId.eventPlace,
+      trialEventId: normalizedTrialId,
     });
     if (!result) {
       log.info(
         {
           event: "not_found",
-          eventDate: parsedTrialId.eventDateIsoDate,
-          eventPlace: parsedTrialId.eventPlace,
+          trialId: normalizedTrialId,
           durationMs: Date.now() - startedAt,
         },
         "trial detail not found",
@@ -66,11 +57,10 @@ export async function getBeagleTrialDetailsService(
       };
     }
 
-    const eventDate = toBusinessDateOnly(result.eventDate);
     const data: BeagleTrialDetailsResponse = {
       trial: {
-        trialId: encodeTrialId(eventDate, result.eventPlace),
-        eventDate,
+        trialId: result.trialEventId,
+        eventDate: toBusinessDateOnly(result.eventDate),
         eventPlace: result.eventPlace,
         judge: result.judge,
         dogCount: result.dogCount,
@@ -101,8 +91,7 @@ export async function getBeagleTrialDetailsService(
     log.info(
       {
         event: "success",
-        eventDate,
-        eventPlace: data.trial.eventPlace,
+        trialId: data.trial.trialId,
         dogCount: data.trial.dogCount,
         durationMs: Date.now() - startedAt,
       },
@@ -117,8 +106,7 @@ export async function getBeagleTrialDetailsService(
     log.error(
       {
         event: "exception",
-        eventDate: parsedTrialId.eventDateIsoDate,
-        eventPlace: parsedTrialId.eventPlace,
+        trialId: normalizedTrialId,
         durationMs: Date.now() - startedAt,
         ...toErrorLog(error),
       },

--- a/packages/server/trials/search-beagle-trials.ts
+++ b/packages/server/trials/search-beagle-trials.ts
@@ -13,7 +13,6 @@ import {
   toTrialBusinessYear,
 } from "./core/business-date";
 import { parseIsoDateOnly } from "./internal/iso-date";
-import { encodeTrialId } from "./internal/trial-id";
 import type { TrialsServiceLogContext } from "./types";
 
 const ALLOWED_SORTS: ReadonlySet<BeagleTrialSearchSortDb> = new Set([
@@ -269,16 +268,13 @@ export async function searchBeagleTrialsService(
       total: result.total,
       totalPages: result.totalPages,
       page: result.page,
-      items: result.items.map((item) => {
-        const eventDate = toBusinessDateOnly(item.eventDate);
-        return {
-          trialId: encodeTrialId(eventDate, item.eventPlace),
-          eventDate,
-          eventPlace: item.eventPlace,
-          judge: item.judge,
-          dogCount: item.dogCount,
-        };
-      }),
+      items: result.items.map((item) => ({
+        trialId: item.trialEventId,
+        eventDate: toBusinessDateOnly(item.eventDate),
+        eventPlace: item.eventPlace,
+        judge: item.judge,
+        dogCount: item.dogCount,
+      })),
     };
 
     log.info(


### PR DESCRIPTION
- return one public trial row per `TrialEvent` and load details by `TrialEvent.id`
- update dog profile trial links and tests to use the canonical event id


