### PR TITLE
[codex] release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ This project uses a user-facing changelog format.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.15.0] - 2026-07-01
+
+### Added
+
 - Lisätty koirakohtainen `Kokeet laaja` -sivu, joka näyttää kaikki koiran koetulokset omalla sivullaan.
 - Lisätty koirakohtaisen `Kokeet laaja` -sivulle linkki kaikkien koiran koetulosten pdf näkymään.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/web",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beagle-app-v2",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/api-client",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "main": "./index.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/auth",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "main": "./index.ts",

--- a/packages/config-eslint/package.json
+++ b/packages/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/config-eslint",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/config-typescript/package.json
+++ b/packages/config-typescript/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@beagle/config-typescript",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/contracts",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "main": "./index.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/db",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "main": "./index.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beagle/server",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "main": "./index.ts",


### PR DESCRIPTION
## What changed

- Promoted the current release notes from `Unreleased` into a dated `0.15.0` changelog entry.
- Reset `Unreleased` for future work.
- Bumped all aligned workspace package versions to `0.15.0`.

## Why

Keep the public changelog and workspace version numbers in sync for the `0.15.0` release.

## Impact

- The “Mitä uutta” page now reads the new latest release block as `v0.15.0`.
- All workspace packages report the same release version.

## Validation

- Confirmed all workspace versions are `0.15.0`.
- Confirmed the release-notes parser reads the new top changelog block correctly.
- Did not run the full lint/test suite.