### PR TITLE
Muunna loput sukusiitosprosentit laskennaliseksi

### DIFF
--- a/docs/features/beagle-dog-profile.md
+++ b/docs/features/beagle-dog-profile.md
@@ -31,6 +31,7 @@ Developer notes for the public beagle dog profile feature.
 3. The web page renders details and lineage always, renders titles when title rows exist, and renders secondary cards conditionally by data (siblings, litters, shows, trials).
 4. Siblings are resolved in DB from one reliable birth litter and rendered after lineage.
 5. Litters are rendered between siblings and result sections.
+6. Public inbreeding is calculated at read time from current pedigree data rather than read from the persisted `Dog.siitosasteProsentti` field.
 
 ## Current contract rules
 
@@ -50,6 +51,7 @@ Current note:
 
 - grouped litter data is already part of the profile contract and backend mapping
 - title rows are stored and rendered as structured row data (`awardedOn`, `titleCode`, `titleName`)
+- `inbreedingCoefficientPct` is derived dynamically from current pedigree ancestry in the public profile read path
 - the UI renders litters as grouped pentue blocks with summary counts, co-parent links, and puppy profile links
 - each litter uses the shared desktop/mobile listing pattern instead of a custom flat row list
 - puppy rows currently include registration number, name, sex, EK number, trial count, show count, litter count, and a placeholder color column

--- a/docs/planning/disease-evidence-model.md
+++ b/docs/planning/disease-evidence-model.md
@@ -1,0 +1,62 @@
+# Disease Evidence Model Planning Note
+
+## Problem
+
+Legacy `beasairaat` rows mix three responsibilities:
+
+- Direct disease fact for a real dog.
+- Anonymous affected puppy/litter evidence, for example `EPI_1/94` and `PUR_1/06`.
+- Relationship lookup through `ISREK` and `EMREK`.
+
+In v2 this should be cleaned up. Canonical dog relationships must come from
+`Dog.sireId` and `Dog.damId`, not from disease rows.
+
+## Decision
+
+Model disease rows as evidence:
+
+- `DOG`: linked to a real affected dog.
+- `LITTER`: anonymous affected puppy/litter linked to resolved sire and dam.
+- `UNRESOLVED`: preserved import/source row, excluded from calculations.
+
+Do not create fake dogs for anonymous disease rows.
+
+## Calculation Policy
+
+For `DOG` evidence:
+
+- Use `dogId` for direct disease evidence.
+- Use canonical dog pedigree for parents, siblings, offspring, and half-siblings.
+- Ignore source `ISREK` and `EMREK` for relationship matching.
+
+For `LITTER` evidence:
+
+- Use resolved sire and dam as anonymous affected litter evidence.
+- Allow it to contribute to EPI/PUR relationship evidence.
+- Never count it as direct disease for any real dog.
+
+For `UNRESOLVED` evidence:
+
+- Preserve for audit/manual cleanup.
+- Exclude from calculations.
+
+## Import Policy
+
+- Real `REKNO` resolving to dog -> `DOG`.
+- Invalid/synthetic/missing `REKNO` with both parents resolved -> `LITTER`.
+- No resolved dog and no resolved complete parent pair -> `UNRESOLVED`.
+- Always preserve raw source registration strings.
+
+## Examples
+
+- `FI15813/15` should be `DOG` evidence because the dog exists.
+- `PKR.VI-15268` vs `PKRVI-15268` is an alias/import cleanup issue, not a reason to lose dog evidence.
+- `EPI_1/94` with resolved sire/dam should be `LITTER` evidence.
+- Missing `REKNO` with unresolved parents should be `UNRESOLVED`.
+
+## Out Of Scope
+
+- Admin UI for adding/editing disease rows.
+- Manual alias cleanup UI.
+- Creating placeholder dogs.
+- Backward compatibility for partially bootstrapped import states.

--- a/packages/db/admin/dogs/profile/internal/profile-db-mappers.ts
+++ b/packages/db/admin/dogs/profile/internal/profile-db-mappers.ts
@@ -2,7 +2,8 @@ import type { Prisma } from "@prisma/client";
 import type { AdminDogProfileDb } from "../types";
 import { adminDogProfileSelect } from "./profile-select";
 
