### PR TITLE
Feature/bej 129 urgent public virtual pairing recalculates with stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,17 @@ This project uses a user-facing changelog format.
 
 ### Fixed
 
-- Julkinen virtuaaliparitus ei enää laske tulosta automaattisesti vanhalla SP-arvolla, kun SP-valintaa muutetaan jaettu linkki -laskennan jälkeen.
+### Removed
+
+## [0.13.1] - 2026-06-16
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Korjattu bugi: Julkinen virtuaaliparitus ei enää laske tulosta automaattisesti vanhalla SP-arvolla, kun SP-valintaa muutetaan jaettu linkki -laskennan jälkeen.
 - Kun uusi koira lisätään tietokantaan, tarkistetaan onko kyseinen koira jo käynyt kokeissa tai näyttelyissä rekisterinumeron perusteella. Jos on, linkitetään käynnit.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project uses a user-facing changelog format.
 
 ### Fixed
 
+- Julkinen virtuaaliparitus ei enää laske tulosta automaattisesti vanhalla SP-arvolla, kun SP-valintaa muutetaan jaettu linkki -laskennan jälkeen.
 - Kun uusi koira lisätään tietokantaan, tarkistetaan onko kyseinen koira jo käynyt kokeissa tai näyttelyissä rekisterinumeron perusteella. Jos on, linkitetään käynnit.
 
 ### Removed

