### PR TITLE
Feature/bej 101 implement admin delete for canonical trial entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project uses a user-facing changelog format.
 
 - Julkinen ajokoelistaus ja kokeen detaljisivu lukevat nyt kanonista AJOK-skeemaa (`TrialEvent` + `TrialEntry`) vanhan `TrialResult`-taulun sijaan. Koirat ilman `dogId`-linkkiä näkyvät edelleen snapshot-rekisterinumerollaan; nimi näytetään vain tietokantaan linkitetyille koirille.
 - Tukemattomat AJOK PDF -sääntöikkunat palauttavat nyt virheen tyhjän PDF:n sijaan. Aiempi `blank-only`-tila on nimetty `not-supported`-tilaksi selkeyden vuoksi.
+- Ylläpidon AJOK-tapahtumanäkymässä yksittäisen koirarivin voi nyt poistaa. Jos poistettu rivi oli tapahtuman viimeinen, tyhjä tapahtuma poistetaan automaattisesti.
 
 ### Fixed
 

--- a/apps/web/app/actions/admin/trials/index.ts
+++ b/apps/web/app/actions/admin/trials/index.ts
@@ -1,0 +1,1 @@
+export { deleteAdminTrialEntryAction } from "./manage";

--- a/apps/web/app/actions/admin/trials/manage/__tests__/delete-admin-trial-entry.test.ts
+++ b/apps/web/app/actions/admin/trials/manage/__tests__/delete-admin-trial-entry.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { deleteAdminTrialEntryAction } from "../delete-admin-trial-entry";
+
+const {
+  requireAdminLayoutAccessMock,
+  getSessionCurrentUserMock,
+  deleteAdminTrialEntryMock,
+} = vi.hoisted(() => ({
+  requireAdminLayoutAccessMock: vi.fn(),
+  getSessionCurrentUserMock: vi.fn(),
+  deleteAdminTrialEntryMock: vi.fn(),
+}));
+
+vi.mock("@/lib/server/admin-guard", () => ({
+  requireAdminLayoutAccess: requireAdminLayoutAccessMock,
+}));
+
+vi.mock("@/lib/server/current-user", () => ({
+  getSessionCurrentUser: getSessionCurrentUserMock,
+}));
+
+vi.mock("@beagle/server", () => ({
+  deleteAdminTrialEntry: deleteAdminTrialEntryMock,
+}));
+
+describe("deleteAdminTrialEntryAction", () => {
+  beforeEach(() => {
+    requireAdminLayoutAccessMock.mockReset();
+    getSessionCurrentUserMock.mockReset();
+    deleteAdminTrialEntryMock.mockReset();
+  });
+
+  it("returns forbidden when user is not admin", async () => {
+    requireAdminLayoutAccessMock.mockResolvedValue({ ok: false, status: 403 });
+
+    await expect(
+      deleteAdminTrialEntryAction({
+        trialEventId: "event-1",
+        trialEntryId: "entry-1",
+      }),
+    ).resolves.toEqual({
+      data: null,
+      hasError: true,
+      errorCode: "FORBIDDEN",
+      message: "Admin access required.",
+    });
+
+    expect(deleteAdminTrialEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns unauthenticated when current user is missing", async () => {
+    requireAdminLayoutAccessMock.mockResolvedValue({ ok: true });
+    getSessionCurrentUserMock.mockResolvedValue(null);
+
+    await expect(
+      deleteAdminTrialEntryAction({
+        trialEventId: "event-1",
+        trialEntryId: "entry-1",
+      }),
+    ).resolves.toEqual({
+      data: null,
+      hasError: true,
+      errorCode: "UNAUTHENTICATED",
+      message: "Admin access required.",
+    });
+
+    expect(deleteAdminTrialEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns mapped service error", async () => {
+    requireAdminLayoutAccessMock.mockResolvedValue({ ok: true });
+    getSessionCurrentUserMock.mockResolvedValue({
+      id: "u_1",
+      email: "admin@example.com",
+      name: "Admin",
+      role: "ADMIN",
+      createdAt: "2026-04-01T10:00:00.000Z",
+    });
+    deleteAdminTrialEntryMock.mockResolvedValue({
+      status: 404,
+      body: {
+        ok: false,
+        code: "ENTRY_NOT_FOUND",
+        error: "Entry not found in selected trial event.",
+      },
+    });
+
+    await expect(
+      deleteAdminTrialEntryAction({
+        trialEventId: "event-1",
+        trialEntryId: "entry-1",
+      }),
+    ).resolves.toEqual({
+      data: null,
+      hasError: true,
+      errorCode: "ENTRY_NOT_FOUND",
+      message: "Entry not found in selected trial event.",
+    });
+  });
+
+  it("returns data on success", async () => {
+    requireAdminLayoutAccessMock.mockResolvedValue({ ok: true });
+    getSessionCurrentUserMock.mockResolvedValue({
+      id: "u_1",
+      email: "admin@example.com",
+      name: "Admin",
+      role: "ADMIN",
+      createdAt: "2026-04-01T10:00:00.000Z",
+    });
+    deleteAdminTrialEntryMock.mockResolvedValue({
+      status: 200,
+      body: {
+        ok: true,
+        data: {
+          deletedTrialEntryId: "entry-1",
+          trialEventId: "event-1",
+          deletedTrialEvent: true,
+        },
+      },
+    });
+
+    await expect(
+      deleteAdminTrialEntryAction({
+        trialEventId: "event-1",
+        trialEntryId: "entry-1",
+      }),
+    ).resolves.toEqual({
+      data: {
+        deletedTrialEntryId: "entry-1",
+        trialEventId: "event-1",
+        deletedTrialEvent: true,
+      },
+      hasError: false,
+    });
+  });
+});

--- a/apps/web/app/actions/admin/trials/manage/delete-admin-trial-entry.ts
+++ b/apps/web/app/actions/admin/trials/manage/delete-admin-trial-entry.ts
@@ -1,0 +1,67 @@
+"use server";
+
+import type {
+  DeleteAdminTrialEntryRequest,
+  DeleteAdminTrialEntryResponse,
+} from "@beagle/contracts";
+import { deleteAdminTrialEntry } from "@beagle/server";
+import { requireAdminLayoutAccess } from "@/lib/server/admin-guard";
+import { getSessionCurrentUser } from "@/lib/server/current-user";
+
+export type DeleteAdminTrialEntryActionResult = {
+  data: DeleteAdminTrialEntryResponse | null;
+  hasError: boolean;
+  errorCode?: string;
+  message?: string;
+};
+
+export async function deleteAdminTrialEntryAction(
+  input: DeleteAdminTrialEntryRequest,
+): Promise<DeleteAdminTrialEntryActionResult> {
+  const adminAccess = await requireAdminLayoutAccess();
+  if (!adminAccess.ok) {
+    return {
+      data: null,
+      hasError: true,
+      errorCode: adminAccess.status === 401 ? "UNAUTHENTICATED" : "FORBIDDEN",
+      message: "Admin access required.",
+    };
+  }
+
+  const currentUser = await getSessionCurrentUser();
+  if (!currentUser) {
+    return {
+      data: null,
+      hasError: true,
+      errorCode: "UNAUTHENTICATED",
+      message: "Admin access required.",
+    };
+  }
+
+  const result = await deleteAdminTrialEntry(
+    input,
+    {
+      id: currentUser.id,
+      email: currentUser.email,
+      username: null,
+      role: currentUser.role,
+    },
+    {
+      actorUserId: currentUser.id,
+    },
+  );
+
+  if (!result.body.ok) {
+    return {
+      data: null,
+      hasError: true,
+      errorCode: result.body.code,
+      message: result.body.error,
+    };
+  }
+
+  return {
+    data: result.body.data,
+    hasError: false,
+  };
+}

--- a/apps/web/app/actions/admin/trials/manage/index.ts
+++ b/apps/web/app/actions/admin/trials/manage/index.ts
@@ -1,0 +1,1 @@
+export { deleteAdminTrialEntryAction } from "./delete-admin-trial-entry";

--- a/apps/web/components/admin/trials/__tests__/admin-trial-entry-actions.test.tsx
+++ b/apps/web/components/admin/trials/__tests__/admin-trial-entry-actions.test.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AdminTrialEntryActions } from "../admin-trial-entry-actions";
 
-const { useDeleteAdminTrialEntryMutationMock } = vi.hoisted(() => ({
-  useDeleteAdminTrialEntryMutationMock: vi.fn(),
-}));
+const { useDeleteAdminTrialEntryMutationMock, rowActionsMock } = vi.hoisted(
+  () => ({
+    useDeleteAdminTrialEntryMutationMock: vi.fn(),
+    rowActionsMock: { current: [] as Array<{ onSelect: () => void }> },
+  }),
+);
 
 vi.mock("@/hooks/i18n", () => ({
   useI18n: () => ({
@@ -29,8 +32,16 @@ vi.mock("@/components/ui/button", () => ({
 }));
 
 vi.mock("@/components/admin", () => ({
-  AdminRowActionsMenu: ({ triggerAriaLabel }: { triggerAriaLabel: string }) =>
-    React.createElement("div", null, `menu-${triggerAriaLabel}`),
+  AdminRowActionsMenu: ({
+    triggerAriaLabel,
+    actions,
+  }: {
+    triggerAriaLabel: string;
+    actions: Array<{ onSelect: () => void }>;
+  }) => {
+    rowActionsMock.current = actions;
+    return React.createElement("div", null, `menu-${triggerAriaLabel}`);
+  },
 }));
 
 vi.mock("next/link", () => ({
@@ -50,6 +61,11 @@ vi.mock("@/queries/admin/trials", () => ({
 }));
 
 describe("AdminTrialEntryActions", () => {
+  beforeEach(() => {
+    useDeleteAdminTrialEntryMutationMock.mockReset();
+    rowActionsMock.current = [];
+  });
+
   it("renders icon pdf action and overflow menu", () => {
     useDeleteAdminTrialEntryMutationMock.mockReturnValue({
       mutateAsync: vi.fn(),
@@ -73,5 +89,73 @@ describe("AdminTrialEntryActions", () => {
     expect(html).toContain("admin.trials.manage.selected.actions.openPdf");
     expect(html).toContain("menu-admin.trials.manage.selected.actions.more");
     expect(html).toContain('href="/api/trials/trial-1/pdf"');
+  });
+
+  it("calls delete mutation with correct ids", async () => {
+    vi.stubGlobal("window", { confirm: () => true, alert: vi.fn() });
+    const mutateAsync = vi.fn().mockResolvedValue({
+      deletedTrialEntryId: "entry-1",
+      trialEventId: "event-1",
+      deletedTrialEvent: false,
+    });
+    useDeleteAdminTrialEntryMutationMock.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    });
+
+    renderToStaticMarkup(
+      React.createElement(AdminTrialEntryActions, {
+        trialEventId: "event-1",
+        trialEntryId: "entry-1",
+        trialId: "trial-1",
+        dogName: "Rex",
+        registrationNo: "FI123",
+        eventDate: "2026-04-14",
+        eventPlace: "Helsinki",
+        eventName: "Kevatkoe",
+        onDeletedTrialEvent: vi.fn(),
+      }),
+    );
+
+    await rowActionsMock.current[0]?.onSelect();
+
+    expect(mutateAsync).toHaveBeenCalledWith({
+      trialEventId: "event-1",
+      trialEntryId: "entry-1",
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("calls onDeletedTrialEvent when deletion removes whole event", async () => {
+    vi.stubGlobal("window", { confirm: () => true, alert: vi.fn() });
+    const onDeletedTrialEvent = vi.fn();
+    const mutateAsync = vi.fn().mockResolvedValue({
+      deletedTrialEntryId: "entry-1",
+      trialEventId: "event-1",
+      deletedTrialEvent: true,
+    });
+    useDeleteAdminTrialEntryMutationMock.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    });
+
+    renderToStaticMarkup(
+      React.createElement(AdminTrialEntryActions, {
+        trialEventId: "event-1",
+        trialEntryId: "entry-1",
+        trialId: "trial-1",
+        dogName: "Rex",
+        registrationNo: "FI123",
+        eventDate: "2026-04-14",
+        eventPlace: "Helsinki",
+        eventName: "Kevatkoe",
+        onDeletedTrialEvent,
+      }),
+    );
+
+    await rowActionsMock.current[0]?.onSelect();
+
+    expect(onDeletedTrialEvent).toHaveBeenCalledWith("event-1");
+    vi.unstubAllGlobals();
   });
 });

--- a/apps/web/components/admin/trials/__tests__/admin-trial-entry-actions.test.tsx
+++ b/apps/web/components/admin/trials/__tests__/admin-trial-entry-actions.test.tsx
@@ -63,6 +63,9 @@ describe("AdminTrialEntryActions", () => {
         trialId: "trial-1",
         dogName: "Rex",
         registrationNo: "FI123",
+        eventDate: "2026-04-14",
+        eventPlace: "Helsinki",
+        eventName: "Kevatkoe",
         onDeletedTrialEvent: vi.fn(),
       }),
     );

--- a/apps/web/components/admin/trials/__tests__/admin-trial-entry-actions.test.tsx
+++ b/apps/web/components/admin/trials/__tests__/admin-trial-entry-actions.test.tsx
@@ -3,6 +3,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import { AdminTrialEntryActions } from "../admin-trial-entry-actions";
 
+const { useDeleteAdminTrialEntryMutationMock } = vi.hoisted(() => ({
+  useDeleteAdminTrialEntryMutationMock: vi.fn(),
+}));
+
 vi.mock("@/hooks/i18n", () => ({
   useI18n: () => ({
     t: (key: string) => key,
@@ -36,15 +40,30 @@ vi.mock("next/link", () => ({
   }) => React.createElement("a", { href, ...props }, children),
 }));
 
+vi.mock("@/queries/admin/trials", () => ({
+  useDeleteAdminTrialEntryMutation: useDeleteAdminTrialEntryMutationMock,
+}));
+
 describe("AdminTrialEntryActions", () => {
-  it("renders the pdf action", () => {
+  it("renders the pdf and delete actions", () => {
+    useDeleteAdminTrialEntryMutationMock.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+
     const html = renderToStaticMarkup(
       React.createElement(AdminTrialEntryActions, {
+        trialEventId: "event-1",
+        trialEntryId: "entry-1",
         trialId: "trial-1",
+        dogName: "Rex",
+        registrationNo: "FI123",
+        onDeletedTrialEvent: vi.fn(),
       }),
     );
 
     expect(html).toContain("admin.trials.manage.selected.actions.openPdf");
+    expect(html).toContain("admin.trials.manage.selected.actions.delete");
     expect(html).toContain('href="/api/trials/trial-1/pdf"');
   });
 });

--- a/apps/web/components/admin/trials/__tests__/admin-trial-entry-actions.test.tsx
+++ b/apps/web/components/admin/trials/__tests__/admin-trial-entry-actions.test.tsx
@@ -28,6 +28,11 @@ vi.mock("@/components/ui/button", () => ({
       : React.createElement("button", props, children),
 }));
 
+vi.mock("@/components/admin", () => ({
+  AdminRowActionsMenu: ({ triggerAriaLabel }: { triggerAriaLabel: string }) =>
+    React.createElement("div", null, `menu-${triggerAriaLabel}`),
+}));
+
 vi.mock("next/link", () => ({
   default: ({
     href,
@@ -45,7 +50,7 @@ vi.mock("@/queries/admin/trials", () => ({
 }));
 
 describe("AdminTrialEntryActions", () => {
-  it("renders the pdf and delete actions", () => {
+  it("renders icon pdf action and overflow menu", () => {
     useDeleteAdminTrialEntryMutationMock.mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
@@ -63,7 +68,7 @@ describe("AdminTrialEntryActions", () => {
     );
 
     expect(html).toContain("admin.trials.manage.selected.actions.openPdf");
-    expect(html).toContain("admin.trials.manage.selected.actions.delete");
+    expect(html).toContain("menu-admin.trials.manage.selected.actions.more");
     expect(html).toContain('href="/api/trials/trial-1/pdf"');
   });
 });

--- a/apps/web/components/admin/trials/__tests__/admin-trial-selected-event-panel.test.tsx
+++ b/apps/web/components/admin/trials/__tests__/admin-trial-selected-event-panel.test.tsx
@@ -57,6 +57,11 @@ vi.mock("next/link", () => ({
   }) => React.createElement("a", { href, ...props }, children),
 }));
 
+vi.mock("../admin-trial-entry-actions", () => ({
+  AdminTrialEntryActions: ({ trialId }: { trialId: string }) =>
+    React.createElement("div", null, `actions-${trialId}`),
+}));
+
 describe("AdminTrialSelectedEventPanel", () => {
   it("renders selected event rows and row actions", () => {
     const html = renderToStaticMarkup(
@@ -89,11 +94,12 @@ describe("AdminTrialSelectedEventPanel", () => {
         isLoading: false,
         isError: false,
         errorText: "error",
+        onDeletedTrialEvent: vi.fn(),
       }),
     );
 
     expect(html).toContain("admin.trials.manage.selected.title");
     expect(html).toContain("Rex");
-    expect(html).toContain("admin.trials.manage.selected.actions.openPdf");
+    expect(html).toContain("actions-trial-1");
   });
 });

--- a/apps/web/components/admin/trials/__tests__/admin-trials-page-client.test.tsx
+++ b/apps/web/components/admin/trials/__tests__/admin-trials-page-client.test.tsx
@@ -89,7 +89,7 @@ vi.mock("../admin-trial-selected-event-panel", () => ({
 vi.mock("@/queries/admin/trials", () => ({
   useAdminTrialEventsQuery: () => ({
     data: {
-      total: 1,
+      total: 2,
       totalPages: 1,
       page: 1,
       items: [
@@ -103,26 +103,44 @@ vi.mock("@/queries/admin/trials", () => ({
           sklKoeId: 12345,
           dogCount: 2,
         },
+        {
+          trialEventId: "event-2",
+          eventDate: "2026-04-13",
+          eventPlace: "Espoo",
+          eventName: "Talvikoe",
+          organizer: "Jarjestaja",
+          judge: "Judge",
+          sklKoeId: 22222,
+          dogCount: 1,
+        },
       ],
     },
     isLoading: false,
     isError: false,
     error: null,
   }),
-  useAdminTrialEventQuery: () => ({
-    data: {
-      event: {
-        trialEventId: "event-1",
-        eventDate: "2026-04-14",
-        eventPlace: "Helsinki",
-        eventName: "Kevatkoe",
-        organizer: "Jarjestaja",
-        judge: "Judge",
-        sklKoeId: 12345,
-        dogCount: 2,
-        entries: [],
-      },
-    },
+  useAdminTrialEventQuery: ({
+    trialEventId,
+    enabled,
+  }: {
+    trialEventId: string;
+    enabled: boolean;
+  }) => ({
+    data: enabled
+      ? {
+          event: {
+            trialEventId,
+            eventDate: "2026-04-14",
+            eventPlace: "Helsinki",
+            eventName: "Kevatkoe",
+            organizer: "Jarjestaja",
+            judge: "Judge",
+            sklKoeId: 12345,
+            dogCount: 2,
+            entries: [],
+          },
+        }
+      : null,
     isLoading: false,
     isError: false,
     error: null,
@@ -138,9 +156,21 @@ describe("AdminTrialsPageClient", () => {
     expect(html).toContain("admin.trials.title");
     expect(html).toContain("admin.trials.description");
     expect(html).toContain("year|||");
-    expect(html).toContain("1|1|1|event-1|admin.trials.manage.error");
+    expect(html).toContain("2|1|1|event-1|admin.trials.manage.error");
     expect(html).toContain(
       "event-1|false|false|admin.trials.manage.selected.error|function",
     );
+  });
+
+  it("blocks fallback auto-selection when a deleted event is blocked", () => {
+    const selectedEventIdInput = "";
+    const fallbackSelectedEventId = "event-2";
+    const blockedAutoSelectedEventId = "event-1";
+
+    const selectedEventId =
+      selectedEventIdInput ||
+      (blockedAutoSelectedEventId ? "" : fallbackSelectedEventId);
+
+    expect(selectedEventId).toBe("");
   });
 });

--- a/apps/web/components/admin/trials/__tests__/admin-trials-page-client.test.tsx
+++ b/apps/web/components/admin/trials/__tests__/admin-trials-page-client.test.tsx
@@ -77,7 +77,7 @@ vi.mock("../admin-trial-selected-event-panel", () => ({
     isLoading: boolean;
     isError: boolean;
     errorText: string;
-    onDeletedTrialEvent: () => void;
+    onDeletedTrialEvent: (deletedTrialEventId: string) => void;
   }) =>
     React.createElement(
       "section",

--- a/apps/web/components/admin/trials/__tests__/admin-trials-page-client.test.tsx
+++ b/apps/web/components/admin/trials/__tests__/admin-trials-page-client.test.tsx
@@ -71,16 +71,18 @@ vi.mock("../admin-trial-selected-event-panel", () => ({
     isLoading,
     isError,
     errorText,
+    onDeletedTrialEvent,
   }: {
     selectedEvent: { trialEventId: string } | null;
     isLoading: boolean;
     isError: boolean;
     errorText: string;
+    onDeletedTrialEvent: () => void;
   }) =>
     React.createElement(
       "section",
       { "data-testid": "selected" },
-      `${selectedEvent?.trialEventId ?? ""}|${isLoading}|${isError}|${errorText}`,
+      `${selectedEvent?.trialEventId ?? ""}|${isLoading}|${isError}|${errorText}|${typeof onDeletedTrialEvent}`,
     ),
 }));
 
@@ -138,7 +140,7 @@ describe("AdminTrialsPageClient", () => {
     expect(html).toContain("year|||");
     expect(html).toContain("1|1|1|event-1|admin.trials.manage.error");
     expect(html).toContain(
-      "event-1|false|false|admin.trials.manage.selected.error",
+      "event-1|false|false|admin.trials.manage.selected.error|function",
     );
   });
 });

--- a/apps/web/components/admin/trials/admin-trial-entry-actions.tsx
+++ b/apps/web/components/admin/trials/admin-trial-entry-actions.tsx
@@ -4,15 +4,47 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { useI18n } from "@/hooks/i18n";
 import { getTrialPdfHref } from "@/lib/public/beagle/trials";
+import { useDeleteAdminTrialEntryMutation } from "@/queries/admin/trials";
 
 type AdminTrialEntryActionsProps = {
+  trialEventId: string;
+  trialEntryId: string;
   trialId: string;
+  dogName: string;
+  registrationNo: string | null;
+  onDeletedTrialEvent: () => void;
 };
 
 export function AdminTrialEntryActions({
+  trialEventId,
+  trialEntryId,
   trialId,
+  dogName,
+  registrationNo,
+  onDeletedTrialEvent,
 }: AdminTrialEntryActionsProps) {
   const { t } = useI18n();
+  const deleteMutation = useDeleteAdminTrialEntryMutation();
+
+  async function handleDelete() {
+    const label = dogName.trim() || registrationNo || trialEntryId;
+    const confirmed = window.confirm(
+      `${t("admin.trials.manage.selected.actions.delete.confirmTitle")}\n\n` +
+        `${t("admin.trials.manage.selected.actions.delete.confirmBody")}\n\n` +
+        `${label}`,
+    );
+    if (!confirmed || deleteMutation.isPending) {
+      return;
+    }
+
+    const result = await deleteMutation.mutateAsync({
+      trialEventId,
+      trialEntryId,
+    });
+    if (result.deletedTrialEvent) {
+      onDeletedTrialEvent();
+    }
+  }
 
   return (
     <div className="flex flex-wrap gap-2">
@@ -20,6 +52,16 @@ export function AdminTrialEntryActions({
         <Link href={getTrialPdfHref(trialId)} target="_blank" rel="noreferrer">
           {t("admin.trials.manage.selected.actions.openPdf")}
         </Link>
+      </Button>
+      <Button
+        size="sm"
+        variant="destructive"
+        onClick={() => {
+          void handleDelete();
+        }}
+        disabled={deleteMutation.isPending}
+      >
+        {t("admin.trials.manage.selected.actions.delete")}
       </Button>
     </div>
   );

--- a/apps/web/components/admin/trials/admin-trial-entry-actions.tsx
+++ b/apps/web/components/admin/trials/admin-trial-entry-actions.tsx
@@ -52,12 +52,20 @@ export function AdminTrialEntryActions({
       return;
     }
 
-    const result = await deleteMutation.mutateAsync({
-      trialEventId,
-      trialEntryId,
-    });
-    if (result.deletedTrialEvent) {
-      onDeletedTrialEvent(result.trialEventId);
+    try {
+      const result = await deleteMutation.mutateAsync({
+        trialEventId,
+        trialEntryId,
+      });
+      if (result.deletedTrialEvent) {
+        onDeletedTrialEvent(result.trialEventId);
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : t("admin.trials.manage.selected.error");
+      window.alert(message);
     }
   }
 

--- a/apps/web/components/admin/trials/admin-trial-entry-actions.tsx
+++ b/apps/web/components/admin/trials/admin-trial-entry-actions.tsx
@@ -18,7 +18,7 @@ type AdminTrialEntryActionsProps = {
   eventDate: string;
   eventPlace: string;
   eventName: string | null;
-  onDeletedTrialEvent: () => void;
+  onDeletedTrialEvent: (deletedTrialEventId: string) => void;
 };
 
 export function AdminTrialEntryActions({
@@ -57,7 +57,7 @@ export function AdminTrialEntryActions({
       trialEntryId,
     });
     if (result.deletedTrialEvent) {
-      onDeletedTrialEvent();
+      onDeletedTrialEvent(result.trialEventId);
     }
   }
 

--- a/apps/web/components/admin/trials/admin-trial-entry-actions.tsx
+++ b/apps/web/components/admin/trials/admin-trial-entry-actions.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { AdminRowActionsMenu } from "@/components/admin";
 import { Button } from "@/components/ui/button";
+import { FileText } from "lucide-react";
 import { useI18n } from "@/hooks/i18n";
+import { formatDateForFinland } from "@/lib/admin/core/date";
 import { getTrialPdfHref } from "@/lib/public/beagle/trials";
 import { useDeleteAdminTrialEntryMutation } from "@/queries/admin/trials";
 
@@ -12,6 +15,9 @@ type AdminTrialEntryActionsProps = {
   trialId: string;
   dogName: string;
   registrationNo: string | null;
+  eventDate: string;
+  eventPlace: string;
+  eventName: string | null;
   onDeletedTrialEvent: () => void;
 };
 
@@ -21,17 +27,26 @@ export function AdminTrialEntryActions({
   trialId,
   dogName,
   registrationNo,
+  eventDate,
+  eventPlace,
+  eventName,
   onDeletedTrialEvent,
 }: AdminTrialEntryActionsProps) {
   const { t } = useI18n();
   const deleteMutation = useDeleteAdminTrialEntryMutation();
 
   async function handleDelete() {
-    const label = dogName.trim() || registrationNo || trialEntryId;
+    const resolvedDogName = dogName.trim() || "-";
+    const resolvedRegistrationNo = registrationNo?.trim() || "-";
+    const eventDateLabel = formatDateForFinland(eventDate);
+    const eventPlaceLabel = eventPlace.trim() || "-";
+    const eventNameLabel = eventName?.trim() || null;
     const confirmed = window.confirm(
       `${t("admin.trials.manage.selected.actions.delete.confirmTitle")}\n\n` +
         `${t("admin.trials.manage.selected.actions.delete.confirmBody")}\n\n` +
-        `${label}`,
+        `${t("admin.trials.manage.selected.actions.delete.confirmDog")}: ${resolvedDogName}\n` +
+        `${t("admin.trials.manage.selected.actions.delete.confirmRegistration")}: ${resolvedRegistrationNo}\n` +
+        `${t("admin.trials.manage.selected.actions.delete.confirmEvent")}: ${eventDateLabel} • ${eventPlaceLabel}${eventNameLabel ? ` • ${eventNameLabel}` : ""}`,
     );
     if (!confirmed || deleteMutation.isPending) {
       return;
@@ -47,22 +62,29 @@ export function AdminTrialEntryActions({
   }
 
   return (
-    <div className="flex flex-wrap gap-2">
-      <Button asChild size="sm" variant="outline">
+    <div className="flex items-center gap-1">
+      <Button asChild variant="ghost" size="icon-xs">
         <Link href={getTrialPdfHref(trialId)} target="_blank" rel="noreferrer">
-          {t("admin.trials.manage.selected.actions.openPdf")}
+          <FileText className="size-3.5" aria-hidden="true" />
+          <span className="sr-only">
+            {t("admin.trials.manage.selected.actions.openPdf")}
+          </span>
         </Link>
       </Button>
-      <Button
-        size="sm"
-        variant="destructive"
-        onClick={() => {
-          void handleDelete();
-        }}
-        disabled={deleteMutation.isPending}
-      >
-        {t("admin.trials.manage.selected.actions.delete")}
-      </Button>
+      <AdminRowActionsMenu
+        triggerAriaLabel={t("admin.trials.manage.selected.actions.more")}
+        actions={[
+          {
+            id: "delete-trial-entry",
+            label: t("admin.trials.manage.selected.actions.delete"),
+            onSelect: () => {
+              void handleDelete();
+            },
+            destructive: true,
+            disabled: deleteMutation.isPending,
+          },
+        ]}
+      />
     </div>
   );
 }

--- a/apps/web/components/admin/trials/admin-trial-selected-event-panel.tsx
+++ b/apps/web/components/admin/trials/admin-trial-selected-event-panel.tsx
@@ -68,6 +68,9 @@ export function AdminTrialSelectedEventPanel({
             </div>
             <SelectedEventEntries
               trialEventId={selectedEvent.trialEventId}
+              eventDate={selectedEvent.eventDate}
+              eventPlace={selectedEvent.eventPlace}
+              eventName={selectedEvent.eventName}
               entries={selectedEntries}
               onDeletedTrialEvent={onDeletedTrialEvent}
             />
@@ -86,10 +89,16 @@ export function AdminTrialSelectedEventPanel({
 
 function SelectedEventEntries({
   trialEventId,
+  eventDate,
+  eventPlace,
+  eventName,
   entries,
   onDeletedTrialEvent,
 }: {
   trialEventId: string;
+  eventDate: string;
+  eventPlace: string;
+  eventName: string | null;
   entries: AdminTrialEventEntry[];
   onDeletedTrialEvent: () => void;
 }) {
@@ -152,6 +161,9 @@ function SelectedEventEntries({
                     trialId={entry.trialId}
                     dogName={entry.dogName}
                     registrationNo={entry.registrationNo}
+                    eventDate={eventDate}
+                    eventPlace={eventPlace}
+                    eventName={eventName}
                     onDeletedTrialEvent={onDeletedTrialEvent}
                   />
                 </td>
@@ -200,6 +212,9 @@ function SelectedEventEntries({
               trialId={entry.trialId}
               dogName={entry.dogName}
               registrationNo={entry.registrationNo}
+              eventDate={eventDate}
+              eventPlace={eventPlace}
+              eventName={eventName}
               onDeletedTrialEvent={onDeletedTrialEvent}
             />
           </CardContent>

--- a/apps/web/components/admin/trials/admin-trial-selected-event-panel.tsx
+++ b/apps/web/components/admin/trials/admin-trial-selected-event-panel.tsx
@@ -20,6 +20,7 @@ type AdminTrialSelectedEventPanelProps = {
   isLoading: boolean;
   isError: boolean;
   errorText: string;
+  onDeletedTrialEvent: () => void;
 };
 
 const EMPTY_ENTRIES: AdminTrialEventEntry[] = [];
@@ -29,6 +30,7 @@ export function AdminTrialSelectedEventPanel({
   isLoading,
   isError,
   errorText,
+  onDeletedTrialEvent,
 }: AdminTrialSelectedEventPanelProps) {
   const { t } = useI18n();
   const selectedEntries = selectedEvent?.entries ?? EMPTY_ENTRIES;
@@ -64,7 +66,11 @@ export function AdminTrialSelectedEventPanel({
                 {t("admin.trials.manage.selected.countSuffix")}
               </p>
             </div>
-            <SelectedEventEntries entries={selectedEntries} />
+            <SelectedEventEntries
+              trialEventId={selectedEvent.trialEventId}
+              entries={selectedEntries}
+              onDeletedTrialEvent={onDeletedTrialEvent}
+            />
           </>
         ) : (
           <Card>
@@ -79,9 +85,13 @@ export function AdminTrialSelectedEventPanel({
 }
 
 function SelectedEventEntries({
+  trialEventId,
   entries,
+  onDeletedTrialEvent,
 }: {
+  trialEventId: string;
   entries: AdminTrialEventEntry[];
+  onDeletedTrialEvent: () => void;
 }) {
   const { t } = useI18n();
 
@@ -136,7 +146,14 @@ function SelectedEventEntries({
                 <td className="px-2 py-2">{showDash(entry.rank)}</td>
                 <td className="px-2 py-2">{showDash(entry.judge)}</td>
                 <td className="px-2 py-2">
-                  <AdminTrialEntryActions trialId={entry.trialId} />
+                  <AdminTrialEntryActions
+                    trialEventId={trialEventId}
+                    trialEntryId={entry.trialId}
+                    trialId={entry.trialId}
+                    dogName={entry.dogName}
+                    registrationNo={entry.registrationNo}
+                    onDeletedTrialEvent={onDeletedTrialEvent}
+                  />
                 </td>
               </tr>
             ))}
@@ -177,7 +194,14 @@ function SelectedEventEntries({
               </span>{" "}
               {showDash(entry.judge)}
             </p>
-            <AdminTrialEntryActions trialId={entry.trialId} />
+            <AdminTrialEntryActions
+              trialEventId={trialEventId}
+              trialEntryId={entry.trialId}
+              trialId={entry.trialId}
+              dogName={entry.dogName}
+              registrationNo={entry.registrationNo}
+              onDeletedTrialEvent={onDeletedTrialEvent}
+            />
           </CardContent>
         </Card>
       ))}

--- a/apps/web/components/admin/trials/admin-trial-selected-event-panel.tsx
+++ b/apps/web/components/admin/trials/admin-trial-selected-event-panel.tsx
@@ -20,7 +20,7 @@ type AdminTrialSelectedEventPanelProps = {
   isLoading: boolean;
   isError: boolean;
   errorText: string;
-  onDeletedTrialEvent: () => void;
+  onDeletedTrialEvent: (deletedTrialEventId: string) => void;
 };
 
 const EMPTY_ENTRIES: AdminTrialEventEntry[] = [];
@@ -100,7 +100,7 @@ function SelectedEventEntries({
   eventPlace: string;
   eventName: string | null;
   entries: AdminTrialEventEntry[];
-  onDeletedTrialEvent: () => void;
+  onDeletedTrialEvent: (deletedTrialEventId: string) => void;
 }) {
   const { t } = useI18n();
 

--- a/apps/web/components/admin/trials/admin-trials-page-client.tsx
+++ b/apps/web/components/admin/trials/admin-trials-page-client.tsx
@@ -44,11 +44,10 @@ export function AdminTrialsPageClient() {
   const totalPages = eventsQuery.data?.totalPages ?? 0;
   const page = eventsQuery.data?.page ?? 1;
   const fallbackSelectedEventId = events[0]?.trialEventId ?? "";
+  // modification: block auto-selection after deleting currently selected event
   const selectedEventId =
     selectedEventIdInput ||
-    (blockedAutoSelectedEventId === fallbackSelectedEventId
-      ? ""
-      : fallbackSelectedEventId);
+    (blockedAutoSelectedEventId ? "" : fallbackSelectedEventId);
   const selectedSummary =
     events.find((event) => event.trialEventId === selectedEventId) || null;
 

--- a/apps/web/components/admin/trials/admin-trials-page-client.tsx
+++ b/apps/web/components/admin/trials/admin-trials-page-client.tsx
@@ -177,6 +177,9 @@ export function AdminTrialsPageClient() {
         isLoading={eventQuery.isLoading}
         isError={eventQuery.isError}
         errorText={selectedErrorText}
+        onDeletedTrialEvent={() => {
+          setSelectedEventIdInput("");
+        }}
       />
     </div>
   );

--- a/apps/web/components/admin/trials/admin-trials-page-client.tsx
+++ b/apps/web/components/admin/trials/admin-trials-page-client.tsx
@@ -33,6 +33,9 @@ export function AdminTrialsPageClient() {
       year: undefined,
     });
   const [selectedEventIdInput, setSelectedEventIdInput] = useState("");
+  const [blockedAutoSelectedEventId, setBlockedAutoSelectedEventId] = useState<
+    string | null
+  >(null);
   const [filterError, setFilterError] = useState<string | null>(null);
 
   const eventsQuery = useAdminTrialEventsQuery(searchRequest);
@@ -40,7 +43,12 @@ export function AdminTrialsPageClient() {
   const totalCount = eventsQuery.data?.total ?? events.length;
   const totalPages = eventsQuery.data?.totalPages ?? 0;
   const page = eventsQuery.data?.page ?? 1;
-  const selectedEventId = selectedEventIdInput || events[0]?.trialEventId || "";
+  const fallbackSelectedEventId = events[0]?.trialEventId ?? "";
+  const selectedEventId =
+    selectedEventIdInput ||
+    (blockedAutoSelectedEventId === fallbackSelectedEventId
+      ? ""
+      : fallbackSelectedEventId);
   const selectedSummary =
     events.find((event) => event.trialEventId === selectedEventId) || null;
 
@@ -68,6 +76,7 @@ export function AdminTrialsPageClient() {
         sort,
       });
       setSelectedEventIdInput("");
+      setBlockedAutoSelectedEventId(null);
       return;
     }
 
@@ -92,6 +101,7 @@ export function AdminTrialsPageClient() {
       sort,
     });
     setSelectedEventIdInput("");
+    setBlockedAutoSelectedEventId(null);
   }
 
   function handleResetSearch() {
@@ -112,6 +122,7 @@ export function AdminTrialsPageClient() {
       sort: "date-desc",
     });
     setSelectedEventIdInput("");
+    setBlockedAutoSelectedEventId(null);
   }
 
   function handlePageDelta(delta: number) {
@@ -168,7 +179,10 @@ export function AdminTrialsPageClient() {
         isLoading={eventsQuery.isLoading}
         isError={eventsQuery.isError}
         errorText={eventsErrorText}
-        onSelectEvent={setSelectedEventIdInput}
+        onSelectEvent={(trialEventId) => {
+          setSelectedEventIdInput(trialEventId);
+          setBlockedAutoSelectedEventId(null);
+        }}
         onPageDelta={handlePageDelta}
       />
 
@@ -177,8 +191,9 @@ export function AdminTrialsPageClient() {
         isLoading={eventQuery.isLoading}
         isError={eventQuery.isError}
         errorText={selectedErrorText}
-        onDeletedTrialEvent={() => {
+        onDeletedTrialEvent={(deletedTrialEventId) => {
           setSelectedEventIdInput("");
+          setBlockedAutoSelectedEventId(deletedTrialEventId);
         }}
       />
     </div>

--- a/apps/web/lib/i18n/messages/admin/trials/__tests__/index.test.ts
+++ b/apps/web/lib/i18n/messages/admin/trials/__tests__/index.test.ts
@@ -9,11 +9,17 @@ describe("admin trial message index", () => {
     expect(
       fiAdminTrialsMessages["admin.trials.manage.selected.actions.openPdf"],
     ).toBe("Avaa pöytäkirja");
+    expect(
+      fiAdminTrialsMessages["admin.trials.manage.selected.actions.more"],
+    ).toBe("Lisää toimintoja");
     expect(svAdminTrialsMessages["admin.trials.manage.events.title"]).toBe(
       "Evenemang",
     );
     expect(
       svAdminTrialsMessages["admin.trials.manage.selected.actions.openPdf"],
     ).toBe("Öppna protokoll");
+    expect(
+      svAdminTrialsMessages["admin.trials.manage.selected.actions.more"],
+    ).toBe("Fler åtgärder");
   });
 });

--- a/apps/web/lib/i18n/messages/admin/trials/manage.ts
+++ b/apps/web/lib/i18n/messages/admin/trials/manage.ts
@@ -59,6 +59,7 @@ export const fiAdminTrialsManageMessages = {
   "admin.trials.manage.selected.columns.judge": "Tuomari",
   "admin.trials.manage.selected.columns.actions": "Toiminnot",
   "admin.trials.manage.selected.actions.openPdf": "Avaa pöytäkirja",
+  "admin.trials.manage.selected.actions.more": "Lisää toimintoja",
   "admin.trials.manage.selected.actions.delete": "Poista tulos",
   "admin.trials.manage.selected.actions.delete.confirmTitle":
     "Delete this trial result?",
@@ -143,6 +144,7 @@ export const svAdminTrialsManageMessages = {
   "admin.trials.manage.selected.columns.judge": "Domare",
   "admin.trials.manage.selected.columns.actions": "Åtgärder",
   "admin.trials.manage.selected.actions.openPdf": "Öppna protokoll",
+  "admin.trials.manage.selected.actions.more": "Fler åtgärder",
   "admin.trials.manage.selected.actions.delete": "Ta bort resultat",
   "admin.trials.manage.selected.actions.delete.confirmTitle":
     "Delete this trial result?",

--- a/apps/web/lib/i18n/messages/admin/trials/manage.ts
+++ b/apps/web/lib/i18n/messages/admin/trials/manage.ts
@@ -62,9 +62,13 @@ export const fiAdminTrialsManageMessages = {
   "admin.trials.manage.selected.actions.more": "Lisää toimintoja",
   "admin.trials.manage.selected.actions.delete": "Poista tulos",
   "admin.trials.manage.selected.actions.delete.confirmTitle":
-    "Delete this trial result?",
+    "Poistetaanko tämä koetulos?",
   "admin.trials.manage.selected.actions.delete.confirmBody":
-    "This removes only this dog-specific trial result.\nIf this was the last result in the trial event, the empty trial event will also be removed.",
+    "Tämä poistaa vain tämän koirakohtaisen koetuloksen.\nJos tämä oli tapahtuman viimeinen tulos, myös tyhjä koetapahtuma poistetaan.",
+  "admin.trials.manage.selected.actions.delete.confirmDog": "Dog",
+  "admin.trials.manage.selected.actions.delete.confirmRegistration":
+    "Registration",
+  "admin.trials.manage.selected.actions.delete.confirmEvent": "Event",
   "admin.trials.manage.pagination.previous": "Edellinen",
   "admin.trials.manage.pagination.page": "Sivu",
   "admin.trials.manage.pagination.next": "Seuraava",
@@ -147,9 +151,13 @@ export const svAdminTrialsManageMessages = {
   "admin.trials.manage.selected.actions.more": "Fler åtgärder",
   "admin.trials.manage.selected.actions.delete": "Ta bort resultat",
   "admin.trials.manage.selected.actions.delete.confirmTitle":
-    "Delete this trial result?",
+    "Ta bort det här provresultatet?",
   "admin.trials.manage.selected.actions.delete.confirmBody":
-    "This removes only this dog-specific trial result.\nIf this was the last result in the trial event, the empty trial event will also be removed.",
+    "Det här tar bara bort det här hundspecifika provresultatet.\nOm detta var det sista resultatet i evenemanget tas även det tomma provevenemanget bort.",
+  "admin.trials.manage.selected.actions.delete.confirmDog": "Hund",
+  "admin.trials.manage.selected.actions.delete.confirmRegistration":
+    "Registrering",
+  "admin.trials.manage.selected.actions.delete.confirmEvent": "Evenemang",
   "admin.trials.manage.pagination.previous": "Föregående",
   "admin.trials.manage.pagination.page": "Sida",
   "admin.trials.manage.pagination.next": "Nästa",

--- a/apps/web/lib/i18n/messages/admin/trials/manage.ts
+++ b/apps/web/lib/i18n/messages/admin/trials/manage.ts
@@ -59,6 +59,11 @@ export const fiAdminTrialsManageMessages = {
   "admin.trials.manage.selected.columns.judge": "Tuomari",
   "admin.trials.manage.selected.columns.actions": "Toiminnot",
   "admin.trials.manage.selected.actions.openPdf": "Avaa pöytäkirja",
+  "admin.trials.manage.selected.actions.delete": "Poista tulos",
+  "admin.trials.manage.selected.actions.delete.confirmTitle":
+    "Delete this trial result?",
+  "admin.trials.manage.selected.actions.delete.confirmBody":
+    "This removes only this dog-specific trial result.\nIf this was the last result in the trial event, the empty trial event will also be removed.",
   "admin.trials.manage.pagination.previous": "Edellinen",
   "admin.trials.manage.pagination.page": "Sivu",
   "admin.trials.manage.pagination.next": "Seuraava",
@@ -138,6 +143,11 @@ export const svAdminTrialsManageMessages = {
   "admin.trials.manage.selected.columns.judge": "Domare",
   "admin.trials.manage.selected.columns.actions": "Åtgärder",
   "admin.trials.manage.selected.actions.openPdf": "Öppna protokoll",
+  "admin.trials.manage.selected.actions.delete": "Ta bort resultat",
+  "admin.trials.manage.selected.actions.delete.confirmTitle":
+    "Delete this trial result?",
+  "admin.trials.manage.selected.actions.delete.confirmBody":
+    "This removes only this dog-specific trial result.\nIf this was the last result in the trial event, the empty trial event will also be removed.",
   "admin.trials.manage.pagination.previous": "Föregående",
   "admin.trials.manage.pagination.page": "Sida",
   "admin.trials.manage.pagination.next": "Nästa",

--- a/apps/web/lib/i18n/messages/admin/trials/manage.ts
+++ b/apps/web/lib/i18n/messages/admin/trials/manage.ts
@@ -65,10 +65,10 @@ export const fiAdminTrialsManageMessages = {
     "Poistetaanko tämä koetulos?",
   "admin.trials.manage.selected.actions.delete.confirmBody":
     "Tämä poistaa vain tämän koirakohtaisen koetuloksen.\nJos tämä oli tapahtuman viimeinen tulos, myös tyhjä koetapahtuma poistetaan.",
-  "admin.trials.manage.selected.actions.delete.confirmDog": "Dog",
+  "admin.trials.manage.selected.actions.delete.confirmDog": "Koira",
   "admin.trials.manage.selected.actions.delete.confirmRegistration":
-    "Registration",
-  "admin.trials.manage.selected.actions.delete.confirmEvent": "Event",
+    "Rekisterinumero",
+  "admin.trials.manage.selected.actions.delete.confirmEvent": "Tapahtuma",
   "admin.trials.manage.pagination.previous": "Edellinen",
   "admin.trials.manage.pagination.page": "Sivu",
   "admin.trials.manage.pagination.next": "Seuraava",

--- a/apps/web/queries/admin/trials/manage/__tests__/use-delete-admin-trial-entry-mutation.test.ts
+++ b/apps/web/queries/admin/trials/manage/__tests__/use-delete-admin-trial-entry-mutation.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AdminMutationError } from "@/queries/admin/mutation-error";
+import { beagleTrialsQueryKeyRoot } from "@/queries/public/beagle/trials/query-keys";
+import {
+  adminTrialEventQueryKeyRoot,
+  adminTrialEventsQueryKeyRoot,
+} from "../query-keys";
+import { useDeleteAdminTrialEntryMutation } from "../use-delete-admin-trial-entry-mutation";
+
+const {
+  useMutationMock,
+  useQueryClientMock,
+  invalidateQueriesMock,
+  deleteAdminTrialEntryActionMock,
+} = vi.hoisted(() => ({
+  useMutationMock: vi.fn(),
+  useQueryClientMock: vi.fn(),
+  invalidateQueriesMock: vi.fn(),
+  deleteAdminTrialEntryActionMock: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: useMutationMock,
+  useQueryClient: useQueryClientMock,
+}));
+
+vi.mock("@/app/actions/admin/trials/manage/delete-admin-trial-entry", () => ({
+  deleteAdminTrialEntryAction: deleteAdminTrialEntryActionMock,
+}));
+
+describe("useDeleteAdminTrialEntryMutation", () => {
+  beforeEach(() => {
+    useMutationMock.mockReset();
+    useQueryClientMock.mockReset();
+    invalidateQueriesMock.mockReset();
+    deleteAdminTrialEntryActionMock.mockReset();
+    useQueryClientMock.mockReturnValue({
+      invalidateQueries: invalidateQueriesMock,
+    });
+  });
+
+  it("calls action and returns response data", async () => {
+    useMutationMock.mockImplementation((options) => options);
+    deleteAdminTrialEntryActionMock.mockResolvedValue({
+      hasError: false,
+      data: {
+        deletedTrialEntryId: "entry-1",
+        trialEventId: "event-1",
+        deletedTrialEvent: false,
+      },
+    });
+
+    useDeleteAdminTrialEntryMutation();
+    const options = useMutationMock.mock.calls[0]?.[0] as {
+      mutationFn: (input: unknown) => Promise<unknown>;
+    };
+
+    const input = {
+      trialEventId: "event-1",
+      trialEntryId: "entry-1",
+    };
+    await expect(options.mutationFn(input)).resolves.toEqual({
+      deletedTrialEntryId: "entry-1",
+      trialEventId: "event-1",
+      deletedTrialEvent: false,
+    });
+    expect(deleteAdminTrialEntryActionMock).toHaveBeenCalledWith(input);
+  });
+
+  it("throws AdminMutationError when action returns error", async () => {
+    useMutationMock.mockImplementation((options) => options);
+    deleteAdminTrialEntryActionMock.mockResolvedValue({
+      hasError: true,
+      data: null,
+      errorCode: "ENTRY_NOT_FOUND",
+      message: "Entry not found in selected trial event.",
+    });
+
+    useDeleteAdminTrialEntryMutation();
+    const options = useMutationMock.mock.calls[0]?.[0] as {
+      mutationFn: (input: unknown) => Promise<unknown>;
+    };
+
+    await expect(
+      options.mutationFn({ trialEventId: "event-1", trialEntryId: "entry-1" }),
+    ).rejects.toBeInstanceOf(AdminMutationError);
+  });
+
+  it("invalidates admin and public trial query roots on success", async () => {
+    useMutationMock.mockImplementation((options) => options);
+
+    useDeleteAdminTrialEntryMutation();
+    const options = useMutationMock.mock.calls[0]?.[0] as {
+      onSuccess: () => Promise<void>;
+    };
+
+    await options.onSuccess();
+
+    expect(invalidateQueriesMock).toHaveBeenCalledTimes(3);
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: adminTrialEventsQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: adminTrialEventQueryKeyRoot,
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: beagleTrialsQueryKeyRoot,
+    });
+  });
+});

--- a/apps/web/queries/admin/trials/manage/index.ts
+++ b/apps/web/queries/admin/trials/manage/index.ts
@@ -1,3 +1,4 @@
 export * from "./query-keys";
 export * from "./use-admin-trial-event-query";
 export * from "./use-admin-trial-events-query";
+export * from "./use-delete-admin-trial-entry-mutation";

--- a/apps/web/queries/admin/trials/manage/use-delete-admin-trial-entry-mutation.ts
+++ b/apps/web/queries/admin/trials/manage/use-delete-admin-trial-entry-mutation.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import type {
+  DeleteAdminTrialEntryRequest,
+  DeleteAdminTrialEntryResponse,
+} from "@beagle/contracts";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteAdminTrialEntryAction } from "@/app/actions/admin/trials/manage/delete-admin-trial-entry";
+import { beagleTrialsQueryKeyRoot } from "@/queries/public/beagle/trials/query-keys";
+import { AdminMutationError } from "@/queries/admin/mutation-error";
+import {
+  adminTrialEventQueryKeyRoot,
+  adminTrialEventsQueryKeyRoot,
+} from "./query-keys";
+
+export function useDeleteAdminTrialEntryMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    DeleteAdminTrialEntryResponse,
+    AdminMutationError,
+    DeleteAdminTrialEntryRequest
+  >({
+    mutationFn: async (input) => {
+      const result = await deleteAdminTrialEntryAction(input);
+      if (result.hasError || !result.data) {
+        throw new AdminMutationError(
+          result.message ?? "Failed to delete trial entry.",
+          result.errorCode,
+        );
+      }
+
+      return result.data;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: adminTrialEventsQueryKeyRoot,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: adminTrialEventQueryKeyRoot,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: beagleTrialsQueryKeyRoot,
+      });
+    },
+  });
+}

--- a/packages/contracts/admin/trials/manage/delete-admin-trial-entry.ts
+++ b/packages/contracts/admin/trials/manage/delete-admin-trial-entry.ts
@@ -1,0 +1,10 @@
+export type DeleteAdminTrialEntryRequest = {
+  trialEventId: string;
+  trialEntryId: string;
+};
+
+export type DeleteAdminTrialEntryResponse = {
+  deletedTrialEntryId: string;
+  trialEventId: string;
+  deletedTrialEvent: boolean;
+};

--- a/packages/contracts/admin/trials/manage/index.ts
+++ b/packages/contracts/admin/trials/manage/index.ts
@@ -12,3 +12,7 @@ export type {
   AdminTrialEventDetailsResponse,
   AdminTrialEventEntry,
 } from "./admin-trial-event-details";
+export type {
+  DeleteAdminTrialEntryRequest,
+  DeleteAdminTrialEntryResponse,
+} from "./delete-admin-trial-entry";

--- a/packages/contracts/index.ts
+++ b/packages/contracts/index.ts
@@ -239,6 +239,8 @@ export type {
   AdminTrialEventDetailsRequest,
   AdminTrialEventDetailsResponse,
   AdminTrialEventEntry,
+  DeleteAdminTrialEntryRequest,
+  DeleteAdminTrialEntryResponse,
   AdminTrialEventSearchFilters,
   AdminTrialEventSearchMode,
   AdminTrialEventSearchRequest,

--- a/packages/db/admin/trials/manage/__tests__/delete-trial-entry.test.ts
+++ b/packages/db/admin/trials/manage/__tests__/delete-trial-entry.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ADMIN_WRITE_TX_CONFIG } from "@db/core/interactive-write-transaction";
+import { deleteAdminTrialEntryWriteDb } from "../delete-trial-entry";
+
+const {
+  prismaTransactionMock,
+  trialEntryDeleteManyMock,
+  trialEntryCountMock,
+  trialEventDeleteMock,
+} = vi.hoisted(() => {
+  const trialEntryDeleteMany = vi.fn();
+  const trialEntryCount = vi.fn();
+  const trialEventDelete = vi.fn();
+
+  const tx = {
+    trialEntry: {
+      deleteMany: trialEntryDeleteMany,
+      count: trialEntryCount,
+    },
+    trialEvent: {
+      delete: trialEventDelete,
+    },
+  };
+
+  return {
+    prismaTransactionMock: vi.fn(async (callback) => callback(tx)),
+    trialEntryDeleteManyMock: trialEntryDeleteMany,
+    trialEntryCountMock: trialEntryCount,
+    trialEventDeleteMock: trialEventDelete,
+  };
+});
+
+vi.mock("@db/core/prisma", () => ({
+  prisma: {
+    $transaction: prismaTransactionMock,
+  },
+}));
+
+describe("deleteAdminTrialEntryWriteDb", () => {
+  beforeEach(() => {
+    prismaTransactionMock.mockClear();
+    trialEntryDeleteManyMock.mockReset();
+    trialEntryCountMock.mockReset();
+    trialEventDeleteMock.mockReset();
+  });
+
+  it("returns not_found when no matching row is deleted", async () => {
+    trialEntryDeleteManyMock.mockResolvedValue({ count: 0 });
+
+    await expect(
+      deleteAdminTrialEntryWriteDb({
+        trialEventId: "event-1",
+        trialEntryId: "entry-1",
+      }),
+    ).resolves.toEqual({ status: "not_found" });
+
+    expect(trialEntryCountMock).not.toHaveBeenCalled();
+    expect(trialEventDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps parent trial event when sibling entries remain", async () => {
+    trialEntryDeleteManyMock.mockResolvedValue({ count: 1 });
+    trialEntryCountMock.mockResolvedValue(2);
+
+    await expect(
+      deleteAdminTrialEntryWriteDb({
+        trialEventId: "event-1",
+        trialEntryId: "entry-1",
+      }),
+    ).resolves.toEqual({
+      status: "deleted",
+      deletedTrialEntryId: "entry-1",
+      trialEventId: "event-1",
+      deletedTrialEvent: false,
+    });
+
+    expect(trialEventDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("deletes parent trial event when last entry is removed", async () => {
+    trialEntryDeleteManyMock.mockResolvedValue({ count: 1 });
+    trialEntryCountMock.mockResolvedValue(0);
+
+    await expect(
+      deleteAdminTrialEntryWriteDb({
+        trialEventId: "event-1",
+        trialEntryId: "entry-1",
+      }),
+    ).resolves.toEqual({
+      status: "deleted",
+      deletedTrialEntryId: "entry-1",
+      trialEventId: "event-1",
+      deletedTrialEvent: true,
+    });
+
+    expect(trialEventDeleteMock).toHaveBeenCalledWith({
+      where: {
+        id: "event-1",
+      },
+    });
+  });
+
+  it("passes explicit transaction timeout options", async () => {
+    trialEntryDeleteManyMock.mockResolvedValue({ count: 1 });
+    trialEntryCountMock.mockResolvedValue(1);
+
+    await deleteAdminTrialEntryWriteDb({
+      trialEventId: "event-1",
+      trialEntryId: "entry-1",
+    });
+
+    expect(prismaTransactionMock).toHaveBeenCalledTimes(1);
+    expect(prismaTransactionMock).toHaveBeenLastCalledWith(
+      expect.any(Function),
+      ADMIN_WRITE_TX_CONFIG,
+    );
+  });
+});

--- a/packages/db/admin/trials/manage/delete-trial-entry.ts
+++ b/packages/db/admin/trials/manage/delete-trial-entry.ts
@@ -1,0 +1,58 @@
+import { prisma } from "@db/core/prisma";
+import { ADMIN_WRITE_TX_CONFIG } from "@db/core/interactive-write-transaction";
+
+export type DeleteAdminTrialEntryWriteRequestDb = {
+  trialEventId: string;
+  trialEntryId: string;
+};
+
+export type DeleteAdminTrialEntryWriteResultDb =
+  | { status: "not_found" }
+  | {
+      status: "deleted";
+      deletedTrialEntryId: string;
+      trialEventId: string;
+      deletedTrialEvent: boolean;
+    };
+
+// modification: deleting TrialEntry cascades to TrialEra and TrialEraLisatieto.
+// If this was the last entry, remove the now-empty TrialEvent as cleanup.
+export async function deleteAdminTrialEntryWriteDb(
+  input: DeleteAdminTrialEntryWriteRequestDb,
+): Promise<DeleteAdminTrialEntryWriteResultDb> {
+  return prisma.$transaction(async (tx) => {
+    const deleted = await tx.trialEntry.deleteMany({
+      where: {
+        id: input.trialEntryId,
+        trialEventId: input.trialEventId,
+      },
+    });
+
+    if (deleted.count === 0) {
+      return { status: "not_found" };
+    }
+
+    const remainingEntries = await tx.trialEntry.count({
+      where: {
+        trialEventId: input.trialEventId,
+      },
+    });
+
+    let deletedTrialEvent = false;
+    if (remainingEntries === 0) {
+      await tx.trialEvent.delete({
+        where: {
+          id: input.trialEventId,
+        },
+      });
+      deletedTrialEvent = true;
+    }
+
+    return {
+      status: "deleted",
+      deletedTrialEntryId: input.trialEntryId,
+      trialEventId: input.trialEventId,
+      deletedTrialEvent,
+    };
+  }, ADMIN_WRITE_TX_CONFIG);
+}

--- a/packages/db/admin/trials/manage/index.ts
+++ b/packages/db/admin/trials/manage/index.ts
@@ -1,5 +1,10 @@
 export { getAdminTrialEventDetailsDb } from "./get-trial-event-details";
 export { searchAdminTrialsDb } from "./search-trials";
+export {
+  deleteAdminTrialEntryWriteDb,
+  type DeleteAdminTrialEntryWriteRequestDb,
+  type DeleteAdminTrialEntryWriteResultDb,
+} from "./delete-trial-entry";
 export type {
   AdminTrialEventDetailsDb,
   AdminTrialEventDetailsRequestDb,

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -148,6 +148,7 @@ export {
 export {
   getAdminTrialEventDetailsDb,
   searchAdminTrialsDb,
+  deleteAdminTrialEntryWriteDb,
   type AdminTrialEventDetailsDb,
   type AdminTrialEventDetailsRequestDb,
   type AdminTrialEventEntryDb,
@@ -155,6 +156,8 @@ export {
   type AdminTrialEventSearchResponseDb,
   type AdminTrialEventSearchSortDb,
   type AdminTrialEventSummaryDb,
+  type DeleteAdminTrialEntryWriteRequestDb,
+  type DeleteAdminTrialEntryWriteResultDb,
 } from "./admin/trials";
 
 export {

--- a/packages/server/admin/index.ts
+++ b/packages/server/admin/index.ts
@@ -13,6 +13,7 @@ export { listAdminDogs } from "./dogs";
 export { listAdminOwnerOptions } from "./dogs";
 export { listAdminTrialEvents } from "./trials";
 export { getAdminTrialEvent } from "./trials";
+export { deleteAdminTrialEntry } from "./trials";
 export { previewAdminShowWorkbookImport } from "./shows";
 export { applyAdminShowWorkbookImport } from "./shows";
 export { listAdminShowWorkbookSchemaRules } from "./shows";

--- a/packages/server/admin/trials/manage/__tests__/delete-trial-entry.test.ts
+++ b/packages/server/admin/trials/manage/__tests__/delete-trial-entry.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { deleteAdminTrialEntry } from "@server/admin/trials/manage/delete-trial-entry";
+
+const { deleteAdminTrialEntryWriteDbMock } = vi.hoisted(() => ({
+  deleteAdminTrialEntryWriteDbMock: vi.fn(),
+}));
+
+vi.mock("@beagle/db", () => ({
+  deleteAdminTrialEntryWriteDb: deleteAdminTrialEntryWriteDbMock,
+}));
+
+describe("deleteAdminTrialEntry", () => {
+  beforeEach(() => {
+    deleteAdminTrialEntryWriteDbMock.mockReset();
+  });
+
+  it("returns 400 for invalid trial event id", async () => {
+    await expect(
+      deleteAdminTrialEntry(
+        {
+          trialEventId: " ",
+          trialEntryId: "entry-1",
+        },
+        {
+          id: "u_1",
+          email: "admin@example.com",
+          username: null,
+          role: "ADMIN",
+        },
+      ),
+    ).resolves.toEqual({
+      status: 400,
+      body: {
+        ok: false,
+        error: "Trial event id is required.",
+        code: "INVALID_TRIAL_EVENT_ID",
+      },
+    });
+  });
+
+  it("returns 400 for invalid trial entry id", async () => {
+    await expect(
+      deleteAdminTrialEntry(
+        {
+          trialEventId: "event-1",
+          trialEntryId: " ",
+        },
+        {
+          id: "u_1",
+          email: "admin@example.com",
+          username: null,
+          role: "ADMIN",
+        },
+      ),
+    ).resolves.toEqual({
+      status: 400,
+      body: {
+        ok: false,
+        error: "Trial entry id is required.",
+        code: "INVALID_TRIAL_ENTRY_ID",
+      },
+    });
+  });
+
+  it("returns 403 for unauthorized user", async () => {
+    await expect(
+      deleteAdminTrialEntry(
+        {
+          trialEventId: "event-1",
+          trialEntryId: "entry-1",
+        },
+        {
+          id: "u_1",
+          email: "user@example.com",
+          username: null,
+          role: "USER",
+        },
+      ),
+    ).resolves.toEqual({
+      status: 403,
+      body: {
+        ok: false,
+        error: "Admin role required.",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 404 when db reports not_found", async () => {
+    deleteAdminTrialEntryWriteDbMock.mockResolvedValue({ status: "not_found" });
+
+    await expect(
+      deleteAdminTrialEntry(
+        {
+          trialEventId: "event-1",
+          trialEntryId: "entry-1",
+        },
+        {
+          id: "u_1",
+          email: "admin@example.com",
+          username: null,
+          role: "ADMIN",
+        },
+      ),
+    ).resolves.toEqual({
+      status: 404,
+      body: {
+        ok: false,
+        error: "Entry not found in selected trial event.",
+        code: "ENTRY_NOT_FOUND",
+      },
+    });
+  });
+
+  it("returns 200 when entry is deleted", async () => {
+    deleteAdminTrialEntryWriteDbMock.mockResolvedValue({
+      status: "deleted",
+      deletedTrialEntryId: "entry-1",
+      trialEventId: "event-1",
+      deletedTrialEvent: true,
+    });
+
+    await expect(
+      deleteAdminTrialEntry(
+        {
+          trialEventId: " event-1 ",
+          trialEntryId: " entry-1 ",
+        },
+        {
+          id: "u_1",
+          email: "admin@example.com",
+          username: null,
+          role: "ADMIN",
+        },
+      ),
+    ).resolves.toEqual({
+      status: 200,
+      body: {
+        ok: true,
+        data: {
+          deletedTrialEntryId: "entry-1",
+          trialEventId: "event-1",
+          deletedTrialEvent: true,
+        },
+      },
+    });
+
+    expect(deleteAdminTrialEntryWriteDbMock).toHaveBeenCalledWith({
+      trialEventId: "event-1",
+      trialEntryId: "entry-1",
+    });
+  });
+
+  it("returns 500 when delete throws", async () => {
+    deleteAdminTrialEntryWriteDbMock.mockRejectedValue(new Error("boom"));
+
+    await expect(
+      deleteAdminTrialEntry(
+        {
+          trialEventId: "event-1",
+          trialEntryId: "entry-1",
+        },
+        {
+          id: "u_1",
+          email: "admin@example.com",
+          username: null,
+          role: "ADMIN",
+        },
+      ),
+    ).resolves.toEqual({
+      status: 500,
+      body: {
+        ok: false,
+        error: "Failed to delete admin trial entry.",
+        code: "INTERNAL_ERROR",
+      },
+    });
+  });
+});

--- a/packages/server/admin/trials/manage/delete-trial-entry.ts
+++ b/packages/server/admin/trials/manage/delete-trial-entry.ts
@@ -1,0 +1,156 @@
+import type {
+  CurrentUserDto,
+  DeleteAdminTrialEntryRequest,
+  DeleteAdminTrialEntryResponse,
+} from "@beagle/contracts";
+import { deleteAdminTrialEntryWriteDb } from "@beagle/db";
+import { requireAdmin } from "@server/admin/core/service";
+import { toErrorLog, withLogContext } from "@server/core/logger";
+import type { ServiceResult } from "@server/core/result";
+
+type ServiceLogContext = {
+  requestId?: string;
+  actorUserId?: string;
+};
+
+// Validates and deletes one admin trial entry scoped to a selected trial event.
+export async function deleteAdminTrialEntry(
+  input: DeleteAdminTrialEntryRequest,
+  currentUser: CurrentUserDto | null,
+  context?: ServiceLogContext,
+): Promise<ServiceResult<DeleteAdminTrialEntryResponse>> {
+  const startedAt = Date.now();
+  const trialEventId = input.trialEventId.trim();
+  const trialEntryId = input.trialEntryId.trim();
+  const log = withLogContext({
+    layer: "service",
+    useCase: "admin-trials.deleteAdminTrialEntry",
+    ...(context?.requestId ? { requestId: context.requestId } : {}),
+    ...(context?.actorUserId ? { actorUserId: context.actorUserId } : {}),
+  });
+
+  if (!trialEventId) {
+    log.warn(
+      { event: "invalid_trial_event_id", durationMs: Date.now() - startedAt },
+      "admin trial entry delete rejected because trialEventId is invalid",
+    );
+    return {
+      status: 400,
+      body: {
+        ok: false,
+        error: "Trial event id is required.",
+        code: "INVALID_TRIAL_EVENT_ID",
+      },
+    };
+  }
+
+  if (!trialEntryId) {
+    log.warn(
+      { event: "invalid_trial_entry_id", durationMs: Date.now() - startedAt },
+      "admin trial entry delete rejected because trialEntryId is invalid",
+    );
+    return {
+      status: 400,
+      body: {
+        ok: false,
+        error: "Trial entry id is required.",
+        code: "INVALID_TRIAL_ENTRY_ID",
+      },
+    };
+  }
+
+  const authResult = requireAdmin(currentUser);
+  if (!authResult.body.ok) {
+    log.warn(
+      {
+        event: "forbidden",
+        status: authResult.status,
+        durationMs: Date.now() - startedAt,
+      },
+      "admin trial entry delete rejected by authorization",
+    );
+    return {
+      status: authResult.status,
+      body: authResult.body,
+    };
+  }
+
+  log.info(
+    {
+      event: "start",
+      trialEventId,
+      trialEntryId,
+    },
+    "admin trial entry delete started",
+  );
+
+  try {
+    const result = await deleteAdminTrialEntryWriteDb({
+      trialEventId,
+      trialEntryId,
+    });
+
+    if (result.status === "not_found") {
+      log.warn(
+        {
+          event: "not_found",
+          trialEventId,
+          trialEntryId,
+          durationMs: Date.now() - startedAt,
+        },
+        "admin trial entry delete failed because entry was not found",
+      );
+      return {
+        status: 404,
+        body: {
+          ok: false,
+          error: "Entry not found in selected trial event.",
+          code: "ENTRY_NOT_FOUND",
+        },
+      };
+    }
+
+    log.info(
+      {
+        event: "success",
+        trialEventId: result.trialEventId,
+        trialEntryId: result.deletedTrialEntryId,
+        deletedTrialEvent: result.deletedTrialEvent,
+        durationMs: Date.now() - startedAt,
+      },
+      "admin trial entry delete succeeded",
+    );
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        data: {
+          deletedTrialEntryId: result.deletedTrialEntryId,
+          trialEventId: result.trialEventId,
+          deletedTrialEvent: result.deletedTrialEvent,
+        },
+      },
+    };
+  } catch (error) {
+    log.error(
+      {
+        event: "exception",
+        trialEventId,
+        trialEntryId,
+        durationMs: Date.now() - startedAt,
+        ...toErrorLog(error),
+      },
+      "admin trial entry delete failed",
+    );
+
+    return {
+      status: 500,
+      body: {
+        ok: false,
+        error: "Failed to delete admin trial entry.",
+        code: "INTERNAL_ERROR",
+      },
+    };
+  }
+}

--- a/packages/server/admin/trials/manage/index.ts
+++ b/packages/server/admin/trials/manage/index.ts
@@ -1,2 +1,3 @@
 export { getAdminTrialEvent } from "./get-trial-event";
 export { listAdminTrialEvents } from "./list-trials";
+export { deleteAdminTrialEntry } from "./delete-trial-entry";

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -28,6 +28,7 @@ export { createTrialsService, trialsService } from "./trials";
 export { upsertKoiratietokantaAjokResultService } from "./trials";
 export { listAdminTrialEvents } from "./admin";
 export { getAdminTrialEvent } from "./admin";
+export { deleteAdminTrialEntry } from "./admin";
 export { createImportsService, importsService } from "./imports";
 export { createStatsService, statsService } from "./home";
 export type { ServiceResult } from "./core/result";


### PR DESCRIPTION

⸻

BEJ-101: Admin delete for canonical trial entries

Summary

Adds admin functionality to delete individual dog-specific trial results (TrialEntry) from canonical trial data.

If the deleted entry was the last one in a trial event, the empty TrialEvent is automatically removed.

⸻

What was implemented

Backend

* Added deleteAdminTrialEntry use case
* Added DB write with transaction:
    * Deletes TrialEntry scoped by trialEventId
    * Relies on cascade to remove TrialEra and TrialEraLisatieto
    * Automatically deletes TrialEvent when no entries remain
* Added server action deleteAdminTrialEntryAction
* Added contract types for request/response (includes deletedTrialEvent flag)

Frontend

* Added delete action to admin trial entry row actions menu
* Confirmation dialog includes:
    * dog name
    * registration number
    * event details
* Handles two outcomes:
    * Entry deleted → stays on event view
    * Last entry deleted → clears selected event (no auto-selection fallback)

State handling

* Introduced blockedAutoSelectedEventId to prevent unintended auto-selection after deleting an event
* Auto-selection is only allowed when no deletion block is active

Query updates

* Invalidates:
    * adminTrialEventsQueryKeyRoot
    * adminTrialEventQueryKeyRoot
    * beagleTrialsQueryKeyRoot

Tests

* DB layer: delete + cascade + empty-event cleanup
* Server use case: validation, auth, error handling
* Server action: mapping and guards
* React Query mutation: success + invalidation
* UI:
    * verifies mutation call with correct IDs
    * verifies onDeletedTrialEvent is triggered
    * verifies selection blocking logic

⸻

Behavior

* Admin can delete a single trial result (dog entry)
* If it was the last entry:
    * trial event is automatically removed
    * UI clears selection instead of jumping to another event
* No separate trial event delete action is included in this PR

⸻

Notes

* Follows existing architecture (same pattern as show entry delete)
* No direct DB access outside packages/db
* All mutations use Server Actions