-type AdminDogProfileDiseaseGroup = AdminDogProfileDb["diseases"][number]["diseaseGroup"];
+type AdminDogProfileDiseaseGroup =
+  AdminDogProfileDb["diseases"][number]["diseaseGroup"];
 
 type AdminDogProfileRow = Prisma.DogGetPayload<{
   select: typeof adminDogProfileSelect;
@@ -21,7 +22,9 @@ function mapDiseaseGroup(group: string): AdminDogProfileDiseaseGroup {
   return "MUU";
 }
 
-export function mapAdminDogProfileDbRow(dog: AdminDogProfileRow): AdminDogProfileDb {
+export function mapAdminDogProfileDbRow(
+  dog: AdminDogProfileRow,
+): AdminDogProfileDb {
   return {
     base: {
       id: dog.id,
@@ -31,8 +34,6 @@ export function mapAdminDogProfileDbRow(dog: AdminDogProfileRow): AdminDogProfil
       sex: dog.sex,
       color: null,
       ekNo: dog.ekNo,
-      inbreedingCoefficientPct:
-        dog.siitosasteProsentti == null ? null : Number(dog.siitosasteProsentti),
       sire: dog.sire
         ? {
             id: dog.sire.id,

--- a/packages/db/admin/dogs/profile/internal/profile-select.ts
+++ b/packages/db/admin/dogs/profile/internal/profile-select.ts
@@ -12,7 +12,6 @@ export const adminDogProfileSelect = Prisma.validator<Prisma.DogSelect>()({
   birthDate: true,
   sex: true,
   ekNo: true,
-  siitosasteProsentti: true,
   sire: {
     select: {
       id: true,

--- a/packages/db/admin/dogs/profile/types.ts
+++ b/packages/db/admin/dogs/profile/types.ts
@@ -35,7 +35,6 @@ export type AdminDogProfileDb = {
     sex: DogSex;
     color: string | null;
     ekNo: number | null;
-    inbreedingCoefficientPct: number | null;
     sire: ParentDogNode | null;
     dam: ParentDogNode | null;
     whelpedPuppies: OffspringDogNode[];

--- a/packages/db/dogs/profile/__tests__/get-beagle-dog-profile.test.ts
+++ b/packages/db/dogs/profile/__tests__/get-beagle-dog-profile.test.ts
@@ -167,6 +167,7 @@ describe("getBeagleDogProfileDb", () => {
     expect(result?.litters).toEqual([]);
     expect(result?.siblingsSummary).toEqual({ siblingCount: 0 });
     expect(result?.siblings).toEqual([]);
+    expect(result).not.toHaveProperty("siitosasteProsentti");
     expect(queryArgs.include).not.toHaveProperty("showResults");
     expect(queryArgs.include).toHaveProperty("whelpedPuppies");
     expect(queryArgs.include).toHaveProperty("siredPuppies");

--- a/packages/db/dogs/profile/get-beagle-dog-profile.ts
+++ b/packages/db/dogs/profile/get-beagle-dog-profile.ts
@@ -73,8 +73,6 @@ export async function getBeagleDogProfileDb(
     sex,
     color: null,
     ekNo: dog.ekNo,
-    siitosasteProsentti:
-      dog.siitosasteProsentti == null ? null : Number(dog.siitosasteProsentti),
     sire: mapParent(dog.sire),
     dam: mapParent(dog.dam),
     pedigree,

--- a/packages/db/dogs/profile/internal/profile-types.ts
+++ b/packages/db/dogs/profile/internal/profile-types.ts
@@ -79,7 +79,6 @@ export type BeagleDogProfileDb = {
   sex: BeagleDogProfileSexDb;
   color: string | null;
   ekNo: number | null;
-  siitosasteProsentti: number | null;
   sire: BeagleDogProfileParentDb | null;
   dam: BeagleDogProfileParentDb | null;
   pedigree: BeagleDogProfilePedigreeGenerationDb[];

--- a/packages/server/admin/dogs/profile/__tests__/get-admin-dog-profile.test.ts
+++ b/packages/server/admin/dogs/profile/__tests__/get-admin-dog-profile.test.ts
@@ -43,7 +43,7 @@ describe("getAdminDogProfile", () => {
     expect(getAdminDogProfileDbMock).not.toHaveBeenCalled();
   });
 
-  it("returns computed EPI fields and admin-only data for an admin user", async () => {
+  it("returns computed health and inbreeding fields for an admin user", async () => {
     getAdminDogProfileDbMock.mockResolvedValue({
       base: {
         id: "dog-1",
@@ -124,29 +124,53 @@ describe("getAdminDogProfile", () => {
         },
       ],
     } as never);
-    loadDogPedigreeAncestryDbMock.mockResolvedValue({
-      rootId: "dog-1",
-      nodes: {
-        "dog-1": {
-          id: "dog-1",
-          sireId: "sire-1",
-          damId: "dam-1",
-          siitosasteProsentti: null,
+    loadDogPedigreeAncestryDbMock
+      .mockResolvedValueOnce({
+        rootId: "dog-1",
+        nodes: {
+          "dog-1": {
+            id: "dog-1",
+            sireId: "sire-1",
+            damId: "dam-1",
+            siitosasteProsentti: null,
+          },
+          "sire-1": {
+            id: "sire-1",
+            sireId: null,
+            damId: null,
+            siitosasteProsentti: null,
+          },
+          "dam-1": {
+            id: "dam-1",
+            sireId: null,
+            damId: null,
+            siitosasteProsentti: null,
+          },
         },
-        "sire-1": {
-          id: "sire-1",
-          sireId: null,
-          damId: null,
-          siitosasteProsentti: null,
+      })
+      .mockResolvedValueOnce({
+        rootId: "dog-1",
+        nodes: {
+          "dog-1": {
+            id: "dog-1",
+            sireId: "sire-1",
+            damId: "dam-1",
+            siitosasteProsentti: null,
+          },
+          "sire-1": {
+            id: "sire-1",
+            sireId: null,
+            damId: null,
+            siitosasteProsentti: null,
+          },
+          "dam-1": {
+            id: "dam-1",
+            sireId: null,
+            damId: null,
+            siitosasteProsentti: null,
+          },
         },
-        "dam-1": {
-          id: "dam-1",
-          sireId: null,
-          damId: null,
-          siitosasteProsentti: null,
-        },
-      },
-    });
+      });
     loadDogEpiDiseaseFactsDbMock.mockResolvedValue([
       {
         dogId: "dog-1",
@@ -179,7 +203,7 @@ describe("getAdminDogProfile", () => {
             ekNo: null,
             offspringCount: 0,
             offspringLitterCount: 0,
-            inbreedingCoefficientPct: 3.0724,
+            inbreedingCoefficientPct: 0,
             epiLuku: 1.5,
             epiTeksti: "I----",
             laforaLuku: 0,
@@ -235,11 +259,77 @@ describe("getAdminDogProfile", () => {
 
     expect(getAdminDogProfileDbMock).toHaveBeenCalledWith("dog-1");
     expect(loadDogPedigreeAncestryDbMock).toHaveBeenCalledWith("dog-1", 5);
+    expect(loadDogPedigreeAncestryDbMock).toHaveBeenCalledWith("dog-1", 17);
     expect(loadDogEpiDiseaseFactsDbMock).toHaveBeenCalledWith([
       "dog-1",
       "sire-1",
       "dam-1",
     ]);
+  });
+
+  it("returns null inbreeding when the dog has no parents", async () => {
+    getAdminDogProfileDbMock.mockResolvedValue({
+      base: {
+        id: "dog-2",
+        name: "JALKA",
+        registrationNos: [
+          {
+            registrationNo: "FIN00000/00",
+            createdAt: new Date("2000-01-01T00:00:00.000Z"),
+          },
+        ],
+        birthDate: null,
+        sex: "MALE",
+        color: null,
+        ekNo: null,
+        sire: null,
+        dam: null,
+        whelpedPuppies: [],
+        siredPuppies: [],
+        breederNameText: null,
+      },
+      note: null,
+      breeder: null,
+      owners: [],
+      diseases: [],
+    } as never);
+    loadDogPedigreeAncestryDbMock
+      .mockResolvedValueOnce({
+        rootId: "dog-2",
+        nodes: {
+          "dog-2": {
+            id: "dog-2",
+            sireId: null,
+            damId: null,
+            siitosasteProsentti: null,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        rootId: "dog-2",
+        nodes: {
+          "dog-2": {
+            id: "dog-2",
+            sireId: null,
+            damId: null,
+            siitosasteProsentti: null,
+          },
+        },
+      });
+    loadDogEpiDiseaseFactsDbMock.mockResolvedValue([]);
+
+    const result = await getAdminDogProfile("dog-2", {
+      id: "admin-1",
+      email: "admin@example.com",
+      username: "admin",
+      role: "ADMIN",
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.ok).toBe(true);
+    if (result.body.ok) {
+      expect(result.body.data.dog.inbreedingCoefficientPct).toBeNull();
+    }
   });
 
   it("rejects invalid dog ids before hitting the database", async () => {

--- a/packages/server/admin/dogs/profile/__tests__/get-admin-dog-profile.test.ts
+++ b/packages/server/admin/dogs/profile/__tests__/get-admin-dog-profile.test.ts
@@ -136,12 +136,18 @@ describe("getAdminDogProfile", () => {
           },
           "sire-1": {
             id: "sire-1",
-            sireId: null,
+            sireId: "ancestor-1",
             damId: null,
             siitosasteProsentti: null,
           },
           "dam-1": {
             id: "dam-1",
+            sireId: "ancestor-1",
+            damId: null,
+            siitosasteProsentti: null,
+          },
+          "ancestor-1": {
+            id: "ancestor-1",
             sireId: null,
             damId: null,
             siitosasteProsentti: null,
@@ -159,12 +165,18 @@ describe("getAdminDogProfile", () => {
           },
           "sire-1": {
             id: "sire-1",
-            sireId: null,
+            sireId: "ancestor-1",
             damId: null,
             siitosasteProsentti: null,
           },
           "dam-1": {
             id: "dam-1",
+            sireId: "ancestor-1",
+            damId: null,
+            siitosasteProsentti: null,
+          },
+          "ancestor-1": {
+            id: "ancestor-1",
             sireId: null,
             damId: null,
             siitosasteProsentti: null,
@@ -203,7 +215,7 @@ describe("getAdminDogProfile", () => {
             ekNo: null,
             offspringCount: 0,
             offspringLitterCount: 0,
-            inbreedingCoefficientPct: 0,
+            inbreedingCoefficientPct: 12.5,
             epiLuku: 1.5,
             epiTeksti: "I----",
             laforaLuku: 0,
@@ -256,6 +268,9 @@ describe("getAdminDogProfile", () => {
         },
       },
     });
+    expect(result.body.ok ? result.body.data.dog : null).not.toHaveProperty(
+      "siitosasteProsentti",
+    );
 
     expect(getAdminDogProfileDbMock).toHaveBeenCalledWith("dog-1");
     expect(loadDogPedigreeAncestryDbMock).toHaveBeenCalledWith("dog-1", 5);
@@ -264,6 +279,7 @@ describe("getAdminDogProfile", () => {
       "dog-1",
       "sire-1",
       "dam-1",
+      "ancestor-1",
     ]);
   });
 
@@ -293,29 +309,17 @@ describe("getAdminDogProfile", () => {
       owners: [],
       diseases: [],
     } as never);
-    loadDogPedigreeAncestryDbMock
-      .mockResolvedValueOnce({
-        rootId: "dog-2",
-        nodes: {
-          "dog-2": {
-            id: "dog-2",
-            sireId: null,
-            damId: null,
-            siitosasteProsentti: null,
-          },
+    loadDogPedigreeAncestryDbMock.mockResolvedValueOnce({
+      rootId: "dog-2",
+      nodes: {
+        "dog-2": {
+          id: "dog-2",
+          sireId: null,
+          damId: null,
+          siitosasteProsentti: null,
         },
-      })
-      .mockResolvedValueOnce({
-        rootId: "dog-2",
-        nodes: {
-          "dog-2": {
-            id: "dog-2",
-            sireId: null,
-            damId: null,
-            siitosasteProsentti: null,
-          },
-        },
-      });
+      },
+    });
     loadDogEpiDiseaseFactsDbMock.mockResolvedValue([]);
 
     const result = await getAdminDogProfile("dog-2", {
@@ -330,6 +334,8 @@ describe("getAdminDogProfile", () => {
     if (result.body.ok) {
       expect(result.body.data.dog.inbreedingCoefficientPct).toBeNull();
     }
+    expect(loadDogPedigreeAncestryDbMock).toHaveBeenCalledWith("dog-2", 5);
+    expect(loadDogPedigreeAncestryDbMock).not.toHaveBeenCalledWith("dog-2", 17);
   });
 
   it("rejects invalid dog ids before hitting the database", async () => {

--- a/packages/server/admin/dogs/profile/__tests__/get-admin-dog-profile.test.ts
+++ b/packages/server/admin/dogs/profile/__tests__/get-admin-dog-profile.test.ts
@@ -58,7 +58,6 @@ describe("getAdminDogProfile", () => {
         sex: "MALE",
         color: null,
         ekNo: null,
-        inbreedingCoefficientPct: 3.0724,
         sire: {
           id: "sire-1",
           name: "JUHANNIN ROOPE",

--- a/packages/server/admin/dogs/profile/get-admin-dog-profile.ts
+++ b/packages/server/admin/dogs/profile/get-admin-dog-profile.ts
@@ -59,6 +59,22 @@ function formatHealthSummary(
   return summary.join(", ");
 }
 
+async function calculateProfileInbreedingCoefficientPct(
+  profileBase: AdminDogProfileDb["base"],
+  parsedDogId: string,
+): Promise<number | null> {
+  if (!profileBase.sire || !profileBase.dam) {
+    return null;
+  }
+
+  const ancestry = await loadDogPedigreeAncestryDb(
+    parsedDogId,
+    getInbreedingAncestryLoadDepth(9),
+  );
+
+  return calculateInbreedingCoefficientPct(parsedDogId, ancestry, 9);
+}
+
 function toAdminDogProfileDto(
   profile: AdminDogProfileDb,
   epiSummary: ReturnType<typeof calculateDogEpiSummary>,
@@ -166,9 +182,9 @@ export async function getAdminDogProfile(
       };
     }
 
-    const [healthAncestry, inbreedingAncestry] = await Promise.all([
+    const [healthAncestry, inbreedingCoefficientPct] = await Promise.all([
       loadDogPedigreeAncestryDb(parsedDogId, 5),
-      loadDogPedigreeAncestryDb(parsedDogId, getInbreedingAncestryLoadDepth(9)),
+      calculateProfileInbreedingCoefficientPct(profile.base, parsedDogId),
     ]);
     const relatedDogIds = Object.keys(healthAncestry.nodes);
     const diseaseFacts = await loadDogEpiDiseaseFactsDb(relatedDogIds);
@@ -176,11 +192,6 @@ export async function getAdminDogProfile(
       parsedDogId,
       healthAncestry,
       diseaseFacts,
-    );
-    const inbreedingCoefficientPct = calculateInbreedingCoefficientPct(
-      parsedDogId,
-      inbreedingAncestry,
-      9,
     );
 
     log.info(

--- a/packages/server/admin/dogs/profile/get-admin-dog-profile.ts
+++ b/packages/server/admin/dogs/profile/get-admin-dog-profile.ts
@@ -14,7 +14,12 @@ import { requireAdmin } from "@server/admin/core/service";
 import { toBusinessDateOnly } from "@server/core/date-only";
 import { toErrorLog, withLogContext } from "@server/core/logger";
 import type { ServiceResult } from "@server/core/result";
-import { calculateDogEpiSummary, parseDogId } from "@server/dogs/core";
+import {
+  calculateDogEpiSummary,
+  calculateInbreedingCoefficientPct,
+  getInbreedingAncestryLoadDepth,
+  parseDogId,
+} from "@server/dogs/core";
 import {
   buildLitters,
   buildOffspringSummary,
@@ -57,6 +62,7 @@ function formatHealthSummary(
 function toAdminDogProfileDto(
   profile: AdminDogProfileDb,
   epiSummary: ReturnType<typeof calculateDogEpiSummary>,
+  inbreedingCoefficientPct: number | null,
 ): AdminDogProfileDto {
   const sex = toSexCode(profile.base.sex);
   const litters = buildLitters(
@@ -81,10 +87,7 @@ function toAdminDogProfileDto(
     ekNo: profile.base.ekNo,
     offspringCount: buildOffspringSummary(litters).puppyCount,
     offspringLitterCount: buildOffspringSummary(litters).litterCount,
-    inbreedingCoefficientPct:
-      profile.base.inbreedingCoefficientPct == null
-        ? null
-        : Number(profile.base.inbreedingCoefficientPct),
+    inbreedingCoefficientPct,
     epiLuku: epiSummary.epiLuku,
     epiTeksti: epiSummary.epiTeksti,
     laforaLuku: epiSummary.laforaLuku,
@@ -163,13 +166,21 @@ export async function getAdminDogProfile(
       };
     }
 
-    const ancestry = await loadDogPedigreeAncestryDb(parsedDogId, 5);
-    const relatedDogIds = Object.keys(ancestry.nodes);
+    const [healthAncestry, inbreedingAncestry] = await Promise.all([
+      loadDogPedigreeAncestryDb(parsedDogId, 5),
+      loadDogPedigreeAncestryDb(parsedDogId, getInbreedingAncestryLoadDepth(9)),
+    ]);
+    const relatedDogIds = Object.keys(healthAncestry.nodes);
     const diseaseFacts = await loadDogEpiDiseaseFactsDb(relatedDogIds);
     const epiSummary = calculateDogEpiSummary(
       parsedDogId,
-      ancestry,
+      healthAncestry,
       diseaseFacts,
+    );
+    const inbreedingCoefficientPct = calculateInbreedingCoefficientPct(
+      parsedDogId,
+      inbreedingAncestry,
+      9,
     );
 
     log.info(
@@ -185,7 +196,13 @@ export async function getAdminDogProfile(
       status: 200,
       body: {
         ok: true,
-        data: { dog: toAdminDogProfileDto(profile, epiSummary) },
+        data: {
+          dog: toAdminDogProfileDto(
+            profile,
+            epiSummary,
+            inbreedingCoefficientPct,
+          ),
+        },
       },
     };
   } catch (error) {

--- a/packages/server/dogs/__tests__/service.test.ts
+++ b/packages/server/dogs/__tests__/service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDogsService } from "@server/dogs";
+import { getInbreedingAncestryLoadDepth } from "@server/dogs/core";
 import { encodeShowId } from "@server/shows/internal/show-id";
 
 const {
@@ -37,6 +38,17 @@ vi.mock("@server/dogs/core/inbreeding-coefficient", () => ({
   calculateInbreedingCoefficientPct: calculateInbreedingCoefficientPctMock,
 }));
 
+vi.mock("@server/dogs/core", async () => {
+  const actual =
+    await vi.importActual<typeof import("@server/dogs/core")>(
+      "@server/dogs/core",
+    );
+  return {
+    ...actual,
+    calculateInbreedingCoefficientPct: calculateInbreedingCoefficientPctMock,
+  };
+});
+
 function withoutEventKey<T extends { eventKey: unknown }>(
   row: T,
 ): Omit<T, "eventKey"> {
@@ -54,6 +66,11 @@ describe("dogs service", () => {
     getBeagleTrialsForDogDbMock.mockReset();
     loadDogPedigreeAncestryDbMock.mockReset();
     calculateInbreedingCoefficientPctMock.mockReset();
+    loadDogPedigreeAncestryDbMock.mockResolvedValue({
+      rootId: "default",
+      nodes: {},
+    });
+    calculateInbreedingCoefficientPctMock.mockReturnValue(null);
   });
 
   it("returns 400 for invalid sort and does not call DB", async () => {
@@ -292,7 +309,6 @@ describe("dogs service", () => {
       sex: "U",
       color: null,
       ekNo: 42,
-      inbreedingCoefficientPct: null,
       sire: { name: "Sire", registrationNo: "FI-2/18" },
       dam: { name: "Dam", registrationNo: "FI-3/18" },
       pedigree: [],
@@ -345,6 +361,17 @@ describe("dogs service", () => {
         },
       ],
     };
+    const mockAncestry = {
+      rootId: "dog1",
+      nodes: {
+        dog1: {
+          id: "dog1",
+          sireId: "sire-1",
+          damId: "dam-1",
+          siitosasteProsentti: null,
+        },
+      },
+    };
     const mockShows = [
       {
         id: "show1",
@@ -384,6 +411,8 @@ describe("dogs service", () => {
       },
     ];
     getBeagleDogProfileDbMock.mockResolvedValue(mockProfile);
+    loadDogPedigreeAncestryDbMock.mockResolvedValue(mockAncestry);
+    calculateInbreedingCoefficientPctMock.mockReturnValue(12.5);
     getBeagleShowsForDogDbMock.mockResolvedValue(mockShows);
     getBeagleTrialsForDogDbMock.mockResolvedValue(mockTrials);
 
@@ -391,6 +420,15 @@ describe("dogs service", () => {
     const result = await service.getBeagleDogProfile("dog1");
 
     expect(getBeagleDogProfileDbMock).toHaveBeenCalledWith("dog1");
+    expect(loadDogPedigreeAncestryDbMock).toHaveBeenCalledWith(
+      "dog1",
+      getInbreedingAncestryLoadDepth(9),
+    );
+    expect(calculateInbreedingCoefficientPctMock).toHaveBeenCalledWith(
+      "dog1",
+      mockAncestry,
+      9,
+    );
     expect(getBeagleShowsForDogDbMock).toHaveBeenCalledWith("dog1");
     expect(getBeagleTrialsForDogDbMock).toHaveBeenCalledWith("dog1");
     const show1 = withoutEventKey(mockShows[0]);
@@ -400,7 +438,7 @@ describe("dogs service", () => {
         ok: true,
         data: {
           ...mockProfile,
-          inbreedingCoefficientPct: null,
+          inbreedingCoefficientPct: 12.5,
           birthDate: "2020-01-01",
           litters: [
             {
@@ -447,6 +485,61 @@ describe("dogs service", () => {
               pin: 6,
             },
           ],
+        },
+      },
+    });
+  });
+
+  it("returns null inbreeding when the calculator returns null", async () => {
+    const mockProfile = {
+      id: "dog-null",
+      name: "Null Dog",
+      title: null,
+      registrationNo: "FI-9/20",
+      registrationNos: ["FI-9/20"],
+      birthDate: null,
+      sex: "N",
+      color: null,
+      ekNo: null,
+      sire: { name: "Sire", registrationNo: "FI-2/18" },
+      dam: { name: "Dam", registrationNo: "FI-3/18" },
+      pedigree: [],
+      offspringSummary: { litterCount: 0, puppyCount: 0 },
+      litters: [],
+      siblingsSummary: { siblingCount: 0 },
+      siblings: [],
+      titles: [],
+    };
+    const mockAncestry = {
+      rootId: "dog-null",
+      nodes: {
+        "dog-null": {
+          id: "dog-null",
+          sireId: "sire-1",
+          damId: "dam-1",
+          siitosasteProsentti: null,
+        },
+      },
+    };
+
+    getBeagleDogProfileDbMock.mockResolvedValue(mockProfile);
+    loadDogPedigreeAncestryDbMock.mockResolvedValue(mockAncestry);
+    calculateInbreedingCoefficientPctMock.mockReturnValue(null);
+    getBeagleShowsForDogDbMock.mockResolvedValue([]);
+    getBeagleTrialsForDogDbMock.mockResolvedValue([]);
+
+    const service = createDogsService();
+    const result = await service.getBeagleDogProfile("dog-null");
+
+    expect(result).toEqual({
+      status: 200,
+      body: {
+        ok: true,
+        data: {
+          ...mockProfile,
+          inbreedingCoefficientPct: null,
+          shows: [],
+          trials: [],
         },
       },
     });
@@ -700,6 +793,8 @@ describe("dogs service", () => {
 
     expect(getBeagleShowsForDogDbMock).not.toHaveBeenCalled();
     expect(getBeagleTrialsForDogDbMock).not.toHaveBeenCalled();
+    expect(loadDogPedigreeAncestryDbMock).not.toHaveBeenCalled();
+    expect(calculateInbreedingCoefficientPctMock).not.toHaveBeenCalled();
     expect(result).toEqual({
       status: 404,
       body: { ok: false, error: "Dog profile not found." },

--- a/packages/server/dogs/__tests__/service.test.ts
+++ b/packages/server/dogs/__tests__/service.test.ts
@@ -488,6 +488,9 @@ describe("dogs service", () => {
         },
       },
     });
+    expect(result.body.ok ? result.body.data : null).not.toHaveProperty(
+      "siitosasteProsentti",
+    );
   });
 
   it("returns null inbreeding when the calculator returns null", async () => {
@@ -543,6 +546,54 @@ describe("dogs service", () => {
         },
       },
     });
+  });
+
+  it("skips deep ancestry loading for parentless public profiles", async () => {
+    const mockProfile = {
+      id: "dog-parentless",
+      name: "Parentless Dog",
+      title: null,
+      registrationNo: "FI-99/20",
+      registrationNos: ["FI-99/20"],
+      birthDate: null,
+      sex: "U",
+      color: null,
+      ekNo: null,
+      inbreedingCoefficientPct: null,
+      sire: null,
+      dam: null,
+      pedigree: [],
+      offspringSummary: { litterCount: 0, puppyCount: 0 },
+      litters: [],
+      siblingsSummary: { siblingCount: 0 },
+      siblings: [],
+      titles: [],
+    };
+
+    getBeagleDogProfileDbMock.mockResolvedValue(mockProfile);
+    getBeagleShowsForDogDbMock.mockResolvedValue([]);
+    getBeagleTrialsForDogDbMock.mockResolvedValue([]);
+
+    const service = createDogsService();
+    const result = await service.getBeagleDogProfile("dog-parentless");
+
+    expect(loadDogPedigreeAncestryDbMock).not.toHaveBeenCalled();
+    expect(calculateInbreedingCoefficientPctMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: 200,
+      body: {
+        ok: true,
+        data: {
+          ...mockProfile,
+          inbreedingCoefficientPct: null,
+          shows: [],
+          trials: [],
+        },
+      },
+    });
+    expect(result.body.ok ? result.body.data : null).not.toHaveProperty(
+      "siitosasteProsentti",
+    );
   });
 
   it("maps date-only profile fields in Helsinki timezone", async () => {

--- a/packages/server/dogs/__tests__/service.test.ts
+++ b/packages/server/dogs/__tests__/service.test.ts
@@ -559,7 +559,6 @@ describe("dogs service", () => {
       sex: "U",
       color: null,
       ekNo: null,
-      inbreedingCoefficientPct: null,
       sire: null,
       dam: null,
       pedigree: [],
@@ -607,7 +606,6 @@ describe("dogs service", () => {
       sex: "N",
       color: null,
       ekNo: null,
-      inbreedingCoefficientPct: null,
       sire: null,
       dam: null,
       pedigree: [],
@@ -669,6 +667,7 @@ describe("dogs service", () => {
         ok: true,
         data: {
           ...mockProfile,
+          inbreedingCoefficientPct: null,
           birthDate: "2020-01-01",
           shows: [
             {
@@ -713,7 +712,6 @@ describe("dogs service", () => {
       sex: "N",
       color: null,
       ekNo: null,
-      inbreedingCoefficientPct: null,
       sire: null,
       dam: null,
       pedigree: [],
@@ -754,6 +752,7 @@ describe("dogs service", () => {
         ok: true,
         data: {
           ...mockProfile,
+          inbreedingCoefficientPct: null,
           shows: [
             {
               ...showCase,
@@ -778,7 +777,6 @@ describe("dogs service", () => {
       sex: "U",
       color: null,
       ekNo: null,
-      inbreedingCoefficientPct: null,
       sire: null,
       dam: null,
       pedigree: [],
@@ -819,6 +817,7 @@ describe("dogs service", () => {
         ok: true,
         data: {
           ...mockProfile,
+          inbreedingCoefficientPct: null,
           shows: [
             {
               ...showLegacy,
@@ -873,7 +872,6 @@ describe("dogs service", () => {
       sex: "N",
       color: null,
       ekNo: null,
-      inbreedingCoefficientPct: null,
       sire: null,
       dam: null,
       pedigree: [],

--- a/packages/server/dogs/profile/get-beagle-dog-profile.ts
+++ b/packages/server/dogs/profile/get-beagle-dog-profile.ts
@@ -2,6 +2,7 @@
 // show/trial domain fetches and shared legacy result normalization helpers.
 import {
   getBeagleDogProfileDb,
+  loadDogPedigreeAncestryDb,
   getBeagleShowsForDogDb,
   getBeagleTrialsForDogDb,
   type BeagleDogProfileDb,
@@ -12,7 +13,11 @@ import type { BeagleDogProfileDto } from "@beagle/contracts";
 import { toBusinessDateOnly } from "@server/core/date-only";
 import { toErrorLog, withLogContext } from "@server/core/logger";
 import type { ServiceResult } from "@server/core/result";
-import { parseDogId } from "@server/dogs/core";
+import {
+  calculateInbreedingCoefficientPct,
+  getInbreedingAncestryLoadDepth,
+  parseDogId,
+} from "@server/dogs/core";
 import { encodeShowId } from "@server/shows/internal/show-id";
 import { formatTrialAward } from "@server/trials/core";
 
@@ -25,6 +30,7 @@ function mapDogProfileFromDb(
   profile: BeagleDogProfileDb,
   shows: BeagleShowDogRowDb[],
   trials: BeagleTrialDogRowDb[],
+  inbreedingCoefficientPct: number | null,
 ): BeagleDogProfileDto {
   return {
     id: profile.id,
@@ -36,7 +42,7 @@ function mapDogProfileFromDb(
     sex: profile.sex,
     color: profile.color,
     ekNo: profile.ekNo,
-    inbreedingCoefficientPct: profile.siitosasteProsentti ?? null,
+    inbreedingCoefficientPct,
     sire: profile.sire,
     dam: profile.dam,
     pedigree: profile.pedigree,
@@ -139,10 +145,16 @@ export async function getBeagleDogProfileService(
       };
     }
 
-    const [shows, trials] = await Promise.all([
+    const [ancestry, shows, trials] = await Promise.all([
+      loadDogPedigreeAncestryDb(parsedDogId, getInbreedingAncestryLoadDepth(9)),
       getBeagleShowsForDogDb(parsedDogId),
       getBeagleTrialsForDogDb(parsedDogId),
     ]);
+    const inbreedingCoefficientPct = calculateInbreedingCoefficientPct(
+      parsedDogId,
+      ancestry,
+      9,
+    );
     log.info(
       {
         event: "success",
@@ -155,7 +167,12 @@ export async function getBeagleDogProfileService(
       status: 200,
       body: {
         ok: true,
-        data: mapDogProfileFromDb(profile, shows, trials),
+        data: mapDogProfileFromDb(
+          profile,
+          shows,
+          trials,
+          inbreedingCoefficientPct,
+        ),
       },
     };
   } catch (error) {

--- a/packages/server/dogs/profile/get-beagle-dog-profile.ts
+++ b/packages/server/dogs/profile/get-beagle-dog-profile.ts
@@ -100,6 +100,22 @@ function mapDogProfileFromDb(
   };
 }
 
+async function calculateProfileInbreedingCoefficientPct(
+  profile: BeagleDogProfileDb,
+  parsedDogId: string,
+): Promise<number | null> {
+  if (!profile.sire || !profile.dam) {
+    return null;
+  }
+
+  const ancestry = await loadDogPedigreeAncestryDb(
+    parsedDogId,
+    getInbreedingAncestryLoadDepth(9),
+  );
+
+  return calculateInbreedingCoefficientPct(parsedDogId, ancestry, 9);
+}
+
 export async function getBeagleDogProfileService(
   dogId: string,
   context?: DogsServiceLogContext,
@@ -145,16 +161,11 @@ export async function getBeagleDogProfileService(
       };
     }
 
-    const [ancestry, shows, trials] = await Promise.all([
-      loadDogPedigreeAncestryDb(parsedDogId, getInbreedingAncestryLoadDepth(9)),
+    const [inbreedingCoefficientPct, shows, trials] = await Promise.all([
+      calculateProfileInbreedingCoefficientPct(profile, parsedDogId),
       getBeagleShowsForDogDb(parsedDogId),
       getBeagleTrialsForDogDb(parsedDogId),
     ]);
-    const inbreedingCoefficientPct = calculateInbreedingCoefficientPct(
-      parsedDogId,
-      ancestry,
-      9,
-    );
     log.info(
       {
         event: "success",


### PR DESCRIPTION
## Summary

This PR removes the remaining persisted inbreeding coefficient usage from public and admin dog profile reads and replaces it with dynamic calculation based on current pedigree data.

### Changes

- Remove profile read-path usage of persisted Dog.siitosasteProsentti.
- Calculate inbreedingCoefficientPct dynamically from pedigree ancestry.
- Keep the public and admin API contract unchanged by continuing to expose inbreedingCoefficientPct.
- Remove legacy siitosasteProsentti mapping from profile DB DTOs and selects.
- Add parent guards to avoid deep ancestry loading when sire or dam is missing.
- Keep admin health/EPI ancestry loading at depth 5 while loading deeper ancestry for inbreeding only when required.
- Add test coverage for:
  - calculated public inbreeding values
  - calculated admin inbreeding values
  - parentless profiles returning null
  - skipping unnecessary deep ancestry loading
  - DTO shape verification to ensure siitosasteProsentti is not exposed

### Why

Persisted inbreeding values can become stale when pedigree data changes. Calculating the value from the current ancestry graph ensures profile data stays consistent with the latest pedigree information while avoiding unnecessary deep ancestry work for dogs without complete parent information.

### Verification

- Public profile returns calculated inbreedingCoefficientPct.
- Admin profile returns calculated inbreedingCoefficientPct.
- Parentless profiles return null and skip deep ancestry loading.
- Public and admin responses do not expose siitosasteProsentti.
- Targeted server tests pass.

closes BEJ-117