### PR TITLE
Feature/bej 139 make default lint fast by moving circular import checks out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,9 @@ Agent operating rules for this repository.
 ## Validation rules
 
 - Run targeted checks for touched code.
+- Prefer targeted checks for regular local validation and agent workflows.
+- Full lint is okay when relevant.
+- Run cycle lint only for import graph, barrel, package boundary, shared utility, or import restructuring risk.
 - If checks are not run, state that explicitly.
 - CI note: if Turbo task chains include `build` (for example via `test:e2e`), required env vars must be present in CI and forwarded via `turbo.json` `globalEnv`.
 

--- a/apps/web/app/api/trials/[trialEntryId]/pdf/route.ts
+++ b/apps/web/app/api/trials/[trialEntryId]/pdf/route.ts
@@ -58,11 +58,8 @@ export async function GET(
       });
     }
 
-    const {
-      trialId: _trialId,
-      trialRuleWindowId,
-      ...restData
-    } = result.body.data;
+    const { trialId, trialRuleWindowId, ...restData } = result.body.data;
+    void trialId;
     if (!canRenderTrialDogPdf(trialRuleWindowId)) {
       const ruleSetId = getTrialDogPdfRuleSetId(trialRuleWindowId);
       log.warn(

--- a/apps/web/lib/public/beagle/dogs/profile/__tests__/trials-laaja-formatters.test.ts
+++ b/apps/web/lib/public/beagle/dogs/profile/__tests__/trials-laaja-formatters.test.ts
@@ -4,7 +4,7 @@ import {
   formatDate,
   formatNumber,
   formatPlacement,
-} from "../../../trials/display-formatters";
+} from "@web/lib/public/beagle/trials/display-formatters";
 
 describe("trials-laaja-formatters", () => {
   it("formats normal placements as rank / class count", () => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "vercel:build": "bash ../../scripts/vercel-build.sh",
     "vercel:ignored-build": "bash ../../scripts/vercel-ignored-build.sh",
     "start": "next start",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "pnpm test:unit && pnpm test:e2e",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "vercel:ignored-build": "bash ../../scripts/vercel-ignored-build.sh",
     "start": "next start",
     "lint": "eslint .",
+    "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:unit": "node ../../node_modules/vitest/vitest.mjs run",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "vercel:build": "bash ./scripts/vercel-build.sh",
     "vercel:ignored-build": "bash ./scripts/vercel-ignored-build.sh",
     "lint": "turbo lint",
+    "lint:cycles": "turbo lint:cycles",
     "format": "prettier . --write",
     "typecheck": "turbo typecheck",
     "test": "pnpm test:coverage && pnpm test:coverage:global-check",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint .",
+    "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -7,7 +7,7 @@
   "types": "./index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint .",
+    "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -7,7 +7,7 @@
   "types": "./index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests",

--- a/packages/config-eslint/index.mjs
+++ b/packages/config-eslint/index.mjs
@@ -11,12 +11,6 @@ export default defineConfig([
       "import/export": "error",
       "import/no-self-import": "error",
       "import/no-useless-path-segments": "error",
-      "import/no-cycle": [
-        "warn",
-        {
-          ignoreExternal: true,
-        },
-      ],
       "import/no-duplicates": "error",
     },
   },

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint .",
+    "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -7,7 +7,7 @@
   "types": "./index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests",

--- a/packages/db/dogs/search/internal/data-access.ts
+++ b/packages/db/dogs/search/internal/data-access.ts
@@ -1,6 +1,6 @@
 import type { Prisma } from "@prisma/client";
-import { prisma } from "../../../core/prisma";
-import { sortRegistrationsByInsertedAsc } from "../../core/registration";
+import { prisma } from "@db/core/prisma";
+import { sortRegistrationsByInsertedAsc } from "@db/dogs/core/registration";
 import type { RegistrationOrderKeyRow } from "./types";
 
 export async function loadRegistrationOrderKeys(

--- a/packages/db/dogs/search/internal/matches-row.ts
+++ b/packages/db/dogs/search/internal/matches-row.ts
@@ -1,4 +1,4 @@
-import type { RawDogRow } from "../../core/dog-row-loader";
+import type { RawDogRow } from "@db/dogs/core/dog-row-loader";
 import { matchesLike } from "./wildcard";
 import type { SearchField } from "./types";
 

--- a/packages/db/dogs/search/internal/sorting.ts
+++ b/packages/db/dogs/search/internal/sorting.ts
@@ -1,5 +1,5 @@
-import type { RawDogRow } from "../../core/dog-row-loader";
-import { compareByRegistrationDesc } from "../../core/registration";
+import type { RawDogRow } from "@db/dogs/core/dog-row-loader";
+import { compareByRegistrationDesc } from "@db/dogs/core/registration";
 import type { BeagleSearchSortDb } from "../repository";
 
 function compareRowsByRegistrationDesc(

--- a/packages/db/dogs/search/repository.ts
+++ b/packages/db/dogs/search/repository.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from "@prisma/client";
-import { prisma } from "../../core/prisma";
+import { prisma } from "@db/core/prisma";
 import { loadDogs } from "../core/dog-row-loader";
 import { compareByRegistrationDesc } from "../core/registration";
 import { toSearchRow } from "../core/search-row-mapper";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint .",
+    "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,7 +7,7 @@
   "types": "./index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests",

--- a/packages/server/admin/core/service.ts
+++ b/packages/server/admin/core/service.ts
@@ -1,6 +1,6 @@
 import type { CurrentUserDto } from "@beagle/contracts";
-import type { ServiceResult } from "../../core/result";
-import { hasAdminRole } from "../../core/types";
+import type { ServiceResult } from "@server/core/result";
+import { hasAdminRole } from "@server/core/types";
 
 export function requireAdmin(
   user: CurrentUserDto | null,

--- a/packages/server/admin/users/manage/create-user.ts
+++ b/packages/server/admin/users/manage/create-user.ts
@@ -12,7 +12,7 @@ import {
   type CreateAdminUserRequest,
   type CreateAdminUserResponse,
 } from "@beagle/contracts";
-import type { ServiceResult } from "../../../core/result";
+import type { ServiceResult } from "@server/core/result";
 
 function normalizeEmail(email: string): string | null {
   return normalizeAndValidateEmailAddress(email);

--- a/packages/server/admin/users/manage/delete-user.ts
+++ b/packages/server/admin/users/manage/delete-user.ts
@@ -7,7 +7,7 @@ import {
   runAdminUserWriteTransactionDb,
 } from "@beagle/db";
 import type { DeleteAdminUserResponse } from "@beagle/contracts";
-import type { ServiceResult } from "../../../core/result";
+import type { ServiceResult } from "@server/core/result";
 
 type DeleteAdminUserInput = {
   userId: string;

--- a/packages/server/admin/users/manage/list-users.ts
+++ b/packages/server/admin/users/manage/list-users.ts
@@ -1,6 +1,6 @@
 import { listAdminUsersDb } from "@beagle/db";
 import type { AdminUsersResponse } from "@beagle/contracts";
-import type { ServiceResult } from "../../../core/result";
+import type { ServiceResult } from "@server/core/result";
 
 function toUserRole(role: string): "ADMIN" | "USER" {
   return role === "ADMIN" ? "ADMIN" : "USER";

--- a/packages/server/admin/users/manage/set-user-password.ts
+++ b/packages/server/admin/users/manage/set-user-password.ts
@@ -10,7 +10,7 @@ import {
   type SetAdminUserPasswordRequest,
   type SetAdminUserPasswordResponse,
 } from "@beagle/contracts";
-import type { ServiceResult } from "../../../core/result";
+import type { ServiceResult } from "@server/core/result";
 
 export async function setAdminUserPassword(
   input: SetAdminUserPasswordRequest,

--- a/packages/server/admin/users/manage/set-user-status.ts
+++ b/packages/server/admin/users/manage/set-user-status.ts
@@ -10,7 +10,7 @@ import type {
   SetAdminUserStatusRequest,
   SetAdminUserStatusResponse,
 } from "@beagle/contracts";
-import type { ServiceResult } from "../../../core/result";
+import type { ServiceResult } from "@server/core/result";
 
 type SetAdminUserStatusInput = SetAdminUserStatusRequest & {
   currentUserId: string;

--- a/packages/server/dogs/newest/get-newest-beagle-dogs.ts
+++ b/packages/server/dogs/newest/get-newest-beagle-dogs.ts
@@ -3,9 +3,9 @@ import type {
   BeagleNewestRequest,
   BeagleNewestResponse,
 } from "@beagle/contracts";
-import { toBusinessDateOnly } from "../../core/date-only";
-import type { ServiceResult } from "../../core/result";
-import { toErrorLog, withLogContext } from "../../core/logger";
+import { toBusinessDateOnly } from "@server/core/date-only";
+import type { ServiceResult } from "@server/core/result";
+import { toErrorLog, withLogContext } from "@server/core/logger";
 import type { DogsServiceLogContext } from "../profile/get-beagle-dog-profile";
 
 function parseNewestLimit(value: number | undefined): number {

--- a/packages/server/dogs/search/service.ts
+++ b/packages/server/dogs/search/service.ts
@@ -7,9 +7,9 @@ import type {
   BeagleDogProfileDto,
   BeagleDogTrialsDto,
 } from "@beagle/contracts";
-import { toBusinessDateOnly } from "../../core/date-only";
-import type { ServiceResult } from "../../core/result";
-import { toErrorLog, withLogContext } from "../../core/logger";
+import { toBusinessDateOnly } from "@server/core/date-only";
+import type { ServiceResult } from "@server/core/result";
+import { toErrorLog, withLogContext } from "@server/core/logger";
 import {
   getBeagleDogProfileService,
   type DogsServiceLogContext,

--- a/packages/server/home/statistics/get-home-statistics.ts
+++ b/packages/server/home/statistics/get-home-statistics.ts
@@ -1,7 +1,7 @@
 import type { HomeStatisticsResponse } from "@beagle/contracts";
 import { getHomeStatisticsSnapshot } from "@beagle/db";
-import type { ServiceResult } from "../../core/result";
-import { toErrorLog, withLogContext } from "../../core/logger";
+import type { ServiceResult } from "@server/core/result";
+import { toErrorLog, withLogContext } from "@server/core/logger";
 import { toHomeStatisticsResponse } from "./to-home-statistics-response";
 
 type ServiceLogContext = {

--- a/packages/server/imports/internal/date-key.ts
+++ b/packages/server/imports/internal/date-key.ts
@@ -1,4 +1,4 @@
-import { toBusinessDateOnly } from "../../core/date-only";
+import { toBusinessDateOnly } from "@server/core/date-only";
 
 export function toOwnershipDateKey(value: Date | null): string {
   // Internal dedupe key: MariaDB/MySQL unique indexes allow multiple NULL values.

--- a/packages/server/imports/internal/show-result-parser.ts
+++ b/packages/server/imports/internal/show-result-parser.ts
@@ -1,4 +1,4 @@
-import { normalizeShowResult } from "../../shows/core";
+import { normalizeShowResult } from "@server/shows/core";
 import {
   CLASS_ALIASES,
   CLASS_CODES,

--- a/packages/server/imports/phase1/run-legacy-phase1.ts
+++ b/packages/server/imports/phase1/run-legacy-phase1.ts
@@ -13,7 +13,7 @@ import {
   seedDogColorsDb,
 } from "@beagle/db";
 import type { ImportRunResponse } from "@beagle/contracts";
-import type { ServiceResult } from "../../core/result";
+import type { ServiceResult } from "@server/core/result";
 import {
   isValidRegistrationNo,
   mapSex,

--- a/packages/server/imports/phase1_5/run-legacy-phase1_5.ts
+++ b/packages/server/imports/phase1_5/run-legacy-phase1_5.ts
@@ -11,7 +11,7 @@ import {
   prisma,
 } from "@beagle/db";
 import type { ImportRunResponse } from "@beagle/contracts";
-import type { ServiceResult } from "../../core/result";
+import type { ServiceResult } from "@server/core/result";
 import {
   isValidRegistrationNo,
   normalizeNullable,

--- a/packages/server/imports/phase3/run-legacy-phase3.ts
+++ b/packages/server/imports/phase3/run-legacy-phase3.ts
@@ -11,7 +11,7 @@ import {
   prisma,
 } from "@beagle/db";
 import type { ImportRunResponse } from "@beagle/contracts";
-import type { ServiceResult } from "../../core/result";
+import type { ServiceResult } from "@server/core/result";
 import { upsertShowRows } from "../internal";
 import { formatLegacyImportSummary } from "../runs/phase-summary";
 import { toImportRunResponse } from "../runs/transform";

--- a/packages/server/imports/runs/service.ts
+++ b/packages/server/imports/runs/service.ts
@@ -9,7 +9,7 @@ import type {
   ImportRunIssuesResponse,
   ImportRunResponse,
 } from "@beagle/contracts";
-import type { ServiceResult } from "../../core/result";
+import type { ServiceResult } from "@server/core/result";
 import { runLegacyPhase1 } from "../phase1";
 import { runLegacyPhase1_25 } from "../phase1_25";
 import { runLegacyPhase1_5 } from "../phase1_5";

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint .",
+    "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node ../../node_modules/vitest/vitest.mjs run",
     "test:unit": "node ../../node_modules/vitest/vitest.mjs run",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,7 +7,7 @@
   "types": "./index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "lint:cycles": "eslint . --rule '{\"import/no-cycle\":[\"warn\",{\"ignoreExternal\":true}]}'",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node ../../node_modules/vitest/vitest.mjs run",

--- a/packages/server/scripts/imports/phase1/run.ts
+++ b/packages/server/scripts/imports/phase1/run.ts
@@ -1,4 +1,4 @@
-import { importsService } from "../../../imports";
+import { importsService } from "@server/imports";
 import { disconnectImportScriptPrisma, runImportPhase } from "../internal";
 
 async function main() {

--- a/packages/server/scripts/imports/phase1_25/run.ts
+++ b/packages/server/scripts/imports/phase1_25/run.ts
@@ -1,4 +1,4 @@
-import { importsService } from "../../../imports";
+import { importsService } from "@server/imports";
 import { disconnectImportScriptPrisma, runImportPhase } from "../internal";
 
 async function main() {

--- a/packages/server/scripts/imports/phase1_5/run.ts
+++ b/packages/server/scripts/imports/phase1_5/run.ts
@@ -1,4 +1,4 @@
-import { importsService } from "../../../imports";
+import { importsService } from "@server/imports";
 import { disconnectImportScriptPrisma, runImportPhase } from "../internal";
 
 async function main() {

--- a/packages/server/scripts/imports/phase2/run.ts
+++ b/packages/server/scripts/imports/phase2/run.ts
@@ -1,4 +1,4 @@
-import { importsService } from "../../../imports";
+import { importsService } from "@server/imports";
 import { disconnectImportScriptPrisma, runImportPhase } from "../internal";
 
 async function main() {

--- a/packages/server/scripts/imports/phase3/run.ts
+++ b/packages/server/scripts/imports/phase3/run.ts
@@ -1,4 +1,4 @@
-import { importsService } from "../../../imports";
+import { importsService } from "@server/imports";
 import { disconnectImportScriptPrisma, runImportPhase } from "../internal";
 
 async function main() {

--- a/packages/server/scripts/imports/trial-mirror-validation/export-csv.ts
+++ b/packages/server/scripts/imports/trial-mirror-validation/export-csv.ts
@@ -1,11 +1,11 @@
 import { prisma } from "@beagle/db";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { runLegacyTrialMirrorValidation } from "../../../imports/trial-mirror-validation";
+import { runLegacyTrialMirrorValidation } from "@server/imports/trial-mirror-validation";
 import type {
   TrialMirrorValidationIssue,
   TrialMirrorValidationSeverity,
-} from "../../../imports/trial-mirror-validation";
+} from "@server/imports/trial-mirror-validation";
 
 type ParsedArgs = {
   code: string | undefined;

--- a/packages/server/scripts/imports/trial-mirror-validation/run.ts
+++ b/packages/server/scripts/imports/trial-mirror-validation/run.ts
@@ -2,7 +2,7 @@ import { prisma } from "@beagle/db";
 import {
   formatTrialMirrorValidationReport,
   runLegacyTrialMirrorValidation,
-} from "../../../imports/trial-mirror-validation";
+} from "@server/imports/trial-mirror-validation";
 
 async function main() {
   const startedAt = Date.now();

--- a/turbo.json
+++ b/turbo.json
@@ -54,6 +54,10 @@
       "dependsOn": ["^lint"],
       "outputs": []
     },
+    "lint:cycles": {
+      "dependsOn": ["^lint:cycles"],
+      "outputs": []
+    },
     "typecheck": {
       "dependsOn": ["^typecheck"],
       "outputs": []


### PR DESCRIPTION
• ## Summary

  - Move cycle linting out of the default lint path so normal lint runs faster.
  - Enforce zero ESLint warnings across workspace packages.
  - Fix existing lint warnings by normalizing internal imports and cleaning up the trial PDF route.

  ## Testing

  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm test`
  - [x] Manual smoke: dog search still loads and sorts results.
  - [x] Manual smoke: dog profile trials section still renders.
  - [x] Manual smoke: trial PDF route still renders for a supported trial entry.
  
  ref bej-139