--- a/apps/web/hooks/public/beagle/dogs/virtual-pairing/__tests__/use-beagle-virtual-pairing-ui-state.test.tsx
+++ b/apps/web/hooks/public/beagle/dogs/virtual-pairing/__tests__/use-beagle-virtual-pairing-ui-state.test.tsx
@@ -119,6 +119,7 @@ type HookResult = {
   onSelectSire: (candidate: VirtualPairingDogOption) => void;
   onSelectDam: (candidate: VirtualPairingDogOption) => void;
   onGenerationDepthChange: (value: string) => void;
+  onCalculate: () => void;
 };
 
 function resetHooks() {
@@ -149,6 +150,50 @@ async function flushMicrotasks() {
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
+function buildCalculationResult(generationDepth: number) {
+  return {
+    generationDepth,
+    sire: {
+      id: "sire-1",
+      ekNo: null,
+      registrationNo: "FIN18665/07",
+      name: "Sire Dog",
+      sex: "U",
+    },
+    dam: {
+      id: "dam-1",
+      ekNo: null,
+      registrationNo: "FIN12562/97",
+      name: "Dam Dog",
+      sex: "N",
+    },
+    inbreedingCoefficientPct: 1.2345,
+    rawInbreedingCoefficientPct: 1.2345,
+    health: {
+      epi: {
+        value: 0,
+        text: "-----",
+        tier: 1,
+        display: "0.000 -----",
+      },
+      risk: {
+        value: 4,
+        display: "4",
+      },
+    },
+    summary: {
+      sharedAncestorCount: 1,
+      sharedOccurrenceCount: 2,
+      includedOccurrenceCount: 3,
+      includedSirePositionCount: 4,
+      includedDamPositionCount: 5,
+      includedPositionCount: 6,
+      knownPedigreePct: 88.5,
+      contributions: [],
+    },
+  } as const;
+}
+
 describe("useBeagleVirtualPairingUiState", () => {
   beforeEach(() => {
     resetHooks();
@@ -170,47 +215,7 @@ describe("useBeagleVirtualPairingUiState", () => {
   });
 
   it("auto-loads a URL-backed calculation once and syncs the result into the URL", async () => {
-    const mutateAsync = vi.fn().mockResolvedValue({
-      generationDepth: 12,
-      sire: {
-        id: "sire-1",
-        ekNo: null,
-        registrationNo: "FIN18665/07",
-        name: "Sire Dog",
-        sex: "U",
-      },
-      dam: {
-        id: "dam-1",
-        ekNo: null,
-        registrationNo: "FIN12562/97",
-        name: "Dam Dog",
-        sex: "N",
-      },
-      inbreedingCoefficientPct: 12.3456,
-      rawInbreedingCoefficientPct: 12.3456,
-      health: {
-        epi: {
-          value: 0,
-          text: "-----",
-          tier: 1,
-          display: "0.000 -----",
-        },
-        risk: {
-          value: 4,
-          display: "4",
-        },
-      },
-      summary: {
-        sharedAncestorCount: 1,
-        sharedOccurrenceCount: 2,
-        includedOccurrenceCount: 3,
-        includedSirePositionCount: 4,
-        includedDamPositionCount: 5,
-        includedPositionCount: 6,
-        knownPedigreePct: 88.5,
-        contributions: [],
-      },
-    });
+    const mutateAsync = vi.fn().mockResolvedValue(buildCalculationResult(12));
 
     calculateMutationMock.mockReturnValue({
       isPending: false,
@@ -274,7 +279,6 @@ describe("useBeagleVirtualPairingUiState", () => {
     expect(hook!.selectedDam).toMatchObject({ name: "Dam Dog" });
     expect(hook!.generationDepth).toBe("9");
 
-    const replaceCallsAfterSelection = replaceMock.mock.calls.length;
     latestHookResult?.onGenerationDepthChange("12");
 
     hook = renderHookHarness();
@@ -283,51 +287,77 @@ describe("useBeagleVirtualPairingUiState", () => {
     expect(hook!.selectedDam).toMatchObject({ name: "Dam Dog" });
     expect(hook!.generationDepth).toBe("12");
     expect(hook!.calculationResult).toBeNull();
-    expect(replaceMock.mock.calls.length).toBe(replaceCallsAfterSelection);
+    expect(replaceMock).toHaveBeenLastCalledWith("/beagle/virtual-pairing");
+  });
+
+  it("does not auto-recalculate from stale URL state after generation depth changes", async () => {
+    const mutateAsync = vi
+      .fn()
+      .mockResolvedValueOnce(buildCalculationResult(9))
+      .mockResolvedValueOnce(buildCalculationResult(12));
+
+    calculateMutationMock.mockReturnValue({
+      isPending: false,
+      mutateAsync,
+    });
+    searchParamsState.sire = "FIN18665/07";
+    searchParamsState.dam = "FIN12562/97";
+    searchParamsState.sp = "9";
+
+    renderHookHarness();
+    await flushMicrotasks();
+    let hook = renderHookHarness();
+
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    expect(hook).not.toBeNull();
+    expect(hook!.selectedSire).toMatchObject({ name: "Sire Dog" });
+    expect(hook!.selectedDam).toMatchObject({ name: "Dam Dog" });
+    expect(hook!.calculationResult).toEqual(
+      expect.objectContaining({ generationDepth: 9 }),
+    );
+
+    latestHookResult?.onGenerationDepthChange("12");
+    hook = renderHookHarness();
+
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    expect(hook).not.toBeNull();
+    expect(hook!.selectedSire).toMatchObject({ name: "Sire Dog" });
+    expect(hook!.selectedDam).toMatchObject({ name: "Dam Dog" });
+    expect(hook!.generationDepth).toBe("12");
+    expect(hook!.calculationResult).toBeNull();
+
+    searchParamsState.sire = "";
+    searchParamsState.dam = "";
+    searchParamsState.sp = "";
+    renderHookHarness();
+    await flushMicrotasks();
+    hook = renderHookHarness();
+
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    expect(hook).not.toBeNull();
+    expect(hook!.selectedSire).toMatchObject({ name: "Sire Dog" });
+    expect(hook!.selectedDam).toMatchObject({ name: "Dam Dog" });
+    expect(hook!.generationDepth).toBe("12");
+    expect(hook!.calculationResult).toBeNull();
+
+    latestHookResult?.onCalculate();
+    await flushMicrotasks();
+    hook = renderHookHarness();
+
+    expect(mutateAsync).toHaveBeenCalledTimes(2);
+    expect(mutateAsync).toHaveBeenLastCalledWith({
+      sireRegistrationNo: "FIN18665/07",
+      damRegistrationNo: "FIN12562/97",
+      generationDepth: 12,
+    });
+    expect(hook).not.toBeNull();
+    expect(hook!.calculationResult).toEqual(
+      expect.objectContaining({ generationDepth: 12 }),
+    );
   });
 
   it("clears stale URL-backed state when the query string becomes incomplete", async () => {
-    const mutateAsync = vi.fn().mockResolvedValue({
-      generationDepth: 9,
-      sire: {
-        id: "sire-1",
-        ekNo: null,
-        registrationNo: "FIN18665/07",
-        name: "Sire Dog",
-        sex: "U",
-      },
-      dam: {
-        id: "dam-1",
-        ekNo: null,
-        registrationNo: "FIN12562/97",
-        name: "Dam Dog",
-        sex: "N",
-      },
-      inbreedingCoefficientPct: 1.2345,
-      rawInbreedingCoefficientPct: 1.2345,
-      health: {
-        epi: {
-          value: 0,
-          text: "-----",
-          tier: 1,
-          display: "0.000 -----",
-        },
-        risk: {
-          value: 4,
-          display: "4",
-        },
-      },
-      summary: {
-        sharedAncestorCount: 0,
-        sharedOccurrenceCount: 0,
-        includedOccurrenceCount: 0,
-        includedSirePositionCount: 0,
-        includedDamPositionCount: 0,
-        includedPositionCount: 0,
-        knownPedigreePct: 0,
-        contributions: [],
-      },
-    });
+    const mutateAsync = vi.fn().mockResolvedValue(buildCalculationResult(9));
 
     calculateMutationMock.mockReturnValue({
       isPending: false,

--- a/apps/web/hooks/public/beagle/dogs/virtual-pairing/use-beagle-virtual-pairing-calculation-state.ts
+++ b/apps/web/hooks/public/beagle/dogs/virtual-pairing/use-beagle-virtual-pairing-calculation-state.ts
@@ -97,19 +97,22 @@ export function useBeagleVirtualPairingCalculationState() {
     [],
   );
 
-  const { rememberAutoLoadKey, forgetAutoLoadKey } =
-    useBeagleVirtualPairingCalculationUrlSync({
-      calculateAsync,
-      beginCalculationRequest,
-      isCurrentCalculationRequest,
-      invalidatePendingCalculationRequests,
-      onUrlCalculationResolved: applyCalculatedResult,
-      onUrlCalculationReset: resetUrlBackedCalculationState,
-      onUrlCalculationError: (message) => {
-        setCalculationResult(null);
-        setCalculationMessage(message);
-      },
-    });
+  const {
+    rememberAutoLoadKey,
+    forgetAutoLoadKey,
+    suppressCurrentUrlCalculation,
+  } = useBeagleVirtualPairingCalculationUrlSync({
+    calculateAsync,
+    beginCalculationRequest,
+    isCurrentCalculationRequest,
+    invalidatePendingCalculationRequests,
+    onUrlCalculationResolved: applyCalculatedResult,
+    onUrlCalculationReset: resetUrlBackedCalculationState,
+    onUrlCalculationError: (message) => {
+      setCalculationResult(null);
+      setCalculationMessage(message);
+    },
+  });
 
   const assignParent = useCallback(
     (candidate: VirtualPairingDogOption, target: "sire" | "dam") => {
@@ -130,6 +133,7 @@ export function useBeagleVirtualPairingCalculationState() {
       setCalculationMessage(null);
       setCalculationResult(null);
       invalidatePendingCalculationRequests();
+      suppressCurrentUrlCalculation();
       forgetAutoLoadKey();
       clearUrlState();
       if (target === "sire") {
@@ -138,7 +142,13 @@ export function useBeagleVirtualPairingCalculationState() {
       }
       setSelectedDam(candidate);
     },
-    [clearUrlState, forgetAutoLoadKey, invalidatePendingCalculationRequests, t],
+    [
+      clearUrlState,
+      forgetAutoLoadKey,
+      invalidatePendingCalculationRequests,
+      suppressCurrentUrlCalculation,
+      t,
+    ],
   );
 
   const handleCalculate = useCallback(async () => {
@@ -211,34 +221,53 @@ export function useBeagleVirtualPairingCalculationState() {
 
   const onClearSire = useCallback(() => {
     invalidatePendingCalculationRequests();
+    suppressCurrentUrlCalculation();
     forgetAutoLoadKey();
     setSelectedSire(null);
     setCalculationResult(null);
     setSelectionMessage(null);
     setCalculationMessage(null);
     clearUrlState();
-  }, [clearUrlState, forgetAutoLoadKey, invalidatePendingCalculationRequests]);
+  }, [
+    clearUrlState,
+    forgetAutoLoadKey,
+    invalidatePendingCalculationRequests,
+    suppressCurrentUrlCalculation,
+  ]);
 
   const onClearDam = useCallback(() => {
     invalidatePendingCalculationRequests();
+    suppressCurrentUrlCalculation();
     forgetAutoLoadKey();
     setSelectedDam(null);
     setCalculationResult(null);
     setSelectionMessage(null);
     setCalculationMessage(null);
     clearUrlState();
-  }, [clearUrlState, forgetAutoLoadKey, invalidatePendingCalculationRequests]);
+  }, [
+    clearUrlState,
+    forgetAutoLoadKey,
+    invalidatePendingCalculationRequests,
+    suppressCurrentUrlCalculation,
+  ]);
 
   const onGenerationDepthChange = useCallback(
     (value: string) => {
       invalidatePendingCalculationRequests();
+      suppressCurrentUrlCalculation();
       forgetAutoLoadKey();
       setGenerationDepth(value);
       setSelectionMessage(null);
       setCalculationResult(null);
       setCalculationMessage(null);
+      clearUrlState();
     },
-    [forgetAutoLoadKey, invalidatePendingCalculationRequests],
+    [
+      clearUrlState,
+      forgetAutoLoadKey,
+      invalidatePendingCalculationRequests,
+      suppressCurrentUrlCalculation,
+    ],
   );
 
   return {

--- a/apps/web/hooks/public/beagle/dogs/virtual-pairing/use-beagle-virtual-pairing-calculation-state.ts
+++ b/apps/web/hooks/public/beagle/dogs/virtual-pairing/use-beagle-virtual-pairing-calculation-state.ts
@@ -133,6 +133,7 @@ export function useBeagleVirtualPairingCalculationState() {
       setCalculationMessage(null);
       setCalculationResult(null);
       invalidatePendingCalculationRequests();
+      // Parent changes are draft edits, not permission to reuse the old URL result.
       suppressCurrentUrlCalculation();
       forgetAutoLoadKey();
       clearUrlState();
@@ -254,6 +255,7 @@ export function useBeagleVirtualPairingCalculationState() {
   const onGenerationDepthChange = useCallback(
     (value: string) => {
       invalidatePendingCalculationRequests();
+      // SP changes clear the result and wait for the next explicit calculation.
       suppressCurrentUrlCalculation();
       forgetAutoLoadKey();
       setGenerationDepth(value);

--- a/apps/web/hooks/public/beagle/dogs/virtual-pairing/use-beagle-virtual-pairing-calculation-url-sync.ts
+++ b/apps/web/hooks/public/beagle/dogs/virtual-pairing/use-beagle-virtual-pairing-calculation-url-sync.ts
@@ -54,6 +54,7 @@ export function useBeagleVirtualPairingCalculationUrlSync({
   const searchParams = useSearchParams();
   const lastAutoLoadKeyRef = useRef<string | null>(null);
   const pendingUrlResetTokenRef = useRef(0);
+  // Local pairing edits should win over the previous share-link calculation.
   const suppressedUrlCalculationKeyRef = useRef<string | null>(null);
 
   const urlState = useMemo(
@@ -83,6 +84,7 @@ export function useBeagleVirtualPairingCalculationUrlSync({
   }, []);
 
   const suppressCurrentUrlCalculation = useCallback(() => {
+    // Prevent the stale URL-backed result from immediately recalculating.
     suppressedUrlCalculationKeyRef.current = urlCalculationKey;
     pendingUrlResetTokenRef.current += 1;
   }, [urlCalculationKey]);

--- a/apps/web/hooks/public/beagle/dogs/virtual-pairing/use-beagle-virtual-pairing-calculation-url-sync.ts
+++ b/apps/web/hooks/public/beagle/dogs/virtual-pairing/use-beagle-virtual-pairing-calculation-url-sync.ts
@@ -54,6 +54,7 @@ export function useBeagleVirtualPairingCalculationUrlSync({
   const searchParams = useSearchParams();
   const lastAutoLoadKeyRef = useRef<string | null>(null);
   const pendingUrlResetTokenRef = useRef(0);
+  const suppressedUrlCalculationKeyRef = useRef<string | null>(null);
 
   const urlState = useMemo(
     () => readPublicVirtualPairingUrlState(searchParams),
@@ -81,6 +82,11 @@ export function useBeagleVirtualPairingCalculationUrlSync({
     lastAutoLoadKeyRef.current = null;
   }, []);
 
+  const suppressCurrentUrlCalculation = useCallback(() => {
+    suppressedUrlCalculationKeyRef.current = urlCalculationKey;
+    pendingUrlResetTokenRef.current += 1;
+  }, [urlCalculationKey]);
+
   const queueUrlBackedCalculationStateReset = useCallback(
     (generationDepthValue: string) => {
       const token = ++pendingUrlResetTokenRef.current;
@@ -97,6 +103,11 @@ export function useBeagleVirtualPairingCalculationUrlSync({
 
   useEffect(() => {
     if (!urlCalculationKey) {
+      if (suppressedUrlCalculationKeyRef.current != null) {
+        suppressedUrlCalculationKeyRef.current = null;
+        return;
+      }
+
       if (lastAutoLoadKeyRef.current != null) {
         forgetAutoLoadKey();
         invalidatePendingCalculationRequests();
@@ -106,6 +117,12 @@ export function useBeagleVirtualPairingCalculationUrlSync({
       }
       return;
     }
+
+    if (suppressedUrlCalculationKeyRef.current === urlCalculationKey) {
+      return;
+    }
+
+    suppressedUrlCalculationKeyRef.current = null;
 
     if (lastAutoLoadKeyRef.current === urlCalculationKey) {
       return;
@@ -163,5 +180,6 @@ export function useBeagleVirtualPairingCalculationUrlSync({
     urlState,
     rememberAutoLoadKey,
     forgetAutoLoadKey,
+    suppressCurrentUrlCalculation,
   };
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/web",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beagle-app-v2",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/api-client",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "type": "module",
   "main": "./index.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/auth",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "type": "module",
   "main": "./index.ts",

--- a/packages/config-eslint/package.json
+++ b/packages/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/config-eslint",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/config-typescript/package.json
+++ b/packages/config-typescript/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@beagle/config-typescript",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/contracts",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "type": "module",
   "main": "./index.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/db",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "type": "module",
   "main": "./index.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/server",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "type": "module",
   "main": "./index.ts",


### PR DESCRIPTION
## Summary

- Fix stale public virtual pairing recalculations when SP (generation depth) changes after loading a shared URL.
- Suppress outdated URL-backed calculations once the user modifies pairing inputs.
- Clear stale URL state when sire, dam, or SP selection changes.
- Preserve manual calculation flow and update shared URLs only from fresh calculations.
- Add regression tests covering stale URL calculation scenarios.

## Testing

- [x] Virtual pairing hook unit tests
- [x] URL sync regression tests
- [x] Typecheck

## Fixed

Users changing SP after opening a shared virtual pairing link could see calculations based on outdated URL parameters. The calculation now stays cleared until a new manual calculation is performed.

closes bej-129